### PR TITLE
Add Python API docs & fix wrapper docs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ pip install --no-build-isolation ./python
 When offline, ensure the `setuptools` and `cmake` packages are already installed
 because build isolation is disabled.
 
+### Python API
+
+VCFX also offers optional Python bindings. See
+[the Python API docs](docs/python_api.md) for details. After installing, you can
+list available command line tools via `vcfx.available_tools()` and run any tool
+with `vcfx.run_tool()`:
+
+```python
+import vcfx
+vcfx.run_tool("alignment_checker", "--help")
+```
+
 ### Basic Usage Example
 
 ```bash

--- a/src/vcfx_wrapper/vcfx.cpp
+++ b/src/vcfx_wrapper/vcfx.cpp
@@ -69,6 +69,7 @@ static std::vector<std::string> get_doc_dirs(){
             dirs.push_back(base + "/../share/vcfx/docs");
             dirs.push_back(base + "/../docs");
             dirs.push_back(base + "/../../docs");
+            dirs.push_back(base + "/../../../docs"); // when run from build/src/vcfx_wrapper
         }
     }
     dirs.push_back("docs");


### PR DESCRIPTION
## Summary
- document optional Python API in README
- fix vcfx wrapper doc search path so docs are found when running tests

## Testing
- `bash tests/test_all.sh`