### PR TITLE
Add unified flag handler

### DIFF
--- a/include/vcfx_core.h
+++ b/include/vcfx_core.h
@@ -39,6 +39,13 @@ inline bool handle_version_flag(int argc, char* argv[], const std::string& tool,
     return false;
 }
 
+// Handle common flags shared by all tools. Returns true if "--version" or
+// "--help"/"-h" was processed and the program should exit.
+bool handle_common_flags(int argc, char* argv[],
+                         const std::string& tool,
+                         void (*print_help)(),
+                         std::ostream& os = std::cout);
+
 // Read entire input stream, automatically decompressing if gzip/BGZF
 // compressed. Returns true on success and stores the resulting text in
 // 'out'.

--- a/src/VCFX_af_subsetter/VCFX_af_subsetter.cpp
+++ b/src/VCFX_af_subsetter/VCFX_af_subsetter.cpp
@@ -156,8 +156,10 @@ void VCFXAfSubsetter::subsetByAlleleFrequency(std::istream& in, std::ostream& ou
 //
 // Typical main():
 //
+static void show_help() { VCFXAfSubsetter obj; char arg0[] = "VCFX_af_subsetter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_af_subsetter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_af_subsetter", show_help)) return 0;
     VCFXAfSubsetter afSubsetter;
     return afSubsetter.run(argc, argv);
 }

--- a/src/VCFX_alignment_checker/VCFX_alignment_checker.cpp
+++ b/src/VCFX_alignment_checker/VCFX_alignment_checker.cpp
@@ -324,8 +324,10 @@ void VCFXAlignmentChecker::checkDiscrepancies(std::istream& vcfIn, std::ostream&
 }
 
 // Typical main(), linking to run()
+static void show_help() { VCFXAlignmentChecker obj; char arg0[] = "VCFX_alignment_checker"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_alignment_checker")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_alignment_checker", show_help)) return 0;
     VCFXAlignmentChecker alignmentChecker;
     return alignmentChecker.run(argc, argv);
 }

--- a/src/VCFX_allele_balance_calc/VCFX_allele_balance_calc.cpp
+++ b/src/VCFX_allele_balance_calc/VCFX_allele_balance_calc.cpp
@@ -224,8 +224,10 @@ bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBal
 // ---------------------------------------------------------------
 // main()
 // ---------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_allele_balance_calc")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_balance_calc", show_help)) return 0;
     AlleleBalanceArguments args;
     parseArguments(argc, argv, args);
 

--- a/src/VCFX_allele_balance_filter/VCFX_allele_balance_filter.cpp
+++ b/src/VCFX_allele_balance_filter/VCFX_allele_balance_filter.cpp
@@ -197,8 +197,10 @@ double VCFXAlleleBalanceFilter::calculateAlleleBalance(const std::string& genoty
 // ------------------------------------------------------
 // main() linking to class
 // ------------------------------------------------------
+static void show_help() { VCFXAlleleBalanceFilter obj; char arg0[] = "VCFX_allele_balance_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_allele_balance_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_balance_filter", show_help)) return 0;
     VCFXAlleleBalanceFilter alleleBalanceFilter;
     return alleleBalanceFilter.run(argc, argv);
 }

--- a/src/VCFX_allele_counter/VCFX_allele_counter.cpp
+++ b/src/VCFX_allele_counter/VCFX_allele_counter.cpp
@@ -232,8 +232,10 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
 // ---------------------------------------------------------------------
 // main()
 // ---------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_allele_counter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_counter", show_help)) return 0;
     AlleleCounterArguments args;
     parseArguments(argc, argv, args);
 

--- a/src/VCFX_allele_freq_calc/VCFX_allele_freq_calc.cpp
+++ b/src/VCFX_allele_freq_calc/VCFX_allele_freq_calc.cpp
@@ -183,8 +183,10 @@ static void calculateAlleleFrequency(std::istream& in, std::ostream& out) {
 // ---------------------------------------------------------
 // main()
 // ---------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_allele_freq_calc")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_freq_calc", show_help)) return 0;
     // Parse arguments for help
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_ancestry_assigner/VCFX_ancestry_assigner.cpp
+++ b/src/VCFX_ancestry_assigner/VCFX_ancestry_assigner.cpp
@@ -408,8 +408,10 @@ void VCFXAncestryAssigner::assignAncestry(std::istream& vcfIn, std::ostream& out
 // ---------------------------------------------------------
 // main() - just instantiate and run
 // ---------------------------------------------------------
+static void show_help() { VCFXAncestryAssigner obj; char arg0[] = "VCFX_ancestry_assigner"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_ancestry_assigner")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ancestry_assigner", show_help)) return 0;
     VCFXAncestryAssigner assigner;
     return assigner.run(argc, argv);
 }

