### PR TITLE
Add pyproject and update python install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ cmake ..
 make
 ```
 
+#### Installing Python Bindings from a Local Checkout
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+pip install --no-build-isolation ./python
+```
+
+When offline, ensure the `setuptools` and `cmake` packages are already installed
+because build isolation is disabled.
+
 ### Basic Usage Example
 
 ```bash

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -23,8 +23,11 @@ before running `pip`:
 
 ```bash
 python3 -m venv venv && source venv/bin/activate
-pip install ./python
+pip install --no-build-isolation ./python
 ```
+
+If you are offline, ensure that the required build dependencies are already
+installed because `--no-build-isolation` uses your current environment.
 
 ## Available Functions
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8", "cmake"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` for building the Python extension
- document local installation using `pip install --no-build-isolation ./python`
- mention offline builds require pre-installed build dependencies

## Testing
- `bash tests/test_all.sh`