### PR TITLE
Fix sed usage in custom annotator test

### DIFF
--- a/src/VCFX_quality_adjuster/VCFX_quality_adjuster.cpp
+++ b/src/VCFX_quality_adjuster/VCFX_quality_adjuster.cpp
@@ -157,7 +157,14 @@ void VCFXQualityAdjuster::adjustQualityScores(std::istream &in, std::ostream &ou
             // clamp large values
             if(newQual>1e12) newQual= 1e12;
         }
-        fields[5]= std::to_string(newQual);
+        std::string qualStr;
+        if(std::isnan(newQual)){
+            // ensure consistent representation for NaN
+            qualStr = "nan";
+        } else {
+            qualStr = std::to_string(newQual);
+        }
+        fields[5]= qualStr;
         std::ostringstream oss;
         for(size_t i=0; i<fields.size(); i++){
             if(i>0) oss<<"\t";

--- a/tests/test_custom_annotator.sh
+++ b/tests/test_custom_annotator.sh
@@ -125,10 +125,11 @@ for i in $(seq 1 1000); do
     echo "1	$i	A	G	Annotation$i"
 done > "$SCRIPT_DIR/data/large_annotations.txt"
 # Add VCF header
-sed -i '' '1i\
+sed -i '1i\
 ##fileformat=VCFv4.2\
 ##contig=<ID=1,length=1000>\
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1' "$SCRIPT_DIR/data/large_input.vcf"
+#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  SAMPLE1\
+' "$SCRIPT_DIR/data/large_input.vcf"
 
 time "$ROOT_DIR/build/src/VCFX_custom_annotator/VCFX_custom_annotator" --add-annotation "$SCRIPT_DIR/data/large_annotations.txt" < "$SCRIPT_DIR/data/large_input.vcf" > "$SCRIPT_DIR/data/large_output.vcf"
 if [ $? -eq 0 ]; then
@@ -139,3 +140,4 @@ else
 fi
 
 echo "All tests for VCFX_custom_annotator passed!" 
+


### PR DESCRIPTION
## Summary
- fix `sed -i` usage in `test_custom_annotator.sh` so it works on GNU sed
- ensure trailing newline at EOF
- handle NaN output in `VCFX_quality_adjuster` to avoid "-nan" values

## Testing
- `bash tests/test_custom_annotator.sh`
- `bash tests/test_all.sh`
