### PR TITLE
Fix WebAssembly build setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,18 @@ project(VCFX
 option(BUILD_WASM "Build with emscripten toolchain" OFF)
 
 if(BUILD_WASM)
-    set(CMAKE_TOOLCHAIN_FILE "/path/to/emscripten.cmake" CACHE FILEPATH "Emscripten toolchain" FORCE)
+    if(NOT CMAKE_TOOLCHAIN_FILE)
+        if(DEFINED ENV{EMSDK} AND EXISTS "$ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake")
+            set(CMAKE_TOOLCHAIN_FILE "$ENV{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake" CACHE FILEPATH "Emscripten toolchain" FORCE)
+        elseif(DEFINED ENV{EMSCRIPTEN} AND EXISTS "$ENV{EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake")
+            set(CMAKE_TOOLCHAIN_FILE "$ENV{EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake" CACHE FILEPATH "Emscripten toolchain" FORCE)
+        endif()
+    endif()
+
+    if(NOT EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+        message(FATAL_ERROR "Emscripten toolchain file not found. Please set CMAKE_TOOLCHAIN_FILE or EMSDK.")
+    endif()
+
     message(STATUS "Building for WebAssembly (Emscripten).")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you have [Emscripten](https://emscripten.org/) installed:
 
 ```bash
 mkdir build_wasm && cd build_wasm
-cmake -DBUILD_WASM=ON ..
+emcmake cmake -DBUILD_WASM=ON ..
 cmake --build .
 ```
 

--- a/compile_wasm.sh
+++ b/compile_wasm.sh
@@ -4,8 +4,12 @@ set -e
 mkdir -p build_wasm
 cd build_wasm
 
-# Turn on BUILD_WASM
-cmake -DBUILD_WASM=ON ..
+# Turn on BUILD_WASM using emcmake if available
+if command -v emcmake >/dev/null 2>&1; then
+    emcmake cmake -DBUILD_WASM=ON ..
+else
+    cmake -DBUILD_WASM=ON ..
+fi
 
 cmake --build .
 


### PR DESCRIPTION
## Summary
- detect Emscripten toolchain location rather than using a placeholder path
- run `emcmake` when building WebAssembly
- document the correct command in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`