### PR TITLE
Fix docs for af filter and missing genotype pipeline

### DIFF
--- a/docs/VCFX_ld_calculator.md
+++ b/docs/VCFX_ld_calculator.md
@@ -78,7 +78,7 @@ VCFX_ld_calculator --region chr1:10000-20000 < input.vcf > ld_matrix.txt
 Filter for common variants first, then calculate LD:
 
 ```bash
-cat input.vcf | VCFX_af_subsetter --min-af 0.05 | VCFX_ld_calculator > common_variants_ld.txt
+cat input.vcf | VCFX_af_subsetter --af-filter '0.05-1.0' | VCFX_ld_calculator > common_variants_ld.txt
 ```
 
 ## Handling Special Cases
@@ -102,4 +102,4 @@ cat input.vcf | VCFX_af_subsetter --min-af 0.05 | VCFX_ld_calculator > common_va
 - Requires diploid genotypes; haploid genotypes will be treated as missing data
 - Assumes standard VCF format with GT field in the FORMAT column
 - Does not support phased vs. unphased distinction; both "/" and "|" separators are treated the same
-- No built-in visualization of LD patterns; additional tools would be needed for heatmap creation 
+- No built-in visualization of LD patterns; additional tools would be needed for heatmap creation

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,7 +119,8 @@ Here are some common workflows that combine multiple VCFX tools:
 cat input.vcf | \
   VCFX_validator | \
   VCFX_variant_classifier --append-info | \
-  VCFX_missing_detector --max-missing 0.1 | \
+  VCFX_missing_detector | \
+  grep -v 'MISSING_GENOTYPES=1' | \
   VCFX_phred_filter --min-qual 20 > qc_passed.vcf
 ```
 
@@ -154,4 +155,4 @@ After becoming familiar with the basic usage of VCFX tools, you can:
 2. Check the [installation guide](installation.md) if you need to install additional tools
 3. Browse through the example VCF files in the repository to practice
 
-For more complex workflows and advanced examples, refer to the individual tool documentation pages. 
+For more complex workflows and advanced examples, refer to the individual tool documentation pages.

--- a/docs/tools_overview.md
+++ b/docs/tools_overview.md
@@ -139,7 +139,7 @@ cat samples.vcf reference.vcf | VCFX_concordance_checker > concordance_report.ts
 ```bash
 # Calculate LD in a specific region after filtering for common variants
 cat input.vcf | \
-  VCFX_af_subsetter --min-af 0.05 | \
+  VCFX_af_subsetter --af-filter '0.05-1.0' | \
   VCFX_ld_calculator --region chr1:10000-20000 > ld_matrix.txt
 ```
 
@@ -167,6 +167,7 @@ cat eur.vcf | VCFX_allele_freq_calc > eur_afs.tsv
 cat input.vcf | \
   VCFX_validator | \
   VCFX_variant_classifier --append-info | \
-  VCFX_missing_detector --max-missing 0.1 | \
+  VCFX_missing_detector | \
+  grep -v 'MISSING_GENOTYPES=1' | \ 
   VCFX_phred_filter --min-qual 20 > qc_passed.vcf
-``` 
+```


### PR DESCRIPTION
## Summary
- update AF filtering example to use `--af-filter '0.05-1.0'`
- remove `--max-missing` from documentation and show how to filter flagged records
- add trailing newlines to updated docs

## Testing
- `tests/test_all.sh`
