### PR TITLE
Add strict mode to VCFX_validator

### DIFF
--- a/docs/VCFX_validator.md
+++ b/docs/VCFX_validator.md
@@ -14,7 +14,7 @@ VCFX_validator [OPTIONS] < input.vcf
 | Option | Description |
 |--------|-------------|
 | `-h`, `--help` | Display help message and exit |
-| `-s`, `--strict` | Enable stricter validation checks (reserved for future implementation) |
+| `-s`, `--strict` | Enable stricter validation checks |
 
 ## Description
 `VCFX_validator` processes a VCF file to verify its structural validity by:
@@ -59,7 +59,16 @@ This tool is useful for validating VCF files before processing them with other t
 - INFO: Must be '.' or contain valid key-value pairs or flags:
   - If not '.', must contain at least one valid entry
   - Key-value pairs must have a non-empty key
+
   - Flags (without '=') are allowed
+
+### Strict Mode
+When `--strict` is used, additional checks are applied:
+- The number of columns in every data line must exactly match the `#CHROM` header.
+- If FORMAT/sample columns are present, each sample field must contain the same
+  number of sub-fields as specified in the FORMAT column.
+- Any warning that would normally be emitted is treated as an error and causes
+  the validator to exit with a non-zero status.
 
 ## Examples
 
@@ -70,7 +79,7 @@ VCFX_validator < input.vcf
 ```
 
 ### Using Strict Mode
-Enable stricter validation (note: additional strict checks are reserved for future implementation):
+Enable stricter validation with additional checks:
 ```bash
 VCFX_validator --strict < input.vcf
 ```

--- a/src/VCFX_validator/VCFX_validator.h
+++ b/src/VCFX_validator/VCFX_validator.h
@@ -11,6 +11,12 @@ public:
 private:
     // If we add advanced checks for e.g. "strict" mode, we store a bool
     bool strictMode = false;
+    // Number of columns in the #CHROM header line
+    int headerColumnCount = 0;
+    // Whether the header includes FORMAT/sample columns
+    bool headerHasFormat = false;
+    // Number of sample columns
+    int sampleCount = 0;
 
     // Show usage
     void displayHelp();


### PR DESCRIPTION
## Summary
- implement strict validation checks for `VCFX_validator`
- document new strict behaviour
- extend validator tests for strict mode

## Testing
- `cd build && make -j src/VCFX_validator/VCFX_validator`
- `cd ../tests && bash test_validator.sh > /tmp/test_validator.log`