### PR TITLE
Fix Windows CI build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,15 +31,22 @@ jobs:
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          choco install -y cmake zlib
+          choco install -y cmake
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install zlib
 
       - name: Configure
-        run: cmake -S . -B build
         shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          else
+            cmake -S . -B build
+          fi
 
       - name: Build
-        run: cmake --build build -- -j
+        run: cmake --build build --parallel
         shell: bash
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- fix the Windows CI step: build using the cmake `--parallel` option to avoid passing `-j` to MSBuild

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`
