### PR TITLE
Add Python tool wrappers

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -86,7 +86,26 @@ print(vcfx.available_tools())
 
 # run through the generic helper
 vcfx.run_tool("alignment_checker", "--help")
+```
 
-# or directly by name (if available)
-vcfx.alignment_checker("--help")
+## Convenience Wrappers
+
+Several tools have Python helpers that run the command line program and
+parse its output into structured data. These wrappers return Python
+objects instead of raw text strings.
+
+```python
+import vcfx
+
+# Check alignment discrepancies and get a list of dictionaries
+rows = vcfx.alignment_checker("tests/data/align_Y.vcf", "tests/data/align_refY.fa")
+print(rows[0]["Discrepancy_Type"])  # 'ALT_MISMATCH'
+
+# Count alleles for all samples
+counts = vcfx.allele_counter("tests/data/allele_counter_A.vcf")
+print(counts[0]["Alt_Count"])  # '1'
+
+# Simply count the variants in a VCF
+n = vcfx.variant_counter("tests/data/variant_counter_normal.vcf")
+print(n)
 ```

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -12,6 +12,11 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
         "read_file_maybe_compressed",
         "read_maybe_compressed",
         "get_version",
+        "available_tools",
+        "run_tool",
+        "alignment_checker",
+        "allele_counter",
+        "variant_counter",
     ]
 
     def trim(text: str) -> str:
@@ -43,6 +48,11 @@ else:
         "read_file_maybe_compressed",
         "read_maybe_compressed",
         "get_version",
+        "available_tools",
+        "run_tool",
+        "alignment_checker",
+        "allele_counter",
+        "variant_counter",
     ]
 
 __version__ = get_version()
@@ -54,6 +64,9 @@ import subprocess
 # Re-export helper functions for convenience
 available_tools = _tools.available_tools
 run_tool = _tools.run_tool
+alignment_checker = _tools.alignment_checker
+allele_counter = _tools.allele_counter
+variant_counter = _tools.variant_counter
 
 
 def __getattr__(name: str) -> Callable[..., subprocess.CompletedProcess]:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TEST_SCRIPTS
     test_variant_counter.sh
     test_doc_lookup.sh
     test_python_bindings.sh
+    test_python_tool_wrappers.sh
 )
 
 foreach(script ${TEST_SCRIPTS})

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+BUILD_DIR="${ROOT_DIR}/build/python_tool_wrappers"
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+cmake -DPYTHON_BINDINGS=ON ../..
+make -j
+
+# ensure tools on PATH for the wrappers
+for exe in "${BUILD_DIR}"/src/VCFX_*/*; do
+    if [ -x "$exe" ]; then
+        PATH="$(dirname "$exe"):${PATH}"
+    fi
+done
+export PATH
+
+cd "$SCRIPT_DIR"
+
+PYTHONPATH="${BUILD_DIR}/python" python3 - <<'PY'
+import vcfx
+
+rows = vcfx.alignment_checker("data/align_Y.vcf", "data/align_refY.fa")
+assert rows and rows[0]["Discrepancy_Type"] == "ALT_MISMATCH"
+
+counts = vcfx.allele_counter("data/allele_counter_A.vcf")
+assert counts[0]["Sample"] == "S1"
+
+n = vcfx.variant_counter("data/variant_counter_normal.vcf")
+assert n == 5
+print("Python tool wrappers OK")
+PY


### PR DESCRIPTION
## Summary
- add explicit Python wrappers for alignment_checker, allele_counter and variant_counter
- export new helpers from the package
- document usage in `docs/python_api.md`
- add tests exercising the wrappers
- fix test script to add tool paths

## Testing
- `bash tests/test_python_tool_wrappers.sh`
