### PR TITLE
Enable non-root installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,20 @@ set(VCFX_VERSION "${VCFX_VERSION_MAJOR}.${VCFX_VERSION_MINOR}.${VCFX_VERSION_PAT
 
 add_compile_definitions(VCFX_VERSION="${VCFX_VERSION}")
 
-project(VCFX 
+project(VCFX
   VERSION ${VCFX_VERSION}
   DESCRIPTION "A Comprehensive VCF Manipulation Toolkit"
   LANGUAGES CXX
 )
+
+# Set a user-friendly default install prefix when none is provided.
+# This prevents installation attempts into system directories when
+# running without root privileges.
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/.local" CACHE PATH "Install prefix" FORCE)
+endif()
+
+include(GNUInstallDirs)
 
 # Optionally allow building for WebAssembly via Emscripten
 option(BUILD_WASM "Build with emscripten toolchain" OFF)
@@ -64,7 +73,6 @@ endif()
 add_subdirectory(tests)
 
 # Installation configuration
-include(GNUInstallDirs)
 
 # Install header files
 install(FILES 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,10 +71,14 @@ This method ensures you have the latest version of VCFX.
    make
    ```
 
-3. (Optional) Install the tools to your system:
+3. (Optional) Install the tools:
    ```bash
-   sudo make install
+   make install
    ```
+
+   By default the tools are installed into `~/.local`, so no administrator
+   privileges are required. You can change the destination with
+   `cmake -DCMAKE_INSTALL_PREFIX=/your/path ..` if desired.
 
 After installation, you should be able to run VCFX tools from your terminal.
 


### PR DESCRIPTION
## Summary
- default CMake install prefix to ~/.local
- document how to install without sudo

## Testing
- `cmake -B build -S .`
- `cmake --build build -j$(nproc)`
- `cmake --install build`
- `ctest --test-dir build`