### PR TITLE
Add macOS and Windows to CI matrix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,23 +8,41 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libz-dev
 
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install cmake zlib
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install -y cmake zlib
+
       - name: Configure
         run: cmake -S . -B build
+        shell: bash
 
       - name: Build
         run: cmake --build build -- -j
+        shell: bash
 
       - name: Run tests
         run: |
           cd build
           ctest --output-on-failure
+        shell: bash

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,12 @@ add_subdirectory(vcfx_wrapper)
 set(VCFX_TOOLS vcfx)
 file(GLOB TOOL_DIRS RELATIVE ${CMAKE_CURRENT_LIST_DIR} VCFX_*)
 foreach(dir ${TOOL_DIRS})
+    # On case-insensitive filesystems the glob may pick up directories such as
+    # "vcfx_wrapper". Ensure only directories that actually start with "VCFX_"
+    # are added to avoid duplicate add_subdirectory calls.
+    if(NOT "${dir}" MATCHES "^VCFX_")
+        continue()
+    endif()
     if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${dir}")
         add_subdirectory(${dir})
         list(APPEND VCFX_TOOLS ${dir})


### PR DESCRIPTION
## Summary
- run build-and-test workflow on ubuntu, macOS and Windows
- install zlib on macOS and use choco for Windows
- use bash shell for build/test steps
- fix case-sensitive glob in CMakeLists for macOS

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j`
- `ctest --output-on-failure`