--- a/src/VCFX_ancestry_inferrer/VCFX_ancestry_inferrer.cpp
+++ b/src/VCFX_ancestry_inferrer/VCFX_ancestry_inferrer.cpp
@@ -58,8 +58,10 @@ private:
 // ----------------------------------------------------
 // main() - create the inferrer and run
 // ----------------------------------------------------
+static void show_help() { VCFXAncestryInferrer obj; char arg0[] = "VCFX_ancestry_inferrer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_ancestry_inferrer")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ancestry_inferrer", show_help)) return 0;
     VCFXAncestryInferrer inferrer;
     return inferrer.run(argc, argv);
 }

--- a/src/VCFX_annotation_extractor/VCFX_annotation_extractor.cpp
+++ b/src/VCFX_annotation_extractor/VCFX_annotation_extractor.cpp
@@ -273,8 +273,10 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
 // --------------------------------------------------------------
 // main()
 // --------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_annotation_extractor")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_annotation_extractor", show_help)) return 0;
     AnnotationOptions opts;
     if (!parseArguments(argc, argv, opts)) {
         // parseArguments already printed help if needed

--- a/src/VCFX_compressor/VCFX_compressor.cpp
+++ b/src/VCFX_compressor/VCFX_compressor.cpp
@@ -149,8 +149,10 @@ static bool compressDecompressVCF(std::istream& in, std::ostream& out, bool comp
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_compressor")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_compressor", show_help)) return 0;
     bool compress = false;
     bool decompress = false;
 

--- a/src/VCFX_concordance_checker/VCFX_concordance_checker.cpp
+++ b/src/VCFX_concordance_checker/VCFX_concordance_checker.cpp
@@ -275,8 +275,10 @@ static bool calculateConcordance(std::istream &in, std::ostream &out, const Conc
 // ---------------------------------------------------------
 // main
 // ---------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_concordance_checker")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_concordance_checker", show_help)) return 0;
     ConcordanceArguments args;
     if (!parseArguments(argc, argv, args)) {
         // parseArguments prints error/help if needed

--- a/src/VCFX_cross_sample_concordance/VCFX_cross_sample_concordance.cpp
+++ b/src/VCFX_cross_sample_concordance/VCFX_cross_sample_concordance.cpp
@@ -258,8 +258,10 @@ static void calculateConcordance(std::istream &in, std::ostream &out,
 // --------------------------------------------------------------------------
 // Command-line parsing + main
 // --------------------------------------------------------------------------
+static void show_help() { displayHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_cross_sample_concordance")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_cross_sample_concordance", show_help)) return 0;
     bool showHelp = false;
     std::string samplesArg;
 

--- a/src/VCFX_custom_annotator/VCFX_custom_annotator.cpp
+++ b/src/VCFX_custom_annotator/VCFX_custom_annotator.cpp
@@ -282,8 +282,10 @@ int VCFXCustomAnnotator::run(int argc, char* argv[]) {
 // ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
+static void show_help() { VCFXCustomAnnotator obj; char arg0[] = "VCFX_custom_annotator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_custom_annotator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_custom_annotator", show_help)) return 0;
     VCFXCustomAnnotator annotator;
     return annotator.run(argc, argv);
 }

--- a/src/VCFX_diff_tool/VCFX_diff_tool.cpp
+++ b/src/VCFX_diff_tool/VCFX_diff_tool.cpp
@@ -205,8 +205,10 @@ int VCFXDiffTool::run(int argc, char* argv[]) {
 // ----------------------------------------------------------------------
 // main
 // ----------------------------------------------------------------------
+static void show_help() { VCFXDiffTool obj; char arg0[] = "VCFX_diff_tool"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_diff_tool")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_diff_tool", show_help)) return 0;
     VCFXDiffTool diffTool;
     return diffTool.run(argc, argv);
 }

