### PR TITLE
Update Docker docs with entrypoint usage

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -57,6 +57,19 @@ docker build -t vcfx:local .
 docker-compose build
 ```
 
+## Entrypoint Script and Passing Commands
+
+The image uses `/usr/local/bin/docker_entrypoint.sh` as its entrypoint. This script
+adds all VCFX tools to the `PATH` and then executes whatever command you pass to
+`docker run`.
+
+```bash
+docker run --rm ghcr.io/jorgemfs/vcfx:latest VCFX_variant_counter < input.vcf
+```
+
+You can substitute `VCFX_variant_counter` with any other tool or quote a more
+complex shell command.
+
 ## Running VCFX Tools
 
 There are several ways to run VCFX tools with Docker:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -57,6 +57,19 @@ docker build -t vcfx:local .
 docker-compose build
 ```
 
+## Entrypoint Script and Passing Commands
+
+The image uses `/usr/local/bin/docker_entrypoint.sh` as its entrypoint. This script
+adds all VCFX tools to the `PATH` and then executes whatever command you pass to
+`docker run`.
+
+```bash
+docker run --rm ghcr.io/jorgemfs/vcfx:latest VCFX_variant_counter < input.vcf
+```
+
+You can substitute `VCFX_variant_counter` with any other tool or quote a more
+complex shell command.
+
 ## Running VCFX Tools
 
 There are several ways to run VCFX tools with Docker:


### PR DESCRIPTION
## Summary
- document how the Docker entrypoint works
- show how to pass commands directly, including `VCFX_variant_counter`

## Testing
- `./tests/test_docker.sh` *(fails: Docker not installed)*
- `./tests/test_all.sh` *(fails: build interrupted due to missing dependencies)*