### PR TITLE
Add vcfx wrapper

### DIFF
--- a/compile_wasm.sh
+++ b/compile_wasm.sh
@@ -13,5 +13,5 @@ fi
 
 cmake --build .
 
-echo "All VCFX tools built for WebAssembly in build_wasm/."
+echo "All VCFX tools and the vcfx wrapper built for WebAssembly in build_wasm/."
 echo "Use 'ls -R build_wasm' to see output. If you want .html or .js from Emscripten, you can adjust linking flags or suffixes."

--- a/docs/tools_overview.md
+++ b/docs/tools_overview.md
@@ -2,6 +2,8 @@
 
 VCFX is a collection of C/C++ tools for processing and analyzing VCF (Variant Call Format) files, with optional WebAssembly compatibility. Each tool is an independent command-line executable that can parse input from `stdin` and write to `stdout`, enabling flexible piping and integration into bioinformatics pipelines.
 
+The suite also includes a convenience wrapper `vcfx` so you can run commands as `vcfx <subcommand>`. For example, `vcfx variant_counter` is equivalent to running `VCFX_variant_counter`. Use `vcfx --list` to see available subcommands. All individual `VCFX_*` binaries remain available if you prefer calling them directly.
+
 ## Tool Categories
 
 ### Data Analysis

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(vcfx_core PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include
 target_link_libraries(vcfx_core PUBLIC ZLIB::ZLIB)
 
 # Add all tool subdirectories
+add_subdirectory(vcfx_wrapper)
 add_subdirectory(VCFX_header_parser)
 add_subdirectory(VCFX_record_filter)
 add_subdirectory(VCFX_field_extractor)
@@ -74,6 +75,7 @@ install(TARGETS vcfx_core
 
 # Define a list of all tool executables for installation
 set(VCFX_TOOLS
+    vcfx
     VCFX_header_parser
     VCFX_record_filter
     VCFX_field_extractor

--- a/src/vcfx_wrapper/CMakeLists.txt
+++ b/src/vcfx_wrapper/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(vcfx vcfx.cpp)

--- a/src/vcfx_wrapper/vcfx.cpp
+++ b/src/vcfx_wrapper/vcfx.cpp
@@ -1,0 +1,97 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <getopt.h>
+#include <cstdlib>
+#include <cstring>
+#include <dirent.h>
+#include <unistd.h>
+#include <set>
+
+static void print_usage(){
+    std::cout << "vcfx - unified interface for VCFX tools\n"
+              << "Usage: vcfx [--help] [--list] <subcommand> [args]\n\n"
+              << "  <subcommand>  Name of a VCFX tool without the 'VCFX_' prefix\n"
+              << "  --list        List available subcommands found in PATH\n"
+              << "  --help        Show this help message\n";
+}
+
+static void list_commands(){
+    const char* path_env = std::getenv("PATH");
+    if(!path_env) return;
+    std::string paths(path_env);
+    std::set<std::string> cmds;
+    size_t start=0;
+    while(true){
+        size_t end = paths.find(':', start);
+        std::string dir = paths.substr(start, end - start);
+        DIR* d = opendir(dir.c_str());
+        if(d){
+            struct dirent* e;
+            while((e = readdir(d)) != nullptr){
+                if(std::strncmp(e->d_name, "VCFX_", 5)==0){
+                    std::string name = e->d_name + 5;
+                    std::string full = dir + "/" + e->d_name;
+                    if(access(full.c_str(), X_OK)==0){
+                        cmds.insert(name);
+                    }
+                }
+            }
+            closedir(d);
+        }
+        if(end == std::string::npos) break;
+        start = end + 1;
+    }
+    for(const auto& c : cmds){
+        std::cout << c << '\n';
+    }
+}
+
+int main(int argc, char* argv[]){
+    bool show_help = false;
+    bool show_list = false;
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'},
+        {"list", no_argument, 0, 'l'},
+        {0,0,0,0}
+    };
+
+    int opt;
+    while((opt = getopt_long(argc, argv, "hl", long_opts, nullptr)) != -1){
+        if(opt == 'h') show_help = true;
+        else if(opt == 'l') show_list = true;
+        else {
+            print_usage();
+            return 1;
+        }
+    }
+
+    if(show_help){
+        print_usage();
+        return 0;
+    }
+    if(show_list){
+        list_commands();
+        return 0;
+    }
+
+    if(optind >= argc){
+        print_usage();
+        return 1;
+    }
+
+    std::string sub = argv[optind];
+    std::string exec_name = "VCFX_" + sub;
+
+    std::vector<char*> exec_args;
+    exec_args.push_back(const_cast<char*>(exec_name.c_str()));
+    for(int i = optind + 1; i < argc; ++i){
+        exec_args.push_back(argv[i]);
+    }
+    exec_args.push_back(nullptr);
+
+    execvp(exec_name.c_str(), exec_args.data());
+    std::perror(exec_name.c_str());
+    return 1;
+}
+


### PR DESCRIPTION
## Summary
- add `vcfx` wrapper command for running `VCFX_*` tools
- build/install wrapper in CMake
- document wrapper usage
- mention wrapper in WASM build script

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`