### PR TITLE
Improve alignment checker memory usage

### DIFF
--- a/src/VCFX_alignment_checker/VCFX_alignment_checker.h
+++ b/src/VCFX_alignment_checker/VCFX_alignment_checker.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <fstream>
 
 // VCFXAlignmentChecker: Header file for Reference Alignment Discrepancy Finder Tool
 class VCFXAlignmentChecker {
@@ -17,7 +18,7 @@ private:
     void displayHelp();
 
     // Loads the reference genome from a FASTA file
-    bool loadReferenceGenome(std::istream& in);
+    bool loadReferenceGenome(const std::string& path);
 
     // Checks discrepancies between VCF variants and the in-memory reference genome
     void checkDiscrepancies(std::istream& vcfIn, std::ostream& out);
@@ -26,7 +27,16 @@ private:
     std::string getReferenceBases(const std::string& chrom, int pos, int length = 1);
 
     // Stores the reference genome sequences, keyed by normalized chromosome name
-    std::unordered_map<std::string, std::string> referenceGenome;
+    struct FastaIndexEntry {
+        std::streampos offset = 0;     // file offset to first base
+        std::size_t   length = 0;      // total bases in sequence
+        std::size_t   basesPerLine = 0;    // number of bases per line in FASTA
+        std::size_t   bytesPerLine = 0;    // bytes per line including newline
+    };
+
+    std::unordered_map<std::string, FastaIndexEntry> referenceIndex;
+    std::ifstream referenceStream;
+    std::string referencePath;
 
     // Helper function to convert chromosome names to a consistent format
     std::string normalizeChromosome(const std::string& chrom);


### PR DESCRIPTION
## Summary
- index FASTA instead of loading entire reference
- unify chromosome name handling
- add reference stream for on-demand reference reads

## Testing
- `cmake ..`
- `make -j4`
- `tests/test_alignment_checker.sh`