### PR TITLE
Enable CTest for shell scripts

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libz-dev
 
-      - name: Run shell tests
+      - name: Configure
+        run: cmake -S . -B build
+
+      - name: Build
+        run: cmake --build build -- -j
+
+      - name: Run tests
         run: |
-          bash tests/test_all.sh
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,8 @@ enable_testing()
 # Add top-level 'src' subdirectory, which in turn references each tool subdirectory
 add_subdirectory(src)
 
-# Add a tests subdir if you have tests
-# Comment out this line since we don't have a CMakeLists.txt file in the tests directory
-# add_subdirectory(tests)
+# Add the test suite
+add_subdirectory(tests)
 
 # Installation configuration
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -87,9 +87,16 @@ cmake --build .
 
 ## Running Tests
 
+From your build directory, run:
+
 ```bash
-cd build
-ctest --verbose
+ctest --output-on-failure
+```
+
+You can also execute all shell scripts directly with:
+
+```bash
+bash ../tests/test_all.sh
 ```
 
 ## Contributing

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -58,11 +58,16 @@ make
 
 ### Running Tests
 
-After building the project, run the tests to ensure everything is working correctly:
+After building the project, run the test suite from the `build` directory:
 
 ```bash
-cd build
-ctest --verbose
+ctest --output-on-failure
+```
+
+You can still run all shell tests directly if needed:
+
+```bash
+bash ../tests/test_all.sh
 ```
 
 ## Coding Standards

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,79 @@
+# CMake tests for VCFX shell scripts
+
+set(TEST_SCRIPTS
+    test_af_subsetter.sh
+    test_alignment_checker.sh
+    test_allele_balance_calc.sh
+    test_allele_balance_filter.sh
+    test_allele_counter.sh
+    test_allele_freq_calc.sh
+    test_ancestry_assigner.sh
+    test_ancestry_inferrer.sh
+    test_annotation_extractor.sh
+    test_compressor.sh
+    test_concordance_checker.sh
+    test_cross_sample_concordance.sh
+    test_custom_annotator.sh
+    test_diff_tool.sh
+    test_distance_calculator.sh
+    test_dosage_calculator.sh
+    test_duplicate_remover.sh
+    test_fasta_converter.sh
+    test_field_extractor.sh
+    test_file_splitter.sh
+    test_format_converter.sh
+    test_genotype_query.sh
+    test_gl_filter.sh
+    test_haplotype_extractor.sh
+    test_header_parser.sh
+    test_hwe_tester.sh
+    test_impact_filter.sh
+    test_indel_normalizer.sh
+    test_indexer.sh
+    test_info_aggregator.sh
+    test_info_summarizer.sh
+    test_inbreeding_calculator.sh
+    test_ld_calculator.sh
+    test_metadata_summarizer.sh
+    test_merger.sh
+    test_missing_data_handler.sh
+    test_missing_detector.sh
+    test_multiallelic_splitter.sh
+    test_nonref_filter.sh
+    test_outlier_detector.sh
+    test_phase_checker.sh
+    test_phase_quality_filter.sh
+    test_phred_filter.sh
+    test_population_filter.sh
+    test_position_subsetter.sh
+    test_probability_filter.sh
+    test_quality_adjuster.sh
+    test_record_filter.sh
+    test_ref_comparator.sh
+    test_reformatter.sh
+    test_region_subsampler.sh
+    test_sample_extractor.sh
+    test_sorter.sh
+    test_sv_handler.sh
+    test_subsampler.sh
+    test_validator.sh
+    test_variant_classifier.sh
+    test_variant_counter.sh
+)
+
+foreach(script ${TEST_SCRIPTS})
+    get_filename_component(name ${script} NAME_WE)
+    add_test(NAME ${name}
+             COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/${script})
+    set_tests_properties(${name} PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endforeach()
+
+# Optional Docker-based tests
+find_program(DOCKER_EXECUTABLE docker)
+if(DOCKER_EXECUTABLE)
+    add_test(NAME test_docker
+             COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test_docker.sh)
+    set_tests_properties(test_docker PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()


### PR DESCRIPTION
## Summary
- register every shell test with CTest
- enable test directory in CMake
- call `ctest` in CI
- document new `ctest` usage

## Testing
- `cmake ..`
- `cmake --build . -- -j$(nproc)`
- `ctest --output-on-failure`