### PR TITLE
Document common flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ vcfx list
 ```bash
 vcfx help allele_counter
 ```
+### Common Flags
+
+All tools recognize `-h`/`--help` and `-v`/`--version` via `vcfx::handle_common_flags`.
+A minimal `main()` typically looks like:
+```cpp
+static void show_help() { printHelp(); }
+
+int main(int argc, char* argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_example", show_help))
+        return 0;
+    // ...
+}
+```
+
 
 ## Building for WebAssembly
 

--- a/docs/VCFX_af_subsetter.md
+++ b/docs/VCFX_af_subsetter.md
@@ -12,8 +12,8 @@ VCFX_af_subsetter --af-filter "MIN-MAX" < input.vcf > filtered.vcf
 | Option | Description |
 |--------|-------------|
 | `-a`, `--af-filter <MIN-MAX>` | Required. Allele frequency range for filtering (e.g., `0.01-0.05`) |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_af_subsetter` processes VCF files line by line and filters variants based on their allele frequency (AF) values from the INFO field. The tool:

--- a/docs/VCFX_alignment_checker.md
+++ b/docs/VCFX_alignment_checker.md
@@ -12,8 +12,8 @@ VCFX_alignment_checker --alignment-discrepancy <vcf_file> <reference.fasta> > di
 | Option | Description |
 |--------|-------------|
 | `-a`, `--alignment-discrepancy` | Enable alignment discrepancy checking mode |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_alignment_checker` compares VCF variants against a reference genome to validate sequence consistency. The tool:

--- a/docs/VCFX_allele_balance_calc.md
+++ b/docs/VCFX_allele_balance_calc.md
@@ -12,8 +12,8 @@ VCFX_allele_balance_calc [OPTIONS] < input.vcf > allele_balance.tsv
 | Option | Description |
 |--------|-------------|
 | `-s`, `--samples "Sample1 Sample2..."` | Optional. Specify sample names to calculate allele balance for (space-separated). If omitted, all samples are processed. |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_allele_balance_calc` processes a VCF file and calculates the allele balance for each variant in each specified sample. The tool:

--- a/docs/VCFX_allele_balance_filter.md
+++ b/docs/VCFX_allele_balance_filter.md
@@ -15,8 +15,8 @@ VCFX_allele_balance_filter --filter-allele-balance <THRESHOLD> < input.vcf > fil
 | Option | Description |
 |--------|-------------|
 | `-f`, `--filter-allele-balance` <VAL> | Required. Allele balance threshold between 0.0 and 1.0 |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_allele_counter.md
+++ b/docs/VCFX_allele_counter.md
@@ -12,8 +12,8 @@ VCFX_allele_counter [OPTIONS] < input.vcf > allele_counts.tsv
 | Option | Description |
 |--------|-------------|
 | `-s`, `--samples "Sample1 Sample2..."` | Optional. Specify sample names to calculate allele counts for (space-separated). If omitted, all samples are processed. |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_allele_counter` processes a VCF file and counts reference and alternate alleles for each variant in each specified sample. The tool:

--- a/docs/VCFX_allele_freq_calc.md
+++ b/docs/VCFX_allele_freq_calc.md
@@ -14,8 +14,8 @@ VCFX_allele_freq_calc [OPTIONS] < input.vcf > allele_frequencies.tsv
 
 | Option      | Description                                |
 |-------------|--------------------------------------------|
-| `--help`, `-h` | Display help message and exit              |
-| `-v`, `--version` | Show program version and exit |
+| `--help`, `-h` | Display help message and exit (handled by `vcfx::handle_common_flags`)              |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_ancestry_assigner.md
+++ b/docs/VCFX_ancestry_assigner.md
@@ -15,8 +15,8 @@ VCFX_ancestry_assigner --assign-ancestry <freq_file> < input.vcf > ancestry_resu
 | Option | Description |
 |--------|-------------|
 | `-a`, `--assign-ancestry <FILE>` | Required. Path to a file containing population-specific allele frequencies |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_ancestry_inferrer.md
+++ b/docs/VCFX_ancestry_inferrer.md
@@ -15,8 +15,8 @@ VCFX_ancestry_inferrer --frequency <freq_file> [OPTIONS] < input.vcf > ancestry_
 | Option | Description |
 |--------|-------------|
 | `--frequency <FILE>` | Required. Path to a file containing population-specific allele frequencies |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_annotation_extractor.md
