### PR TITLE
Fix heredoc delimiter in build workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,12 +88,12 @@ jobs:
           python -m pip install dist/*.whl
           export PATH="$PWD/install/bin:$PATH"
           echo "$PWD/install/bin" >> $GITHUB_PATH
-          cat <<'          EOF' | sed 's/^          //' | python -
+          cat <<'EOF' | python -
           import vcfx
           print('version:', vcfx.get_version())
           tools = vcfx.available_tools()
           print('tools:', len(tools))
           if tools:
               vcfx.run_tool(tools[0], '--help', check=False)
-          EOF
+EOF
         shell: bash


### PR DESCRIPTION
## Summary
- fix heredoc delimiter in build-test workflow so EOF line is recognized by the shell

## Testing
- `sed -n '90,99p' .github/workflows/build-test.yml`
