### PR TITLE
Add Python wrappers and wheel CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,3 +41,53 @@ jobs:
           cd build
           ctest --output-on-failure
         shell: bash
+
+  python-wheels:
+    needs: build-and-test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libz-dev python3-pip
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install cmake zlib python@3 bash
+          echo "$(brew --prefix)/bin" >> $GITHUB_PATH
+
+      - name: Build project
+        run: |
+          cmake -S . -B build -DPYTHON_BINDINGS=ON
+          cmake --build build --parallel
+          cmake --install build --prefix $PWD/install
+        shell: bash
+
+      - name: Build wheel
+        run: |
+          python3 -m pip install --upgrade pip wheel
+          pip wheel ./python -w dist
+        shell: bash
+
+      - name: Test Python wheel
+        run: |
+          pip install dist/*.whl
+          echo "$PWD/install/bin" >> $GITHUB_PATH
+          python3 - <<'EOF'
+import vcfx
+print('version:', vcfx.get_version())
+tools = vcfx.available_tools()
+print('tools:', len(tools))
+if tools:
+    vcfx.run_tool(tools[0], '--help', check=False)
+EOF
+        shell: bash

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -47,3 +47,25 @@ print(vcfx.split("A,B,C", ","))
 version = vcfx.get_version()
 print("VCFX version:", version)
 ```
+
+## Tool Wrappers
+
+Besides the helper functions, the package provides lightweight wrappers for
+all command line tools shipped with VCFX.  The wrappers simply invoke the
+corresponding ``VCFX_*`` executable via ``subprocess``.
+
+Use ``vcfx.available_tools()`` to see which tools are accessible on your
+``PATH`` and call them either via ``vcfx.run_tool(name, *args)`` or by using
+the tool name as a function:
+
+```python
+import vcfx
+
+print(vcfx.available_tools())
+
+# run through the generic helper
+vcfx.run_tool("alignment_checker", "--help")
+
+# or directly by name (if available)
+vcfx.alignment_checker("--help")
+```

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,8 +17,9 @@ set_target_properties(_vcfx PROPERTIES
 )
 
 configure_file(__init__.py "${CMAKE_BINARY_DIR}/python/vcfx/__init__.py" COPYONLY)
+configure_file(tools.py "${CMAKE_BINARY_DIR}/python/vcfx/tools.py" COPYONLY)
 
 install(TARGETS _vcfx
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx)
-install(FILES __init__.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx)
+install(FILES __init__.py tools.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx)

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,3 +1,14 @@
 """Python bindings for the VCFX toolkit."""
 
 from ._vcfx import *  # noqa: F401,F403
+from . import tools as _tools
+
+# Re-export helper functions for convenience
+available_tools = _tools.available_tools
+run_tool = _tools.run_tool
+
+
+def __getattr__(name):
+    """Provide access to tool wrappers as attributes."""
+    return getattr(_tools, name)
+

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,14 @@
 import pathlib
+import re
 import subprocess
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+
+def read_version():
+    root = pathlib.Path(__file__).resolve().parent.parent / "CMakeLists.txt"
+    text = root.read_text()
+    m = re.search(r"set\(VCFX_VERSION\s+\"([0-9.]+)\"\)", text)
+    return m.group(1) if m else "0.0.0"
 
 class CMakeExtension(Extension):
     def __init__(self, name):
@@ -23,10 +30,15 @@ class CMakeBuild(build_ext):
 
 setup(
     name='vcfx',
-    version='0.0.0',
+    version=read_version(),
     packages=['vcfx'],
     package_dir={'vcfx': '.'},
     ext_modules=[CMakeExtension('_vcfx')],
     cmdclass={'build_ext': CMakeBuild},
     zip_safe=False,
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX :: Linux',
+    ],
 )

--- a/python/tools.py
+++ b/python/tools.py
@@ -1,0 +1,52 @@
+import subprocess
+import shutil
+import functools
+
+__all__ = ["available_tools", "run_tool"]
+
+
+def available_tools():
+    """Return a list of VCFX tools available on the PATH."""
+    result = subprocess.run(["vcfx", "--list"], capture_output=True, text=True)
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def run_tool(tool, *args, check=True, capture_output=False, text=True, **kwargs):
+    """Run a VCFX tool using subprocess.
+
+    Parameters
+    ----------
+    tool : str
+        Name of the tool without the ``VCFX_`` prefix.
+    *args : list
+        Arguments passed to the tool.
+    check : bool, optional
+        If ``True`` (default) raise ``CalledProcessError`` on non-zero
+        return code.
+    capture_output : bool, optional
+        If ``True`` capture stdout/stderr and return them on the returned
+        ``CompletedProcess`` object.
+    text : bool, optional
+        If ``True`` decode output as text. Defaults to ``True``.
+    **kwargs : dict
+        Additional keyword arguments forwarded to ``subprocess.run``.
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+    """
+    exe = shutil.which(f"VCFX_{tool}")
+    if exe is None:
+        raise FileNotFoundError(f"VCFX tool '{tool}' not found in PATH")
+    cmd = [exe, *map(str, args)]
+    return subprocess.run(cmd, check=check, capture_output=capture_output, text=text, **kwargs)
+
+
+# Lazy attribute access for tool wrappers
+
+def __getattr__(name):
+    if name in available_tools():
+        return functools.partial(run_tool, name)
+    raise AttributeError(f"module 'vcfx' has no attribute '{name}'")


### PR DESCRIPTION
## Summary
- expose CLI tools to Python via new `tools` module
- re-export wrappers from `vcfx` package
- fetch version from CMake in `setup.py`
- document Python wrappers
- build wheels and run example usage in CI

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`