+++ b/docs/VCFX_annotation_extractor.md
@@ -15,8 +15,8 @@ VCFX_annotation_extractor --annotation-extract "FIELD1,FIELD2,..." < input.vcf >
 | Option | Description |
 |--------|-------------|
 | `-a`, `--annotation-extract <FIELDS>` | Required. Comma-separated list of INFO field annotations to extract (e.g., "ANN,Gene,Impact") |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_compressor.md
+++ b/docs/VCFX_compressor.md
@@ -16,8 +16,8 @@ VCFX_compressor [OPTIONS] < input_file > output_file
 |--------|-------------|
 | `-c`, `--compress` | Compress the input VCF file (read from stdin, write to stdout) |
 | `-d`, `--decompress` | Decompress the input VCF.gz file (read from stdin, write to stdout) |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_concordance_checker.md
+++ b/docs/VCFX_concordance_checker.md
@@ -12,8 +12,8 @@ VCFX_concordance_checker --samples "SAMPLE1 SAMPLE2" < input.vcf > concordance_r
 | Option | Description |
 |--------|-------------|
 | `-s`, `--samples "SAMPLE1 SAMPLE2"` | Required. Names of the two samples to compare, separated by a space |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_concordance_checker` analyzes a VCF file and compares the genotypes of two specified samples for each variant. The tool:

--- a/docs/VCFX_cross_sample_concordance.md
+++ b/docs/VCFX_cross_sample_concordance.md
@@ -11,8 +11,8 @@ VCFX_cross_sample_concordance [OPTIONS] < input.vcf > concordance_results.tsv
 ## Options
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-s`, `--samples` | Comma-separated list of samples to check |
 
 ## Description

--- a/docs/VCFX_custom_annotator.md
+++ b/docs/VCFX_custom_annotator.md
@@ -15,8 +15,8 @@ VCFX_custom_annotator --add-annotation <annotations.txt> [OPTIONS] < input.vcf >
 | Option | Description |
 |--------|-------------|
 | `-a`, `--add-annotation <file>` | Required. Path to the annotation file containing the custom annotations |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_diff_tool.md
+++ b/docs/VCFX_diff_tool.md
@@ -16,8 +16,8 @@ VCFX_diff_tool --file1 <file1.vcf> --file2 <file2.vcf>
 |--------|-------------|
 | `-a`, `--file1 <FILE>` | Required. Path to the first VCF file |
 | `-b`, `--file2 <FILE>` | Required. Path to the second VCF file |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_distance_calculator.md
+++ b/docs/VCFX_distance_calculator.md
@@ -14,8 +14,8 @@ VCFX_distance_calculator [OPTIONS] < input.vcf > variant_distances.tsv
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_dosage_calculator.md
+++ b/docs/VCFX_dosage_calculator.md
@@ -14,8 +14,8 @@ VCFX_dosage_calculator [OPTIONS] < input.vcf > dosage_output.txt
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_duplicate_remover.md
+++ b/docs/VCFX_duplicate_remover.md
@@ -14,8 +14,8 @@ VCFX_duplicate_remover [OPTIONS] < input.vcf > deduplicated.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_fasta_converter.md
+++ b/docs/VCFX_fasta_converter.md
@@ -14,8 +14,8 @@ VCFX_fasta_converter [OPTIONS] < input.vcf > output.fasta
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_field_extractor.md
+++ b/docs/VCFX_field_extractor.md
@@ -12,8 +12,8 @@ VCFX_field_extractor --fields "FIELD1,FIELD2,..." [OPTIONS] < input.vcf > output
 | Option | Description |
 |--------|-------------|
 | `-f`, `--fields` | Required. Comma-separated list of fields to extract (no spaces between fields) |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_field_extractor` processes a VCF file and extracts only the specified fields for each variant. The tool:

--- a/docs/VCFX_file_splitter.md
+++ b/docs/VCFX_file_splitter.md
@@ -15,8 +15,8 @@ VCFX_file_splitter [OPTIONS] < input.vcf
 | Option | Description |
 |--------|-------------|
 | `-p`, `--prefix <PREFIX>` | Output file prefix (default: "split") |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_format_converter.md
+++ b/docs/VCFX_format_converter.md
@@ -13,8 +13,8 @@ VCFX_format_converter [OPTIONS] < input.vcf > output.file
 |--------|-------------|
 | `--to-bed` | Convert the input VCF file to BED format |
 | `--to-csv` | Convert the input VCF file to CSV format |
-| `--help`, `-h` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `--help`, `-h` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_format_converter` reads a VCF file from standard input and converts it to the specified output format. The tool:

--- a/docs/VCFX_genotype_query.md
+++ b/docs/VCFX_genotype_query.md
@@ -16,8 +16,8 @@ VCFX_genotype_query [OPTIONS] < input.vcf > filtered.vcf
 |--------|-------------|
 | `--genotype-query`, `-g` "GENOTYPE" | Specify the genotype to query (e.g., "0/1", "1/1") |
 | `--strict` | Use strict string comparison (no phasing unification or allele sorting) |
-| `--help`, `-h` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `--help`, `-h` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_gl_filter.md
+++ b/docs/VCFX_gl_filter.md
@@ -13,8 +13,8 @@ VCFX_gl_filter --filter "<CONDITION>" [--mode <any|all>] < input.vcf > filtered.
 |--------|-------------|
 | `-f`, `--filter <CONDITION>` | Required. Filter condition (e.g., `GQ>20`, `DP>=10`, `PL<50`) |
 | `-m`, `--mode <any\|all>` | Optional. Determines if all samples must pass the condition (`all`, default) or at least one sample must pass (`any`) |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_gl_filter` examines numeric fields in the FORMAT column of a VCF file and filters variant records based on whether the samples satisfy the specified condition. The tool:

--- a/docs/VCFX_haplotype_extractor.md
+++ b/docs/VCFX_haplotype_extractor.md
@@ -16,8 +16,8 @@ VCFX_haplotype_extractor [OPTIONS] < input.vcf > haplotypes.tsv
 |--------|-------------|
 | `--block-size <SIZE>` | Maximum distance in base pairs between consecutive variants to be included in the same block (default: 100,000) |
 | `--check-phase-consistency` | Enable checks for phase consistency between adjacent variants in a block |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_haplotype_phaser.md
+++ b/docs/VCFX_haplotype_phaser.md
@@ -15,8 +15,8 @@ VCFX_haplotype_phaser [OPTIONS] < input.vcf > blocks.txt
 | Option | Description |
 |--------|-------------|
 | `-l`, `--ld-threshold <VALUE>` | r² threshold for LD-based grouping (0.0-1.0, default: 0.8) |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_header_parser.md
+++ b/docs/VCFX_header_parser.md
@@ -14,8 +14,8 @@ VCFX_header_parser [OPTIONS] < input.vcf > header.txt
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_hwe_tester.md
+++ b/docs/VCFX_hwe_tester.md
@@ -14,8 +14,8 @@ VCFX_hwe_tester [OPTIONS] < input.vcf > hwe_results.txt
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_impact_filter.md
+++ b/docs/VCFX_impact_filter.md
@@ -15,8 +15,8 @@ VCFX_impact_filter --filter-impact <LEVEL> < input.vcf > filtered.vcf
 | Option | Description |
 |--------|-------------|
 | `-i`, `--filter-impact <LEVEL>` | Required. Impact level threshold. Must be one of: HIGH, MODERATE, LOW, MODIFIER |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_inbreeding_calculator.md
+++ b/docs/VCFX_inbreeding_calculator.md
@@ -17,8 +17,8 @@ VCFX_inbreeding_calculator [OPTIONS] < input.vcf > output.txt
 | `--freq-mode` MODE | How to calculate allele frequencies: 'excludeSample' (default) or 'global' |
 | `--skip-boundary` | Skip sites with boundary frequencies (p=0 or p=1) |
 | `--count-boundary-as-used` | Count boundary sites in usedCount even when skipping them |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_indel_normalizer.md
+++ b/docs/VCFX_indel_normalizer.md
@@ -11,8 +11,8 @@ VCFX_indel_normalizer [OPTIONS] < input.vcf > normalized.vcf
 ## Options
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_indel_normalizer` processes a VCF file and normalizes indel variants by:

--- a/docs/VCFX_indexer.md
+++ b/docs/VCFX_indexer.md
@@ -13,8 +13,8 @@ VCFX_indexer [OPTIONS] < input.vcf > index.tsv
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_info_aggregator.md
+++ b/docs/VCFX_info_aggregator.md
@@ -13,8 +13,8 @@ VCFX_info_aggregator [OPTIONS] < input.vcf > output.vcf
 ## Options
 
 - `-a`, `--aggregate-info <fields>`: Comma-separated list of INFO fields to aggregate (required).
-- `-h`, `--help`: Display help message and exit.
-| `-v`, `--version` | Show program version and exit |
+- `-h`, `--help`: Display help message and exit (handled by `vcfx::handle_common_flags`)
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_info_parser.md
+++ b/docs/VCFX_info_parser.md
@@ -15,8 +15,8 @@ VCFX_info_parser --info "FIELD1,FIELD2,..." < input.vcf > extracted_info.tsv
 | Option | Description |
 |--------|-------------|
 | `-i`, `--info <FIELDS>` | Required. Comma-separated list of INFO fields to extract (e.g., "DP,AF,SOMATIC") |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_info_summarizer.md
+++ b/docs/VCFX_info_summarizer.md
@@ -15,8 +15,8 @@ VCFX_info_summarizer --info "FIELD1,FIELD2,..." < input.vcf > summary_stats.tsv
 | Option | Description |
 |--------|-------------|
 | `-i`, `--info <FIELDS>` | Required. Comma-separated list of INFO fields to analyze (e.g., "DP,AF,MQ") |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_ld_calculator.md
+++ b/docs/VCFX_ld_calculator.md
@@ -15,8 +15,8 @@ VCFX_ld_calculator [OPTIONS] < input.vcf > ld_matrix.txt
 | Option | Description |
 |--------|-------------|
 | `--region <chr:start-end>` | Only compute LD for variants in the specified region |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_merger.md
+++ b/docs/VCFX_merger.md
@@ -15,8 +15,8 @@ VCFX_merger --merge file1.vcf,file2.vcf,... [options] > merged.vcf
 | Option | Description |
 |--------|-------------|
 | `-m, --merge` | Comma-separated list of VCF files to merge |
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_metadata_summarizer.md
+++ b/docs/VCFX_metadata_summarizer.md
@@ -14,8 +14,8 @@ VCFX_metadata_summarizer [options] < input.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_missing_data_handler.md
+++ b/docs/VCFX_missing_data_handler.md
@@ -16,8 +16,8 @@ VCFX_missing_data_handler [OPTIONS] [files...] > processed.vcf
 |--------|-------------|
 | `--fill-missing`, `-f` | Impute missing genotypes with a default value |
 | `--default-genotype`, `-d` <GEN> | Specify the default genotype for imputation (default: "./.")  |
-| `--help`, `-h` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `--help`, `-h` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_missing_detector.md
+++ b/docs/VCFX_missing_detector.md
@@ -14,8 +14,8 @@ VCFX_missing_detector [OPTIONS] < input.vcf > flagged.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_multiallelic_splitter.md
+++ b/docs/VCFX_multiallelic_splitter.md
@@ -14,8 +14,8 @@ VCFX_multiallelic_splitter [OPTIONS] < input.vcf > biallelic_output.vcf
 
 | Option | Description |
 |--------|-------------|
-| `--help`, `-h` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `--help`, `-h` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_nonref_filter.md
+++ b/docs/VCFX_nonref_filter.md
@@ -14,8 +14,8 @@ VCFX_nonref_filter [OPTIONS] < input.vcf > filtered.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_outlier_detector.md
+++ b/docs/VCFX_outlier_detector.md
@@ -18,8 +18,8 @@ VCFX_outlier_detector --metric <KEY> --threshold <VAL> [--variant|--sample] < in
 | `--threshold`, `-t` <VAL> | Numeric threshold value for outlier detection |
 | `--variant`, `-V` | Variant mode: identify variants with INFO field metrics above threshold |
 | `--sample`, `-s` | Sample mode: identify samples with average genotype metrics above threshold |
-| `--help`, `-h` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `--help`, `-h` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 **Note:** `-v` shows the version information. Use `--variant` or the short option `-V` to run in variant mode.
 

