### PR TITLE
Fix workflow PATH handling

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Test Python wheel
         run: |
           pip install dist/*.whl
+          export PATH="$PWD/install/bin:$PATH"
           echo "$PWD/install/bin" >> $GITHUB_PATH
           cat <<'          EOF' | sed 's/^          //' | python3 -
           import vcfx


### PR DESCRIPTION
## Summary
- ensure `$PATH` includes installed tools during wheel tests
- revert Python API to use `vcfx --list` directly

## Testing
- `bash tests/test_python_bindings.sh`