--- a/src/VCFX_distance_calculator/VCFX_distance_calculator.cpp
+++ b/src/VCFX_distance_calculator/VCFX_distance_calculator.cpp
@@ -160,8 +160,10 @@ bool calculateDistances(std::istream& in, std::ostream& out) {
 // --------------------------------------------------------------------------
 // main: Parses command-line arguments and calls calculateDistances.
 // --------------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_distance_calculator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_distance_calculator", show_help)) return 0;
     // Check for help option.
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_dosage_calculator/VCFX_dosage_calculator.cpp
+++ b/src/VCFX_dosage_calculator/VCFX_dosage_calculator.cpp
@@ -216,8 +216,10 @@ std::vector<std::string> VCFXDosageCalculator::split(const std::string& str, cha
     return tokens;
 }
 
+static void show_help() { VCFXDosageCalculator obj; char arg0[] = "VCFX_dosage_calculator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_dosage_calculator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_dosage_calculator", show_help)) return 0;
     VCFXDosageCalculator dosageCalculator;
     return dosageCalculator.run(argc, argv);
 }

--- a/src/VCFX_duplicate_remover/VCFX_duplicate_remover.cpp
+++ b/src/VCFX_duplicate_remover/VCFX_duplicate_remover.cpp
@@ -123,8 +123,10 @@ bool removeDuplicates(std::istream& in, std::ostream& out) {
 // ----------------------------------------------------------------------
 // main: Parse command-line arguments and call removeDuplicates.
 // ----------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_duplicate_remover")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_duplicate_remover", show_help)) return 0;
     // Simple argument parsing: if --help or -h is provided, print help.
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_fasta_converter/VCFX_fasta_converter.cpp
+++ b/src/VCFX_fasta_converter/VCFX_fasta_converter.cpp
@@ -320,8 +320,10 @@ void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) 
     }
 }
 
+static void show_help() { VCFXFastaConverter obj; char arg0[] = "VCFX_fasta_converter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_fasta_converter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_fasta_converter", show_help)) return 0;
     VCFXFastaConverter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_field_extractor/VCFX_field_extractor.cpp
+++ b/src/VCFX_field_extractor/VCFX_field_extractor.cpp
@@ -245,8 +245,10 @@ void extractFields(std::istream& in, std::ostream& out, const std::vector<std::s
 // ------------------------------------------------------------------------
 // main: parse arguments, call extractFields
 // ------------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_field_extractor")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_field_extractor", show_help)) return 0;
     std::vector<std::string> fields;
     bool showHelp = false;
 

--- a/src/VCFX_file_splitter/VCFX_file_splitter.cpp
+++ b/src/VCFX_file_splitter/VCFX_file_splitter.cpp
@@ -159,8 +159,10 @@ void VCFXFileSplitter::splitVCFByChromosome(std::istream& in,
     }
 }
 
+static void show_help() { VCFXFileSplitter obj; char arg0[] = "VCFX_file_splitter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_file_splitter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_file_splitter", show_help)) return 0;
     VCFXFileSplitter splitter;
     return splitter.run(argc, argv);
 }

