### PR TITLE
Add wrappers for more VCFX tools

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -133,3 +133,30 @@ print(summary[0]["Mean"])  # '20.0000'
 fasta = vcfx.fasta_converter("tests/data/fasta_converter/basic.vcf")
 print(fasta.splitlines()[0])  # '>SAMPLE1'
 ```
+
+### Additional Wrappers
+
+```python
+# Calculate allele balance for all samples
+balance = vcfx.allele_balance_calc("tests/data/allele_balance_calc_A.vcf")
+print(balance[0]["Allele_Balance"])  # '1.000000'
+
+# Check concordance between two samples
+conc = vcfx.concordance_checker(
+    "tests/data/concordance_input.vcf",
+    "SAMPLE1",
+    "SAMPLE2",
+)
+print(conc[0]["Concordance"])  # 'Concordant'
+
+# Query variants with heterozygous genotypes
+filtered = vcfx.genotype_query(
+    "tests/data/genotype_query/sample.vcf",
+    "0/1",
+)
+print(filtered.startswith("##"))  # True
+
+# Remove duplicate records
+dedup = vcfx.duplicate_remover("tests/data/allele_balance_calc_A.vcf")
+print(dedup.splitlines()[0].startswith("#"))  # True
+```

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -18,12 +18,18 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
         "allele_counter",
         "variant_counter",
         "allele_freq_calc",
+        "allele_balance_calc",
+        "concordance_checker",
+        "genotype_query",
+        "duplicate_remover",
         "info_aggregator",
         "info_parser",
         "info_summarizer",
         "fasta_converter",
         "AlleleFrequency",
         "InfoSummary",
+        "AlleleBalance",
+        "ConcordanceRow",
     ]
 
     def trim(text: str) -> str:
@@ -61,12 +67,18 @@ else:
         "allele_counter",
         "variant_counter",
         "allele_freq_calc",
+        "allele_balance_calc",
+        "concordance_checker",
+        "genotype_query",
+        "duplicate_remover",
         "info_aggregator",
         "info_parser",
         "info_summarizer",
         "fasta_converter",
         "AlleleFrequency",
         "InfoSummary",
+        "AlleleBalance",
+        "ConcordanceRow",
     ]
 
 __version__ = get_version()
@@ -82,11 +94,20 @@ alignment_checker = _tools.alignment_checker
 allele_counter = _tools.allele_counter
 variant_counter = _tools.variant_counter
 allele_freq_calc = _tools.allele_freq_calc
+allele_balance_calc = _tools.allele_balance_calc
+concordance_checker = _tools.concordance_checker
+genotype_query = _tools.genotype_query
+duplicate_remover = _tools.duplicate_remover
 info_aggregator = _tools.info_aggregator
 info_parser = _tools.info_parser
 info_summarizer = _tools.info_summarizer
 fasta_converter = _tools.fasta_converter
-from .results import AlleleFrequency, InfoSummary
+from .results import (
+    AlleleFrequency,
+    InfoSummary,
+    AlleleBalance,
+    ConcordanceRow,
+)
 
 
 def __getattr__(name: str) -> Callable[..., subprocess.CompletedProcess]:

--- a/python/results.py
+++ b/python/results.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
 
-__all__ = ["AlleleFrequency", "InfoSummary"]
+__all__ = [
+    "AlleleFrequency",
+    "InfoSummary",
+    "AlleleBalance",
+    "ConcordanceRow",
+]
 
 
 @dataclass
@@ -19,3 +24,26 @@ class InfoSummary:
     Mean: str
     Median: str
     Mode: str
+
+
+@dataclass
+class AlleleBalance:
+    CHROM: str
+    POS: str
+    ID: str
+    REF: str
+    ALT: str
+    Sample: str
+    Allele_Balance: str
+
+
+@dataclass
+class ConcordanceRow:
+    CHROM: str
+    POS: str
+    ID: str
+    REF: str
+    ALT: str
+    SAMPLE1_GT: str
+    SAMPLE2_GT: str
+    Concordance: str

--- a/python/tools.py
+++ b/python/tools.py
@@ -15,6 +15,10 @@ __all__ = [
     "allele_counter",
     "variant_counter",
     "allele_freq_calc",
+    "allele_balance_calc",
+    "concordance_checker",
+    "genotype_query",
+    "duplicate_remover",
     "info_aggregator",
     "info_parser",
     "info_summarizer",
@@ -315,6 +319,91 @@ def fasta_converter(vcf_file: str) -> str:
 
     result = run_tool(
         "fasta_converter",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def allele_balance_calc(
+    vcf_file: str, samples: Sequence[str] | None = None
+) -> list[dict]:
+    """Calculate allele balance for samples in a VCF."""
+
+    args: list[str] = []
+    if samples:
+        args.extend(["--samples", " ".join(samples)])
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "allele_balance_calc",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def concordance_checker(
+    vcf_file: str, sample1: str, sample2: str
+) -> list[dict]:
+    """Check genotype concordance between two samples."""
+
+    args = ["--samples", f"{sample1} {sample2}"]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "concordance_checker",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def genotype_query(
+    vcf_file: str, genotype: str, strict: bool = False
+) -> str:
+    """Filter variants by genotype pattern and return VCF text."""
+
+    args = ["--genotype-query", genotype]
+    if strict:
+        args.append("--strict")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "genotype_query",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def duplicate_remover(vcf_file: str) -> str:
+    """Remove duplicate variant records from a VCF."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "duplicate_remover",
         capture_output=True,
         text=True,
         input=inp,

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -48,5 +48,17 @@ assert summary[0]["Mean"] == "20.0000"
 
 fasta = vcfx.fasta_converter("data/fasta_converter/basic.vcf")
 assert fasta.startswith(">")
+
+balance = vcfx.allele_balance_calc("data/allele_balance_calc_A.vcf")
+assert balance[0]["Allele_Balance"] == "1.000000"
+
+conc = vcfx.concordance_checker("data/concordance_input.vcf", "SAMPLE1", "SAMPLE2")
+assert conc[0]["Concordance"] == "Concordant"
+
+filtered = vcfx.genotype_query("data/genotype_query/sample.vcf", "0/1")
+assert filtered.startswith("##")
+
+dedup = vcfx.duplicate_remover("data/allele_balance_calc_A.vcf")
+assert dedup.startswith("##")
 print("Python tool wrappers OK")
 PY


### PR DESCRIPTION
## Summary
- expose additional VCFX wrappers in the Python package
- provide dataclasses for allele balance and concordance results
- document the new helpers in the Python API docs
- exercise new wrappers in the Python tool wrapper tests

## Testing
- `bash tests/test_python_tool_wrappers.sh`
- `bash tests/test_python_bindings.sh`