### PR TITLE
Improve executable path handling and add doc lookup test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TEST_SCRIPTS
     test_validator.sh
     test_variant_classifier.sh
     test_variant_counter.sh
+    test_doc_lookup.sh
     test_python_bindings.sh
 )
 

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -82,6 +82,7 @@ TEST_SCRIPTS=(
     "test_variant_classifier.sh"
     "test_variant_counter.sh"
     "test_vcfx_wrapper.sh"
+    "test_doc_lookup.sh"
     "test_available_tools_fallback.sh"
     "test_python_bindings.sh"
 )

--- a/tests/test_doc_lookup.sh
+++ b/tests/test_doc_lookup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+VCFX_BUILD_BIN="$ROOT_DIR/build/src/vcfx_wrapper/vcfx"
+TMPDIR="$(mktemp -d)"
+install -D "$VCFX_BUILD_BIN" "$TMPDIR/bin/vcfx"
+# copy docs to share/doc/VCFX relative to bin
+mkdir -p "$TMPDIR/share/doc"
+cp -r "$ROOT_DIR/docs" "$TMPDIR/share/doc/VCFX"
+
+PATH="$TMPDIR/bin:$PATH" vcfx help allele_counter > "$TMPDIR/out.txt"
+FIRST_LINE="$(head -n 1 "$TMPDIR/out.txt")"
+rm -rf "$TMPDIR"
+
+if ! echo "$FIRST_LINE" | grep -q "VCFX_allele_counter"; then
+  echo "Documentation lookup failed"
+  exit 1
+fi
+
+echo "✓ doc lookup portable test passed"


### PR DESCRIPTION
## Summary
- make `vcfx` wrapper detect its executable path on macOS with `_NSGetExecutablePath`
- fall back to `argv[0]` when `/proc/self/exe` isn't available
- add regression test for documentation lookup using installed layout

## Testing
- `tests/test_vcfx_wrapper.sh >/tmp/out.txt && tail -n 1 /tmp/out.txt`
- `tests/test_doc_lookup.sh`