--- a/src/VCFX_format_converter/VCFX_format_converter.cpp
+++ b/src/VCFX_format_converter/VCFX_format_converter.cpp
@@ -185,8 +185,10 @@ void convertVCFtoCSV(std::istream& in, std::ostream& out) {
 // -----------------------------------------------------------------------
 // main
 // -----------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_format_converter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_format_converter", show_help)) return 0;
     OutputFormat format;
     bool valid = parseArguments(argc, argv, format);
 

--- a/src/VCFX_genotype_query/VCFX_genotype_query.cpp
+++ b/src/VCFX_genotype_query/VCFX_genotype_query.cpp
@@ -239,8 +239,10 @@ void genotypeQuery(std::istream& in, std::ostream& out,
 // ------------------------------------------------------------------
 // main
 // ------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_genotype_query")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_genotype_query", show_help)) return 0;
     std::string genotypeQueryStr;
     bool strictCompare = false;
     if (!parseArguments(argc, argv, genotypeQueryStr, strictCompare)) {

--- a/src/VCFX_gl_filter/VCFX_gl_filter.cpp
+++ b/src/VCFX_gl_filter/VCFX_gl_filter.cpp
@@ -263,8 +263,10 @@ void VCFXGLFilter::filterByGL(std::istream& in,
     }
 }
 
+static void show_help() { VCFXGLFilter obj; char arg0[] = "VCFX_gl_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_gl_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_gl_filter", show_help)) return 0;
     VCFXGLFilter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_haplotype_extractor/VCFX_haplotype_extractor.cpp
+++ b/src/VCFX_haplotype_extractor/VCFX_haplotype_extractor.cpp
@@ -327,8 +327,10 @@ bool HaplotypeExtractor::extractHaplotypes(std::istream& in, std::ostream& out) 
 // ---------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_haplotype_extractor")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_haplotype_extractor", show_help)) return 0;
     int blockSize = 100000;
     bool doCheck = false;
     bool debug = false;

--- a/src/VCFX_haplotype_phaser/VCFX_haplotype_phaser.cpp
+++ b/src/VCFX_haplotype_phaser/VCFX_haplotype_phaser.cpp
@@ -318,8 +318,10 @@ std::vector<std::vector<int>> VCFXHaplotypePhaser::groupVariants(const std::vect
     return blocks;
 }
 
+static void show_help() { VCFXHaplotypePhaser obj; char arg0[] = "VCFX_haplotype_phaser"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_haplotype_phaser")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_haplotype_phaser", show_help)) return 0;
     VCFXHaplotypePhaser hp;
     return hp.run(argc, argv);
 }

--- a/src/VCFX_header_parser/VCFX_header_parser.cpp
+++ b/src/VCFX_header_parser/VCFX_header_parser.cpp
@@ -26,8 +26,10 @@ void processHeader(std::istream& in, std::ostream& out) {
     }
 }
 
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_header_parser")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_header_parser", show_help)) return 0;
     // Simple argument parsing
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_hwe_tester/VCFX_hwe_tester.cpp
+++ b/src/VCFX_hwe_tester/VCFX_hwe_tester.cpp
@@ -255,8 +255,10 @@ void VCFXHWETester::performHWE(std::istream& in){
 }
 
 // actual main
+static void show_help() { VCFXHWETester obj; char arg0[] = "VCFX_hwe_tester"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_hwe_tester")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_hwe_tester", show_help)) return 0;
     VCFXHWETester tester;
     return tester.run(argc, argv);
 }

--- a/src/VCFX_impact_filter/VCFX_impact_filter.cpp
+++ b/src/VCFX_impact_filter/VCFX_impact_filter.cpp
@@ -200,8 +200,10 @@ void VCFXImpactFilter::filterByImpact(std::istream& in,
     }
 }
 
+static void show_help() { VCFXImpactFilter obj; char arg0[] = "VCFX_impact_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_impact_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_impact_filter", show_help)) return 0;
     VCFXImpactFilter filt;
     return filt.run(argc, argv);
 }

--- a/src/VCFX_inbreeding_calculator/VCFX_inbreeding_calculator.cpp
+++ b/src/VCFX_inbreeding_calculator/VCFX_inbreeding_calculator.cpp
@@ -351,8 +351,10 @@ int VCFXInbreedingCalculator::run(int argc, char* argv[]){
 
 // -------------------------------------------------------------------------
 // main entry point
+static void show_help() { VCFXInbreedingCalculator obj; char arg0[] = "VCFX_inbreeding_calculator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_inbreeding_calculator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_inbreeding_calculator", show_help)) return 0;
     VCFXInbreedingCalculator calc;
     return calc.run(argc, argv);
 }

--- a/src/VCFX_indel_normalizer/VCFX_indel_normalizer.cpp
+++ b/src/VCFX_indel_normalizer/VCFX_indel_normalizer.cpp
@@ -253,8 +253,10 @@ void VCFXIndelNormalizer::normalizeIndels(std::istream& in, std::ostream& out) {
     }
 }
 
