### PR TITLE
Add macOS and Windows to CI matrix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,23 +8,42 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake libz-dev
 
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install cmake zlib bash
+          echo "$(brew --prefix)/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install -y cmake zlib
+
       - name: Configure
         run: cmake -S . -B build
+        shell: bash
 
       - name: Build
         run: cmake --build build -- -j
+        shell: bash
 
       - name: Run tests
         run: |
           cd build
           ctest --output-on-failure
+        shell: bash

--- a/tests/test_custom_annotator.sh
+++ b/tests/test_custom_annotator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e
@@ -125,11 +125,19 @@ for i in $(seq 1 1000); do
     echo "1	$i	A	G	Annotation$i"
 done > "$SCRIPT_DIR/data/large_annotations.txt"
 # Add VCF header
-sed -i '1i\
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' '1i\
 ##fileformat=VCFv4.2\
 ##contig=<ID=1,length=1000>\
 #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  SAMPLE1\
 ' "$SCRIPT_DIR/data/large_input.vcf"
+else
+    sed -i '1i\
+##fileformat=VCFv4.2\
+##contig=<ID=1,length=1000>\
+#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  SAMPLE1\
+' "$SCRIPT_DIR/data/large_input.vcf"
+fi
 
 time "$ROOT_DIR/build/src/VCFX_custom_annotator/VCFX_custom_annotator" --add-annotation "$SCRIPT_DIR/data/large_annotations.txt" < "$SCRIPT_DIR/data/large_input.vcf" > "$SCRIPT_DIR/data/large_output.vcf"
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary
- run build-and-test workflow on ubuntu, macOS and Windows
- install bash via brew on macOS so associative-array tests run
- fix `test_custom_annotator` sed command for macOS compatibility

## Testing
- `cmake -S . -B build`
- `cmake --build build -- -j`
- `ctest --output-on-failure`
