### PR TITLE
Add gzip input support

### DIFF
--- a/include/vcfx_core.h
+++ b/include/vcfx_core.h
@@ -18,6 +18,16 @@ void print_error(const std::string& msg, std::ostream& os = std::cerr);
 void print_version(const std::string& tool, const std::string& version,
                    std::ostream& os = std::cout);
 
+// Read entire input stream, automatically decompressing if gzip/BGZF
+// compressed. Returns true on success and stores the resulting text in
+// 'out'.
+bool read_maybe_compressed(std::istream& in, std::string& out);
+
+// Convenience helper to read a file that may be gzip/BGZF compressed. The file
+// is loaded completely into memory and stored in 'out'. Returns true on
+// success.
+bool read_file_maybe_compressed(const std::string& path, std::string& out);
+
 }  // namespace vcfx
 
 #endif // VCFX_CORE_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # Build the core library from your shared code
 add_library(vcfx_core STATIC vcfx_core.cpp)
 target_include_directories(vcfx_core PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include)
+target_link_libraries(vcfx_core PUBLIC ZLIB::ZLIB)
 
 # Add all tool subdirectories
 add_subdirectory(VCFX_header_parser)

--- a/src/VCFX_variant_counter/VCFX_variant_counter.cpp
+++ b/src/VCFX_variant_counter/VCFX_variant_counter.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include "vcfx_core.h"
 
 void VCFXVariantCounter::displayHelp(){
     std::cout <<
@@ -55,7 +56,13 @@ int VCFXVariantCounter::run(int argc, char* argv[]){
         return 0;
     }
     
-    int total= countVariants(std::cin);
+    std::string plainInput;
+    if(!vcfx::read_maybe_compressed(std::cin, plainInput)){
+        std::cerr << "Error: failed to read input" << std::endl;
+        return 1;
+    }
+    std::istringstream inStream(plainInput);
+    int total= countVariants(inStream);
     if(total<0){
         // indicates an error if strict
         return 1;

--- a/src/vcfx_core.cpp
+++ b/src/vcfx_core.cpp
@@ -2,6 +2,9 @@
 #include <algorithm>
 #include <cctype>
 #include <sstream>
+#include <fstream>
+#include <zlib.h>
+#include <cstring>
 
 namespace vcfx {
 
@@ -31,6 +34,105 @@ void print_error(const std::string& msg, std::ostream& os) {
 void print_version(const std::string& tool, const std::string& version,
                    std::ostream& os) {
     os << tool << " version " << version << '\n';
+}
+
+// ------------------------------------------------------------
+// Internal helper: decompress gzip/BGZF data from 'in' into 'out'
+// ------------------------------------------------------------
+static bool decompress_gzip_stream(std::istream& in, std::string& out) {
+    constexpr int CHUNK = 16384;
+    char inBuf[CHUNK];
+    char outBuf[CHUNK];
+
+    z_stream strm;
+    std::memset(&strm, 0, sizeof(strm));
+    if (inflateInit2(&strm, 15 + 32) != Z_OK) {
+        return false;
+    }
+
+    int ret = Z_OK;
+    do {
+        in.read(inBuf, CHUNK);
+        strm.avail_in = static_cast<uInt>(in.gcount());
+        if (strm.avail_in == 0 && in.eof()) {
+            break;
+        }
+        strm.next_in = reinterpret_cast<Bytef*>(inBuf);
+
+        do {
+            strm.avail_out = CHUNK;
+            strm.next_out = reinterpret_cast<Bytef*>(outBuf);
+            ret = inflate(&strm, Z_NO_FLUSH);
+            if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT ||
+                ret == Z_DATA_ERROR || ret == Z_MEM_ERROR) {
+                inflateEnd(&strm);
+                return false;
+            }
+            size_t have = CHUNK - strm.avail_out;
+            if (have > 0) {
+                out.append(outBuf, have);
+            }
+        } while (strm.avail_out == 0);
+    } while (ret != Z_STREAM_END);
+
+    inflateEnd(&strm);
+    return ret == Z_STREAM_END;
+}
+
+// ------------------------------------------------------------
+// Detect gzip magic numbers on a stream without consuming them
+// ------------------------------------------------------------
+static bool stream_has_gzip_magic(std::istream& in) {
+    int c1 = in.get();
+    if (c1 == EOF) {
+        return false;
+    }
+    int c2 = in.get();
+    if (c2 == EOF) {
+        in.unget();
+        return false;
+    }
+    bool isGz = (static_cast<unsigned char>(c1) == 0x1f &&
+                 static_cast<unsigned char>(c2) == 0x8b);
+    in.putback(static_cast<char>(c2));
+    in.putback(static_cast<char>(c1));
+    return isGz;
+}
+
+bool read_maybe_compressed(std::istream& in, std::string& out) {
+    out.clear();
+    if (stream_has_gzip_magic(in)) {
+        return decompress_gzip_stream(in, out);
+    }
+    std::ostringstream oss;
+    oss << in.rdbuf();
+    out = oss.str();
+    return true;
+}
+
+bool read_file_maybe_compressed(const std::string& path, std::string& out) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        return false;
+    }
+    bool isGz = false;
+    if (path.size() >= 3 &&
+        (path.compare(path.size() - 3, 3, ".gz") == 0)) {
+        isGz = true;
+    } else if (path.size() >= 4 &&
+               (path.compare(path.size() - 4, 4, ".bgz") == 0)) {
+        isGz = true;
+    } else if (path.size() >= 5 &&
+               (path.compare(path.size() - 5, 5, ".bgzf") == 0)) {
+        isGz = true;
+    }
+    if (isGz || stream_has_gzip_magic(file)) {
+        return decompress_gzip_stream(file, out);
+    }
+    std::ostringstream oss;
+    oss << file.rdbuf();
+    out = oss.str();
+    return true;
 }
 
 }  // namespace vcfx

