### PR TITLE
Add reusable utilities to vcfx_core

### DIFF
--- a/include/vcfx_core.h
+++ b/include/vcfx_core.h
@@ -3,7 +3,21 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
-// Core functionalities for VCFX tools
+namespace vcfx {
+
+// Trim leading and trailing whitespace from a string
+std::string trim(const std::string& str);
+
+// Split a string on the given delimiter
+std::vector<std::string> split(const std::string& str, char delimiter);
+
+// Convenience helpers for printing common messages
+void print_error(const std::string& msg, std::ostream& os = std::cerr);
+void print_version(const std::string& tool, const std::string& version,
+                   std::ostream& os = std::cout);
+
+}  // namespace vcfx
 
 #endif // VCFX_CORE_H

--- a/src/vcfx_core.cpp
+++ b/src/vcfx_core.cpp
@@ -1,4 +1,36 @@
 #include "vcfx_core.h"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
 
-// Implementation of core functionalities
-// Add actual implementations as needed
+namespace vcfx {
+
+std::string trim(const std::string& str) {
+    auto first = str.find_first_not_of(" \t\n\r");
+    if (first == std::string::npos) {
+        return "";
+    }
+    auto last = str.find_last_not_of(" \t\n\r");
+    return str.substr(first, last - first + 1);
+}
+
+std::vector<std::string> split(const std::string& str, char delimiter) {
+    std::vector<std::string> result;
+    std::istringstream iss(str);
+    std::string item;
+    while (std::getline(iss, item, delimiter)) {
+        result.push_back(item);
+    }
+    return result;
+}
+
+void print_error(const std::string& msg, std::ostream& os) {
+    os << "Error: " << msg << '\n';
+}
+
+void print_version(const std::string& tool, const std::string& version,
+                   std::ostream& os) {
+    os << tool << " version " << version << '\n';
+}
+
+}  // namespace vcfx


### PR DESCRIPTION
## Summary
- implement `trim`, `split`, `print_error`, and `print_version` in `vcfx_core`
- expose the new utility functions in the header

## Testing
- `./tests/test_all.sh`