### PR TITLE
Enhance VCFX_validator checks

### DIFF
--- a/src/VCFX_validator/VCFX_validator.h
+++ b/src/VCFX_validator/VCFX_validator.h
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 class VCFXValidator {
 public:
@@ -11,12 +13,21 @@ public:
 private:
     // If we add advanced checks for e.g. "strict" mode, we store a bool
     bool strictMode = false;
+    bool reportDuplicates = false;
     // Number of columns in the #CHROM header line
     int headerColumnCount = 0;
     // Whether the header includes FORMAT/sample columns
     bool headerHasFormat = false;
     // Number of sample columns
     int sampleCount = 0;
+
+    struct FieldDef {
+        std::string number;
+        std::string type;
+    };
+    std::unordered_map<std::string, FieldDef> infoDefs;
+    std::unordered_map<std::string, FieldDef> formatDefs;
+    std::unordered_set<std::string> seenVariants;
 
     // Show usage
     void displayHelp();


### PR DESCRIPTION
## Summary
- validate INFO and FORMAT fields using header definitions
- verify genotype strings and REF/ALT sequences
- detect duplicate records with optional reporting
- accept gzip/BGZF input via `read_maybe_compressed`
- document new behaviour and extend validator tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `ctest -j $(nproc) --output-on-failure`