+static void show_help() { VCFXIndelNormalizer obj; char arg0[] = "VCFX_indel_normalizer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_indel_normalizer")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_indel_normalizer", show_help)) return 0;
     VCFXIndelNormalizer norm;
     return norm.run(argc, argv);
 }

--- a/src/VCFX_indexer/VCFX_indexer.cpp
+++ b/src/VCFX_indexer/VCFX_indexer.cpp
@@ -189,8 +189,10 @@ void VCFXIndexer::createVCFIndex(std::istream &in, std::ostream &out) {
 }
 
 // Optional main if you build as a single executable
+static void show_help() { VCFXIndexer obj; char arg0[] = "VCFX_indexer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_indexer")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_indexer", show_help)) return 0;
     VCFXIndexer idx;
     return idx.run(argc, argv);
 }

--- a/src/VCFX_info_aggregator/VCFX_info_aggregator.cpp
+++ b/src/VCFX_info_aggregator/VCFX_info_aggregator.cpp
@@ -214,8 +214,10 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
     }
 }
 
+static void show_help() { VCFXInfoAggregator obj; char arg0[] = "VCFX_info_aggregator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_info_aggregator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_aggregator", show_help)) return 0;
     VCFXInfoAggregator app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_info_parser/VCFX_info_parser.cpp
+++ b/src/VCFX_info_parser/VCFX_info_parser.cpp
@@ -139,8 +139,10 @@ bool parseInfoFields(std::istream& in, std::ostream& out, const std::vector<std:
     return true;
 }
 
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_info_parser")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_parser", show_help)) return 0;
     std::vector<std::string> info_fields;
 
     // parse arguments

--- a/src/VCFX_info_summarizer/VCFX_info_summarizer.cpp
+++ b/src/VCFX_info_summarizer/VCFX_info_summarizer.cpp
@@ -225,8 +225,10 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
     return true;
 }
 
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_info_summarizer")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_summarizer", show_help)) return 0;
     std::vector<std::string> info_fields;
 
     // parse arguments

--- a/src/VCFX_ld_calculator/VCFX_ld_calculator.cpp
+++ b/src/VCFX_ld_calculator/VCFX_ld_calculator.cpp
@@ -345,8 +345,10 @@ int VCFXLDCalculator::run(int argc, char* argv[]) {
     return 0;
 }
 
+static void show_help() { VCFXLDCalculator obj; char arg0[] = "VCFX_ld_calculator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_ld_calculator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ld_calculator", show_help)) return 0;
     VCFXLDCalculator calc;
     return calc.run(argc, argv);
 }

--- a/src/VCFX_merger/VCFX_merger.cpp
+++ b/src/VCFX_merger/VCFX_merger.cpp
@@ -120,8 +120,10 @@ void VCFXMerger::mergeVCF(const std::vector<std::string>& inputFiles, std::ostre
 }
 
 
+static void show_help() { VCFXMerger obj; char arg0[] = "VCFX_merger"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_merger")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_merger", show_help)) return 0;
     VCFXMerger merger;
     return merger.run(argc, argv);
 }

--- a/src/VCFX_metadata_summarizer/VCFX_metadata_summarizer.cpp
+++ b/src/VCFX_metadata_summarizer/VCFX_metadata_summarizer.cpp
@@ -155,8 +155,10 @@ void VCFXMetadataSummarizer::printSummary() const {
     std::cout << "Number of variants: " << numVariants << "\n";
 }
 
+static void show_help() { VCFXMetadataSummarizer obj; char arg0[] = "VCFX_metadata_summarizer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_metadata_summarizer")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_metadata_summarizer", show_help)) return 0;
     VCFXMetadataSummarizer summarizer;
     return summarizer.run(argc, argv);
 }

--- a/src/VCFX_missing_data_handler/VCFX_missing_data_handler.cpp
+++ b/src/VCFX_missing_data_handler/VCFX_missing_data_handler.cpp
@@ -259,8 +259,10 @@ nextFile:
  * @param argv Argument vector.
  * @return int Exit status.
  */
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_missing_data_handler")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_missing_data_handler", show_help)) return 0;
     Arguments args;
     parseArguments(argc, argv, args);
 

