### PR TITLE
Fix Windows CI build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,12 +31,19 @@ jobs:
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          choco install -y cmake zlib
+          choco install -y cmake
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install zlib getopt-win32
 
       - name: Configure
-        run: cmake -S . -B build
         shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          else
+            cmake -S . -B build
+          fi
 
       - name: Build
         run: cmake --build build -- -j

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.14)
 add_library(vcfx_core STATIC vcfx_core.cpp)
 target_include_directories(vcfx_core PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include)
 target_link_libraries(vcfx_core PUBLIC ZLIB::ZLIB)
+if(WIN32)
+    target_link_libraries(vcfx_core PUBLIC getopt)
+endif()
 
 # Add all tool subdirectories
 add_subdirectory(vcfx_wrapper)


### PR DESCRIPTION
## Summary
- fix the Windows CI step: install getopt via vcpkg for headers on Windows
- link vcfx_core with getopt when building on Windows

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`
