### PR TITLE
Streamed reading for variant counter

### DIFF
--- a/src/VCFX_variant_counter/VCFX_variant_counter.h
+++ b/src/VCFX_variant_counter/VCFX_variant_counter.h
@@ -17,6 +17,8 @@ private:
 
     // The actual counting function
     int countVariants(std::istream &in);
+    int countVariantsGzip(std::istream &in);
+    bool processLine(const std::string &line, int lineNumber, int &count);
 
 };
 


### PR DESCRIPTION
## Summary
- refactor `VCFX_variant_counter` to avoid reading whole input into memory
- add gzip streaming support

## Testing
- `cmake --build build`
- `cd tests && ./test_variant_counter.sh`