--- a/src/VCFX_missing_detector/VCFX_missing_detector.cpp
+++ b/src/VCFX_missing_detector/VCFX_missing_detector.cpp
@@ -208,8 +208,10 @@ void VCFXMissingDetector::detectMissingGenotypes(std::istream& in, std::ostream&
     }
 }
 
+static void show_help() { VCFXMissingDetector obj; char arg0[] = "VCFX_missing_detector"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_missing_detector")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_missing_detector", show_help)) return 0;
     VCFXMissingDetector missingDetector;
     return missingDetector.run(argc, argv);
 }

--- a/src/VCFX_multiallelic_splitter/VCFX_multiallelic_splitter.cpp
+++ b/src/VCFX_multiallelic_splitter/VCFX_multiallelic_splitter.cpp
@@ -288,8 +288,10 @@ bool splitMultiAllelicVariants(std::istream &in, std::ostream &out){
     return true;
 }
 
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_multiallelic_splitter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_multiallelic_splitter", show_help)) return 0;
     for(int i=1; i< argc; i++){
         std::string arg= argv[i];
         if(arg=="--help"|| arg=="-h"){

--- a/src/VCFX_nonref_filter/VCFX_nonref_filter.cpp
+++ b/src/VCFX_nonref_filter/VCFX_nonref_filter.cpp
@@ -132,8 +132,10 @@ void VCFXNonRefFilter::filterNonRef(std::istream& in, std::ostream& out){
     }
 }
 
+static void show_help() { VCFXNonRefFilter obj; char arg0[] = "VCFX_nonref_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_nonref_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_nonref_filter", show_help)) return 0;
     VCFXNonRefFilter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_outlier_detector/VCFX_outlier_detector.cpp
+++ b/src/VCFX_outlier_detector/VCFX_outlier_detector.cpp
@@ -304,8 +304,10 @@ void VCFXOutlierDetector::detectOutliers(std::istream &in,
     }
 }
 
+static void show_help() { VCFXOutlierDetector obj; char arg0[] = "VCFX_outlier_detector"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_outlier_detector")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_outlier_detector", show_help)) return 0;
     VCFXOutlierDetector app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_phase_checker/VCFX_phase_checker.cpp
+++ b/src/VCFX_phase_checker/VCFX_phase_checker.cpp
@@ -164,8 +164,10 @@ void VCFXPhaseChecker::processVCF(std::istream &in, std::ostream &out) {
     }
 }
 
+static void show_help() { VCFXPhaseChecker obj; char arg0[] = "VCFX_phase_checker"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_phase_checker")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_phase_checker", show_help)) return 0;
     VCFXPhaseChecker checker;
     return checker.run(argc, argv);
 }

--- a/src/VCFX_phase_quality_filter/VCFX_phase_quality_filter.cpp
+++ b/src/VCFX_phase_quality_filter/VCFX_phase_quality_filter.cpp
@@ -201,8 +201,10 @@ double VCFXPhaseQualityFilter::parsePQScore(const std::string &info) {
     return 0.0;
 }
 
+static void show_help() { VCFXPhaseQualityFilter obj; char arg0[] = "VCFX_phase_quality_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_phase_quality_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_phase_quality_filter", show_help)) return 0;
     VCFXPhaseQualityFilter f;
     return f.run(argc, argv);
 }

--- a/src/VCFX_phred_filter/VCFX_phred_filter.cpp
+++ b/src/VCFX_phred_filter/VCFX_phred_filter.cpp
@@ -119,8 +119,10 @@ double VCFXPhredFilter::parseQUAL(const std::string &qualStr, bool keepMissingAs
     }
 }
 
+static void show_help() { VCFXPhredFilter obj; char arg0[] = "VCFX_phred_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_phred_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_phred_filter", show_help)) return 0;
     VCFXPhredFilter pf;
     return pf.run(argc,argv);
 }

--- a/src/VCFX_population_filter/VCFX_population_filter.cpp
+++ b/src/VCFX_population_filter/VCFX_population_filter.cpp
@@ -190,8 +190,10 @@ void VCFXPopulationFilter::filterPopulation(std::istream &in,
     }
 }
 
+static void show_help() { VCFXPopulationFilter obj; char arg0[] = "VCFX_population_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_population_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_population_filter", show_help)) return 0;
     VCFXPopulationFilter pf;
     return pf.run(argc, argv);
 }