--- a/docs/VCFX_phase_checker.md
+++ b/docs/VCFX_phase_checker.md
@@ -14,8 +14,8 @@ VCFX_phase_checker [OPTIONS] < input.vcf > phased_output.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_phase_quality_filter.md
+++ b/docs/VCFX_phase_quality_filter.md
@@ -14,8 +14,8 @@ VCFX_phase_quality_filter --filter-pq "PQ<OP><THRESHOLD>" < input.vcf > output.v
 
 | Option | Description |
 |--------|-------------|
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-f, --filter-pq` | Condition like 'PQ>30', 'PQ>=20', 'PQ!=10', etc. |
 
 ## Description

--- a/docs/VCFX_phred_filter.md
+++ b/docs/VCFX_phred_filter.md
@@ -16,8 +16,8 @@ VCFX_phred_filter [OPTIONS] < input.vcf > filtered.vcf
 |--------|-------------|
 | `-p`, `--phred-filter` <THRESHOLD> | Set PHRED quality score threshold (default: 30.0) |
 | `-k`, `--keep-missing-qual` | Keep variants with missing quality values (represented as ".") |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_population_filter.md
+++ b/docs/VCFX_population_filter.md
@@ -11,8 +11,8 @@ VCFX_population_filter [OPTIONS] < input.vcf > output.vcf
 ## Options
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-p`, `--population <TAG>` | **Required**: Population tag to keep (e.g., 'EUR', 'AFR', 'EAS') |
 | `-m`, `--pop-map <FILE>` | **Required**: Tab-delimited file mapping sample names to populations |
 

--- a/docs/VCFX_position_subsetter.md
+++ b/docs/VCFX_position_subsetter.md
@@ -12,8 +12,8 @@ VCFX_position_subsetter --region "CHR:START-END" < input.vcf > filtered.vcf
 | Option | Description |
 |--------|-------------|
 | `-r`, `--region <CHR:START-END>` | Required. Genomic region to extract in the format "chromosome:start-end" |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_position_subsetter` reads a VCF file from standard input and outputs only those variants that fall within the specified genomic region. The tool:

--- a/docs/VCFX_probability_filter.md
+++ b/docs/VCFX_probability_filter.md
@@ -12,8 +12,8 @@ VCFX_probability_filter --filter-probability "<CONDITION>" < input.vcf > filtere
 | Option | Description |
 |--------|-------------|
 | `-f, --filter-probability <condition>` | Specify the probability filter condition (e.g., `GP>0.9`) |
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_probability_filter` analyzes the genotype probability fields in the FORMAT column of a VCF file and filters variants based on a user-defined condition. The tool:

--- a/docs/VCFX_quality_adjuster.md
+++ b/docs/VCFX_quality_adjuster.md
@@ -16,8 +16,8 @@ VCFX_quality_adjuster [OPTIONS] < input.vcf > output.vcf
 |--------|-------------|
 | `-a`, `--adjust-qual <FUNC>` | Required. The transformation function to apply. Must be one of: `log`, `sqrt`, `square`, or `identity`. |
 | `-n`, `--no-clamp` | Do not clamp negative or extremely large values resulting from transformations. |
-| `-h`, `--help` | Display help message and exit. |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_record_filter.md
+++ b/docs/VCFX_record_filter.md
@@ -13,8 +13,8 @@ VCFX_record_filter --filter "CRITERIA" [OPTIONS] < input.vcf > filtered.vcf
 |--------|-------------|
 | `-f`, `--filter <CRITERIA>` | Required. One or more filtering criteria separated by semicolons (e.g., `"POS>10000;QUAL>=30;AF<0.05"`) |
 | `-l`, `--logic <and\|or>` | Logic for combining multiple criteria: `and` (default) requires all criteria to pass, `or` requires any criterion to pass |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 `VCFX_record_filter` evaluates each variant in a VCF file against specified criteria and outputs only variants that satisfy these criteria. The tool:

--- a/docs/VCFX_ref_comparator.md
+++ b/docs/VCFX_ref_comparator.md
@@ -15,8 +15,8 @@ VCFX_ref_comparator --reference <reference.fasta> < input.vcf > annotated.vcf
 | Option | Description |
 |--------|-------------|
 | `-r`, `--reference` <FASTA> | Required. Path to reference genome in FASTA format |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_reformatter.md