--- a/tests/test_variant_counter.sh
+++ b/tests/test_variant_counter.sh
@@ -155,6 +155,17 @@ if [ ! -f data/variant_counter_empty.vcf ]; then
 EOF
 fi
 
+# Create gzipped versions of VCFs
+if [ ! -f data/variant_counter_normal.vcf.gz ]; then
+  gzip -c data/variant_counter_normal.vcf > data/variant_counter_normal.vcf.gz
+fi
+if [ ! -f data/variant_counter_invalid.vcf.gz ]; then
+  gzip -c data/variant_counter_invalid.vcf > data/variant_counter_invalid.vcf.gz
+fi
+if [ ! -f data/variant_counter_empty.vcf.gz ]; then
+  gzip -c data/variant_counter_empty.vcf > data/variant_counter_empty.vcf.gz
+fi
+
 # Test 1: Count variants in a normal VCF file (strict mode)
 run_test 1 "Counting variants in a normal VCF file (strict mode)" \
   "cat data/variant_counter_normal.vcf | $VCFX_EXECUTABLE --strict" \
@@ -212,4 +223,10 @@ diff -u expected/variant_counter_large.txt out/variant_counter_large.txt || {
 }
 echo "  Test 8 passed."
 
-echo "All VCFX_variant_counter tests passed!" 
+# Test 9: Gzipped normal VCF
+run_test 9 "Counting variants in a gzipped VCF file" \
+  "cat data/variant_counter_normal.vcf.gz | $VCFX_EXECUTABLE" \
+  "expected/variant_counter_normal_nonstrict.txt" \
+  "out/variant_counter_normal_gz.txt"
+
+echo "All VCFX_variant_counter tests passed!"


### PR DESCRIPTION
## Summary
- add gzip/BGZF reading helpers in `vcfx_core`
- link vcfx_core with zlib
- auto-decompress stdin in `VCFX_variant_counter`
- test gzipped input for variant counter

## Testing
- `cmake ..`
- `make -j`
- `cd tests && ./test_variant_counter.sh`