### PR TITLE
Fix Docker test build context

### DIFF
--- a/tests/test_docker.sh
+++ b/tests/test_docker.sh
@@ -4,6 +4,10 @@
 # built image.
 VCFX_IMAGE="${VCFX_IMAGE:-ghcr.io/jorgemfs/vcfx:latest}"
 
+# Directory paths
+TESTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_ROOT="$(dirname "$TESTS_DIR")"
+
 # Function to check if command succeeded
 check_success() {
   if [ $? -ne 0 ]; then
@@ -28,14 +32,12 @@ if docker pull "$VCFX_IMAGE"; then
   check_success "Pulled VCFX Docker image"
 else
   echo "⚠️  Unable to pull $VCFX_IMAGE. Building Docker image locally..."
-  docker build -t vcfx:local .
+  docker build -t vcfx:local "${REPO_ROOT}"
   check_success "Built local Docker image"
   VCFX_IMAGE="vcfx:local"
 fi
 
 # Get the directory of this script (tests directory)
-TESTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-
 echo "🔍 Using test files from: ${TESTS_DIR}"
 
 # Create temporary output directory in tests/out


### PR DESCRIPTION
## Summary
- ensure Docker build context points to repo root in tests

## Testing
- `ctest --output-on-failure`