--- a/src/VCFX_position_subsetter/VCFX_position_subsetter.cpp
+++ b/src/VCFX_position_subsetter/VCFX_position_subsetter.cpp
@@ -146,8 +146,10 @@ bool VCFXPositionSubsetter::subsetVCFByPosition(std::istream &in,
     return true;
 }
 
+static void show_help() { VCFXPositionSubsetter obj; char arg0[] = "VCFX_position_subsetter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_position_subsetter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_position_subsetter", show_help)) return 0;
     VCFXPositionSubsetter subsetter;
     return subsetter.run(argc, argv);
 }

--- a/src/VCFX_probability_filter/VCFX_probability_filter.cpp
+++ b/src/VCFX_probability_filter/VCFX_probability_filter.cpp
@@ -210,8 +210,10 @@ void VCFXProbabilityFilter::filterByProbability(std::istream& in, std::ostream& 
     }
 }
 
+static void show_help() { VCFXProbabilityFilter obj; char arg0[] = "VCFX_probability_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_probability_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_probability_filter", show_help)) return 0;
     VCFXProbabilityFilter probabilityFilter;
     return probabilityFilter.run(argc, argv);
 }

--- a/src/VCFX_quality_adjuster/VCFX_quality_adjuster.cpp
+++ b/src/VCFX_quality_adjuster/VCFX_quality_adjuster.cpp
@@ -175,8 +175,10 @@ void VCFXQualityAdjuster::adjustQualityScores(std::istream &in, std::ostream &ou
     }
 }
 
+static void show_help() { VCFXQualityAdjuster obj; char arg0[] = "VCFX_quality_adjuster"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_quality_adjuster")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_quality_adjuster", show_help)) return 0;
     VCFXQualityAdjuster app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_record_filter/VCFX_record_filter.cpp
+++ b/src/VCFX_record_filter/VCFX_record_filter.cpp
@@ -320,8 +320,10 @@ void printHelp(){
 }
 
 // main with typical argument parse
+static void show_help() { printHelp(); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_record_filter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_record_filter", show_help)) return 0;
     if(argc==1){
         printHelp();
         return 0;

--- a/src/VCFX_ref_comparator/VCFX_ref_comparator.cpp
+++ b/src/VCFX_ref_comparator/VCFX_ref_comparator.cpp
@@ -273,8 +273,10 @@ void VCFXRefComparator::compareVCF(std::istream &vcfIn, std::ostream &vcfOut){
     }
 }
 
+static void show_help() { VCFXRefComparator obj; char arg0[] = "VCFX_ref_comparator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_ref_comparator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ref_comparator", show_help)) return 0;
     VCFXRefComparator refComp;
     return refComp.run(argc, argv);
 }

--- a/src/VCFX_reformatter/VCFX_reformatter.cpp
+++ b/src/VCFX_reformatter/VCFX_reformatter.cpp
@@ -461,8 +461,10 @@ std::string VCFXReformatter::applyFormatReorderToSample(const std::string &sampl
     return oss.str();
 }
 
+static void show_help() { VCFXReformatter obj; char arg0[] = "VCFX_reformatter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_reformatter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_reformatter", show_help)) return 0;
     VCFXReformatter reformatter;
     return reformatter.run(argc, argv);
 }

--- a/src/VCFX_region_subsampler/VCFX_region_subsampler.cpp
+++ b/src/VCFX_region_subsampler/VCFX_region_subsampler.cpp
@@ -254,8 +254,10 @@ void VCFXRegionSubsampler::processVCF(std::istream &in, std::ostream &out) {
     }
 }
 
+static void show_help() { VCFXRegionSubsampler obj; char arg0[] = "VCFX_region_subsampler"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_region_subsampler")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_region_subsampler", show_help)) return 0;
     VCFXRegionSubsampler app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_sample_extractor/VCFX_sample_extractor.cpp
+++ b/src/VCFX_sample_extractor/VCFX_sample_extractor.cpp
@@ -215,8 +215,10 @@ void VCFXSampleExtractor::extractSamples(std::istream &in, std::ostream &out,
     }
 }
 
