### PR TITLE
Improve executable path detection and fix doc lookup test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TEST_SCRIPTS
     test_validator.sh
     test_variant_classifier.sh
     test_variant_counter.sh
+    test_doc_lookup.sh
     test_python_bindings.sh
 )
 

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -82,6 +82,7 @@ TEST_SCRIPTS=(
     "test_variant_classifier.sh"
     "test_variant_counter.sh"
     "test_vcfx_wrapper.sh"
+    "test_doc_lookup.sh"
     "test_available_tools_fallback.sh"
     "test_python_bindings.sh"
 )

--- a/tests/test_doc_lookup.sh
+++ b/tests/test_doc_lookup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+VCFX_BUILD_BIN="$ROOT_DIR/build/src/vcfx_wrapper/vcfx"
+TMPDIR="$(mktemp -d)"
+mkdir -p "$TMPDIR/bin"
+cp "$VCFX_BUILD_BIN" "$TMPDIR/bin/vcfx"
+# copy docs to share/doc/VCFX relative to bin
+mkdir -p "$TMPDIR/share/doc/VCFX"
+cp -r "$ROOT_DIR/docs/." "$TMPDIR/share/doc/VCFX"
+
+PATH="$TMPDIR/bin:$PATH" vcfx help allele_counter > "$TMPDIR/out.txt"
+FIRST_LINE="$(head -n 1 "$TMPDIR/out.txt")"
+rm -rf "$TMPDIR"
+
+if ! echo "$FIRST_LINE" | grep -q "VCFX_allele_counter"; then
+  echo "Documentation lookup failed"
+  exit 1
+fi
+
+echo "✓ doc lookup portable test passed"


### PR DESCRIPTION
## Summary
- make `vcfx` fall back to argv[0] for doc lookup when /proc/self/exe is missing
- use `_NSGetExecutablePath` on macOS to detect the executable path
- ensure doc lookup test copies docs correctly for all platforms

## Testing
- `ctest --output-on-failure`
