### PR TITLE
Fix YAML build-test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,5 +95,5 @@ jobs:
           print('tools:', len(tools))
           if tools:
               vcfx.run_tool(tools[0], '--help', check=False)
-EOF
+          EOF
         shell: bash


### PR DESCRIPTION
## Summary
- fix indentation for EOF in build-test.yml to avoid YAML parse errors

## Testing
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/build-test.yml"); puts "ok"'`