+++ b/docs/VCFX_reformatter.md
@@ -14,8 +14,8 @@ VCFX_reformatter [options] < input.vcf > output.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-c, --compress-info <keys>` | Remove specified INFO keys (comma-separated) |
 | `-f, --compress-format <keys>` | Remove specified FORMAT keys (comma-separated) |
 | `-i, --reorder-info <keys>` | Reorder INFO keys (comma-separated) |

--- a/docs/VCFX_region_subsampler.md
+++ b/docs/VCFX_region_subsampler.md
@@ -14,8 +14,8 @@ VCFX_region_subsampler --region-bed FILE < input.vcf > output.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-b, --region-bed FILE` | BED file listing regions to keep |
 
 ## Description

--- a/docs/VCFX_sample_extractor.md
+++ b/docs/VCFX_sample_extractor.md
@@ -15,8 +15,8 @@ VCFX_sample_extractor [OPTIONS] < input.vcf > subset.vcf
 | Option | Description |
 |--------|-------------|
 | `-s`, `--samples` LIST | Comma or space separated list of sample names to extract |
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_sorter.md
+++ b/docs/VCFX_sorter.md
@@ -11,8 +11,8 @@ VCFX_sorter [OPTIONS] < input.vcf > output.vcf
 ## Options
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-n`, `--natural-chr` | Use natural chromosome sorting (chr1 < chr2 < chr10) instead of lexicographic sorting |
 
 ## Description

--- a/docs/VCFX_subsampler.md
+++ b/docs/VCFX_subsampler.md
@@ -16,8 +16,8 @@ VCFX_subsampler [options] < input.vcf > output.vcf
 |--------|-------------|
 | `-s, --subsample <N>` | Required: Number of variants to keep in the output |
 | `--seed <INT>` | Optional: Use a specific random seed for reproducible results |
-| `-h, --help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h, --help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 
 ## Description
 

--- a/docs/VCFX_sv_handler.md
+++ b/docs/VCFX_sv_handler.md
@@ -11,8 +11,8 @@ VCFX_sv_handler [OPTIONS] < input.vcf > output.vcf
 ## Options
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-f`, `--sv-filter-only` | Keep only lines that have 'SVTYPE=' in their INFO field |
 | `-m`, `--sv-modify` | Modify the INFO field of structural variants to add additional annotations |
 

--- a/docs/VCFX_validator.md
+++ b/docs/VCFX_validator.md
@@ -13,8 +13,8 @@ VCFX_validator [OPTIONS] < input.vcf
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-s`, `--strict` | Enable stricter validation checks |
 
 ## Description

--- a/docs/VCFX_variant_classifier.md
+++ b/docs/VCFX_variant_classifier.md
@@ -14,8 +14,8 @@ VCFX_variant_classifier [OPTIONS] < input.vcf > output.vcf_or_tsv
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-a`, `--append-info` | Instead of producing a TSV, output a valid VCF with a new 'VCF_CLASS' subfield in the INFO column |
 
 ## Description

--- a/docs/VCFX_variant_counter.md
+++ b/docs/VCFX_variant_counter.md
@@ -11,8 +11,8 @@ VCFX_variant_counter [OPTIONS] < input.vcf
 ## Options
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
-| `-v`, `--version` | Show program version and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
+| `-v`, `--version` | Show program version and exit (handled by `vcfx::handle_common_flags`) |
 | `-s`, `--strict` | Fail on any data line with fewer than 8 columns |
 
 ## Description

--- a/docs/tool_template.md
+++ b/docs/tool_template.md
@@ -14,7 +14,7 @@ VCFX_tool_name [OPTIONS] < input.vcf > output.format
 
 | Option | Description |
 |--------|-------------|
-| `-h`, `--help` | Display help message and exit |
+| `-h`, `--help` | Display help message and exit (handled by `vcfx::handle_common_flags`) |
 | `-o`, `--option1` | Description of option 1 |
 | `-p`, `--option2 VALUE` | Description of option 2 which requires a value |
 


### PR DESCRIPTION
## Summary
- document that all VCFX tools handle `-h/--help` and `-v/--version` the same way
- add `main()` snippet using `vcfx::handle_common_flags`
- note common flag handling in each tool doc

## Testing
- `bash tests/test_all.sh`