### PR TITLE
Fix Windows build by installing getopt via vcpkg

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
         shell: pwsh
         run: |
           choco install -y cmake
-          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install zlib
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install zlib getopt
 
 
       - name: Configure


### PR DESCRIPTION
## Summary
- on Windows install `getopt` via vcpkg

## Testing
- `bash tests/test_all.sh`