### PR TITLE
Update docs to recommend virtual env

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -26,8 +26,11 @@ This setup only needs to be done once. After this, the GitHub Actions workflow w
 
 Before pushing any changes, you should test the documentation site locally:
 
-1. Install the required dependencies:
+1. Install the required dependencies. It's best to use a Python virtual
+   environment because some systems mark the system Python as
+   "externally managed", which can interfere with installation:
    ```bash
+   python3 -m venv venv && source venv/bin/activate
    pip install mkdocs-material pymdown-extensions
    ```
 

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -16,9 +16,13 @@ make -j
 
 The compiled module will be placed in the `build/python` directory.
 You can also install the package via `pip` which will invoke CMake
-automatically:
+automatically. We recommend using a Python virtual environment because
+some systems mark the system Python as "externally managed", which can
+prevent direct installation. Create and activate a virtual environment
+before running `pip`:
 
 ```bash
+python3 -m venv venv && source venv/bin/activate
 pip install ./python
 ```
 


### PR DESCRIPTION
## Summary
- recommend creating a Python virtual environment before running `pip install`
- note that some system Pythons are "externally managed"

## Testing
- `ctest --output-on-failure` (no tests found)