### PR TITLE
Add python wrappers for additional VCFX tools

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -109,3 +109,27 @@ print(counts[0]["Alt_Count"])  # '1'
 n = vcfx.variant_counter("tests/data/variant_counter_normal.vcf")
 print(n)
 ```
+
+Additional wrappers are available for other tools:
+
+```python
+# Allele frequency calculation
+freqs = vcfx.allele_freq_calc("tests/data/allele_freq_calc/simple.vcf")
+print(freqs[0]["Allele_Frequency"])  # '0.5000'
+
+# Aggregate INFO fields and read the updated VCF text
+annotated = vcfx.info_aggregator("tests/data/aggregator/basic.vcf", ["DP"])
+print("#AGGREGATION_SUMMARY" in annotated)
+
+# Parse INFO fields into dictionaries
+info_rows = vcfx.info_parser("tests/data/info_parser/basic.vcf", ["DP"])
+print(info_rows[0]["DP"])  # '10'
+
+# Summarize INFO fields
+summary = vcfx.info_summarizer("tests/data/info_summarizer/basic.vcf", ["DP"])
+print(summary[0]["Mean"])  # '20.0000'
+
+# Convert VCF to FASTA alignment
+fasta = vcfx.fasta_converter("tests/data/fasta_converter/basic.vcf")
+print(fasta.splitlines()[0])  # '>SAMPLE1'
+```

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,8 +18,9 @@ set_target_properties(_vcfx PROPERTIES
 
 configure_file(__init__.py "${CMAKE_BINARY_DIR}/python/vcfx/__init__.py" COPYONLY)
 configure_file(tools.py "${CMAKE_BINARY_DIR}/python/vcfx/tools.py" COPYONLY)
+configure_file(results.py "${CMAKE_BINARY_DIR}/python/vcfx/results.py" COPYONLY)
 
 install(TARGETS _vcfx
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx)
-install(FILES __init__.py tools.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx)
+install(FILES __init__.py tools.py results.py DESTINATION ${CMAKE_INSTALL_LIBDIR}/vcfx)

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -17,6 +17,13 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
         "alignment_checker",
         "allele_counter",
         "variant_counter",
+        "allele_freq_calc",
+        "info_aggregator",
+        "info_parser",
+        "info_summarizer",
+        "fasta_converter",
+        "AlleleFrequency",
+        "InfoSummary",
     ]
 
     def trim(text: str) -> str:
@@ -53,6 +60,13 @@ else:
         "alignment_checker",
         "allele_counter",
         "variant_counter",
+        "allele_freq_calc",
+        "info_aggregator",
+        "info_parser",
+        "info_summarizer",
+        "fasta_converter",
+        "AlleleFrequency",
+        "InfoSummary",
     ]
 
 __version__ = get_version()
@@ -67,6 +81,12 @@ run_tool = _tools.run_tool
 alignment_checker = _tools.alignment_checker
 allele_counter = _tools.allele_counter
 variant_counter = _tools.variant_counter
+allele_freq_calc = _tools.allele_freq_calc
+info_aggregator = _tools.info_aggregator
+info_parser = _tools.info_parser
+info_summarizer = _tools.info_summarizer
+fasta_converter = _tools.fasta_converter
+from .results import AlleleFrequency, InfoSummary
 
 
 def __getattr__(name: str) -> Callable[..., subprocess.CompletedProcess]:

--- a/python/results.py
+++ b/python/results.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+__all__ = ["AlleleFrequency", "InfoSummary"]
+
+
+@dataclass
+class AlleleFrequency:
+    CHROM: str
+    POS: str
+    ID: str
+    REF: str
+    ALT: str
+    Allele_Frequency: str
+
+
+@dataclass
+class InfoSummary:
+    INFO_Field: str
+    Mean: str
+    Median: str
+    Mode: str

--- a/python/tools.py
+++ b/python/tools.py
@@ -14,6 +14,11 @@ __all__ = [
     "alignment_checker",
     "allele_counter",
     "variant_counter",
+    "allele_freq_calc",
+    "info_aggregator",
+    "info_parser",
+    "info_summarizer",
+    "fasta_converter",
 ]
 
 
@@ -213,6 +218,109 @@ def variant_counter(vcf_file: str, strict: bool = False) -> int:
     if ":" in out:
         out = out.split(":", 1)[1]
     return int(out.strip())
+
+
+def allele_freq_calc(vcf_file: str) -> list[dict]:
+    """Calculate allele frequencies from a VCF file.
+
+    Parameters
+    ----------
+    vcf_file : str
+        Path to the VCF input file.
+
+    Returns
+    -------
+    list[dict]
+        Rows from the frequency table as dictionaries.
+    """
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "allele_freq_calc",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def info_aggregator(vcf_file: str, fields: Sequence[str]) -> str:
+    """Aggregate INFO fields and return the annotated VCF text."""
+
+    args = ["--aggregate-info", ",".join(fields)]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "info_aggregator",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def info_parser(vcf_file: str, fields: Sequence[str]) -> list[dict]:
+    """Parse INFO fields from a VCF file."""
+
+    args = ["--info", ",".join(fields)]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "info_parser",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def info_summarizer(vcf_file: str, fields: Sequence[str]) -> list[dict]:
+    """Summarize INFO fields from a VCF file."""
+
+    args = ["--info", ",".join(fields)]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "info_summarizer",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def fasta_converter(vcf_file: str) -> str:
+    """Convert a VCF to FASTA format and return the FASTA text."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "fasta_converter",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
 
 
 # Lazy attribute access for tool wrappers

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -33,5 +33,20 @@ assert counts[0]["Sample"] == "S1"
 
 n = vcfx.variant_counter("data/variant_counter_normal.vcf")
 assert n == 5
+
+freqs = vcfx.allele_freq_calc("data/allele_freq_calc/simple.vcf")
+assert freqs[0]["Allele_Frequency"] == "0.5000"
+
+annotated = vcfx.info_aggregator("data/aggregator/basic.vcf", ["DP"])
+assert "#AGGREGATION_SUMMARY" in annotated
+
+parsed = vcfx.info_parser("data/info_parser/basic.vcf", ["DP"])
+assert parsed[0]["DP"] == "10"
+
+summary = vcfx.info_summarizer("data/info_summarizer/basic.vcf", ["DP"])
+assert summary[0]["Mean"] == "20.0000"
+
+fasta = vcfx.fasta_converter("data/fasta_converter/basic.vcf")
+assert fasta.startswith(">")
 print("Python tool wrappers OK")
 PY


### PR DESCRIPTION
## Summary
- expose several more CLI tools through the python helpers
- add `AlleleFrequency` and `InfoSummary` dataclasses
- document new wrappers in the Python API docs
- ensure the build installs `results.py`
- exercise the wrappers in the tool wrapper test script

## Testing
- `./tests/test_python_tool_wrappers.sh`