+static void show_help() { VCFXSampleExtractor obj; char arg0[] = "VCFX_sample_extractor"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_sample_extractor")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_sample_extractor", show_help)) return 0;
     VCFXSampleExtractor app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_sorter/VCFX_sorter.cpp
+++ b/src/VCFX_sorter/VCFX_sorter.cpp
@@ -218,8 +218,10 @@ void VCFXSorter::outputVCF(std::ostream &out){
     }
 }
 
+static void show_help() { VCFXSorter obj; char arg0[] = "VCFX_sorter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_sorter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_sorter", show_help)) return 0;
     VCFXSorter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_subsampler/VCFX_subsampler.cpp
+++ b/src/VCFX_subsampler/VCFX_subsampler.cpp
@@ -162,8 +162,10 @@ void VCFXSubsampler::subsampleLines(std::istream &in,
     }
 }
 
+static void show_help() { VCFXSubsampler obj; char arg0[] = "VCFX_subsampler"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_subsampler")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_subsampler", show_help)) return 0;
     VCFXSubsampler app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_sv_handler/VCFX_sv_handler.cpp
+++ b/src/VCFX_sv_handler/VCFX_sv_handler.cpp
@@ -205,8 +205,10 @@ void VCFXSvHandler::handleStructuralVariants(std::istream &in, std::ostream &out
     }
 }
 
+static void show_help() { VCFXSvHandler obj; char arg0[] = "VCFX_sv_handler"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_sv_handler")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_sv_handler", show_help)) return 0;
     VCFXSvHandler app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_validator/VCFX_validator.cpp
+++ b/src/VCFX_validator/VCFX_validator.cpp
@@ -305,8 +305,10 @@ bool VCFXValidator::validateVCF(std::istream &in){
     return true;
 }
 
+static void show_help() { VCFXValidator obj; char arg0[] = "VCFX_validator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_validator")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_validator", show_help)) return 0;
     VCFXValidator validator;
     return validator.run(argc, argv);
 }

--- a/src/VCFX_variant_classifier/VCFX_variant_classifier.cpp
+++ b/src/VCFX_variant_classifier/VCFX_variant_classifier.cpp
@@ -326,8 +326,10 @@ void VCFXVariantClassifier::classifyStream(std::istream &in, std::ostream &out){
     }
 }
 
+static void show_help() { VCFXVariantClassifier obj; char arg0[] = "VCFX_variant_classifier"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]){
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_variant_classifier")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_variant_classifier", show_help)) return 0;
     VCFXVariantClassifier app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_variant_counter/VCFX_variant_counter.cpp
+++ b/src/VCFX_variant_counter/VCFX_variant_counter.cpp
@@ -175,8 +175,10 @@ int VCFXVariantCounter::countVariantsGzip(std::istream &in){
     return count;
 }
 
+static void show_help() { VCFXVariantCounter obj; char arg0[] = "VCFX_variant_counter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+
 int main(int argc, char* argv[]) {
-    if (vcfx::handle_version_flag(argc, argv, "VCFX_variant_counter")) return 0;
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_variant_counter", show_help)) return 0;
     VCFXVariantCounter app;
     return app.run(argc, argv);
 }

--- a/src/vcfx_core.cpp
+++ b/src/vcfx_core.cpp
@@ -135,4 +135,25 @@ bool read_file_maybe_compressed(const std::string& path, std::string& out) {
     return true;
 }
 
+bool handle_common_flags(int argc, char* argv[],
+                         const std::string& tool,
+                         void (*print_help)(),
+                         std::ostream& os) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--version") == 0 ||
+            std::strcmp(argv[i], "-v") == 0) {
+            print_version(tool, get_version(), os);
+            return true;
+        }
+        if (std::strcmp(argv[i], "--help") == 0 ||
+            std::strcmp(argv[i], "-h") == 0) {
+            if (print_help) {
+                print_help();
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
 }  // namespace vcfx


### PR DESCRIPTION
## Summary
- add a `handle_common_flags` helper that prints version or help for any tool
- use `handle_common_flags` in all tool `main()` functions
- provide lightweight wrappers around class help methods

## Testing
- `cmake --build build`
- `bash compile_wasm.sh` *(fails: Emscripten toolchain not found)*
- `tests/test_all.sh`