### PR TITLE
Fix Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y \
     cmake \
     git \
     libz-dev \
+    python3 \
+    python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a working directory


### PR DESCRIPTION
## Summary
- update Dockerfile with Python dependencies so the build succeeds

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`