### PR TITLE
Fix validator passthrough

### DIFF
--- a/docs/VCFX_validator.md
+++ b/docs/VCFX_validator.md
@@ -75,14 +75,18 @@ When `--strict` is used, additional checks are applied:
 ### Basic Validation
 Check if a VCF file is valid:
 ```bash
-VCFX_validator < input.vcf
+VCFX_validator < input.vcf > validated.vcf
 ```
 
 ### Using Strict Mode
 Enable stricter validation with additional checks:
 ```bash
-VCFX_validator --strict < input.vcf
+VCFX_validator --strict < input.vcf > validated.vcf
 ```
+
+When the input is valid, the original VCF is written unchanged to standard output,
+allowing `VCFX_validator` to be used as a filter in processing pipelines. Informational
+messages such as `VCF file is valid.` are printed to standard error.
 
 ### Redirecting Error Messages
 Save validation errors to a file:

--- a/site/VCFX_validator/index.html
+++ b/site/VCFX_validator/index.html
@@ -2884,12 +2884,13 @@
 <h2 id="examples">Examples<a class="headerlink" href="#examples" title="Permanent link">&para;</a></h2>
 <h3 id="basic-validation">Basic Validation<a class="headerlink" href="#basic-validation" title="Permanent link">&para;</a></h3>
 <p>Check if a VCF file is valid:
-<div class="highlight"><pre><span></span><code>VCFX_validator<span class="w"> </span>&lt;<span class="w"> </span>input.vcf
+<div class="highlight"><pre><span></span><code>VCFX_validator<span class="w"> </span>&lt;<span class="w"> </span>input.vcf<span class="w"> </span>&gt;<span class="w"> </span>validated.vcf
 </code></pre></div></p>
 <h3 id="using-strict-mode">Using Strict Mode<a class="headerlink" href="#using-strict-mode" title="Permanent link">&para;</a></h3>
 <p>Enable stricter validation (note: additional strict checks are reserved for future implementation):
-<div class="highlight"><pre><span></span><code>VCFX_validator<span class="w"> </span>--strict<span class="w"> </span>&lt;<span class="w"> </span>input.vcf
+<div class="highlight"><pre><span></span><code>VCFX_validator<span class="w"> </span>--strict<span class="w"> </span>&lt;<span class="w"> </span>input.vcf<span class="w"> </span>&gt;<span class="w"> </span>validated.vcf
 </code></pre></div></p>
+<p>When the input is valid, the VCF contents are echoed to standard output so the tool can be used in pipelines. Informational messages such as <code>VCF file is valid.</code> are written to standard error.</p>
 <h3 id="redirecting-error-messages">Redirecting Error Messages<a class="headerlink" href="#redirecting-error-messages" title="Permanent link">&para;</a></h3>
 <p>Save validation errors to a file:
 <div class="highlight"><pre><span></span><code>VCFX_validator<span class="w"> </span>&lt;<span class="w"> </span>input.vcf<span class="w"> </span><span class="m">2</span>&gt;<span class="w"> </span>validation_errors.txt

--- a/src/VCFX_validator/VCFX_validator.cpp
+++ b/src/VCFX_validator/VCFX_validator.cpp
@@ -260,6 +260,7 @@ bool VCFXValidator::validateVCF(std::istream &in){
     std::string line;
     int lineNum=0;
     bool foundChromLine= false;
+    std::vector<std::string> lines;
 
     while(true){
         if(!std::getline(in, line)) break;
@@ -290,12 +291,16 @@ bool VCFXValidator::validateVCF(std::istream &in){
             }
             if(!validateDataLine(line, lineNum)) return false;
         }
+        lines.push_back(line);
     }
     if(!foundChromLine){
         std::cerr<<"Error: no #CHROM line found in file.\n";
         return false;
     }
-    std::cout<<"VCF file is valid.\n";
+    for(const auto &l : lines){
+        std::cout << l << '\n';
+    }
+    std::cerr<<"VCF file is valid.\n";
     return true;
 }
 


### PR DESCRIPTION
## Summary
- update `VCFX_validator` so validated VCF is echoed to stdout while messages go to stderr
- document passthrough behaviour in `docs/VCFX_validator.md`
- regenerate static site docs

## Testing
- `ctest -j4`
