### PR TITLE
Add wrappers for remaining VCFX command line tools

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -212,3 +212,32 @@ print(assign[0]["Assigned_Population"])  # 'EUR'
 dosage = vcfx.dosage_calculator("tests/data/dosage_calculator/basic.vcf")
 print(dosage[0]["Dosages"])  # '0,1,2'
 ```
+
+## New Wrappers
+
+Additional helper functions mirror the rest of the ``VCFX_*`` tools. They work
+like the wrappers above. A few examples:
+
+```python
+# Infer population ancestry
+infer = vcfx.ancestry_inferrer(
+    "tests/data/ancestry_inferrer/eur_samples.vcf",
+    "tests/data/ancestry_inferrer/population_freqs.txt",
+)
+print(infer[0]["Inferred_Population"])  # 'EUR'
+
+# Extract annotation fields
+rows = vcfx.annotation_extractor(
+    "tests/data/haplotype_extractor/basic.vcf",
+    ["ANN", "Gene"],
+)
+print(rows[0]["Gene"])
+
+# Normalize indels
+normalized = vcfx.indel_normalizer("tests/data/indel_normalizer/basic.vcf")
+print(normalized.startswith("##"))
+
+# Validate a file
+report = vcfx.validator("tests/data/variant_counter_normal.vcf")
+print("VCF" in report)
+```

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -37,6 +37,43 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
         "variant_classifier",
         "cross_sample_concordance",
         "field_extractor",
+        "ancestry_inferrer",
+        "annotation_extractor",
+        "compressor",
+        "custom_annotator",
+        "diff_tool",
+        "distance_calculator",
+        "file_splitter",
+        "format_converter",
+        "gl_filter",
+        "haplotype_extractor",
+        "haplotype_phaser",
+        "header_parser",
+        "impact_filter",
+        "indel_normalizer",
+        "indexer",
+        "ld_calculator",
+        "merger",
+        "metadata_summarizer",
+        "missing_data_handler",
+        "multiallelic_splitter",
+        "nonref_filter",
+        "outlier_detector",
+        "phase_checker",
+        "phase_quality_filter",
+        "phred_filter",
+        "population_filter",
+        "position_subsetter",
+        "probability_filter",
+        "quality_adjuster",
+        "ref_comparator",
+        "reformatter",
+        "region_subsampler",
+        "sample_extractor",
+        "sorter",
+        "subsampler",
+        "sv_handler",
+        "validator",
         "AlleleFrequency",
         "InfoSummary",
         "AlleleBalance",
@@ -47,6 +84,9 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
         "CrossSampleConcordanceRow",
         "AncestryAssignment",
         "DosageRow",
+        "AncestryInference",
+        "DistanceRow",
+        "IndexEntry",
     ]
 
     def trim(text: str) -> str:
@@ -103,6 +143,43 @@ else:
         "variant_classifier",
         "cross_sample_concordance",
         "field_extractor",
+        "ancestry_inferrer",
+        "annotation_extractor",
+        "compressor",
+        "custom_annotator",
+        "diff_tool",
+        "distance_calculator",
+        "file_splitter",
+        "format_converter",
+        "gl_filter",
+        "haplotype_extractor",
+        "haplotype_phaser",
+        "header_parser",
+        "impact_filter",
+        "indel_normalizer",
+        "indexer",
+        "ld_calculator",
+        "merger",
+        "metadata_summarizer",
+        "missing_data_handler",
+        "multiallelic_splitter",
+        "nonref_filter",
+        "outlier_detector",
+        "phase_checker",
+        "phase_quality_filter",
+        "phred_filter",
+        "population_filter",
+        "position_subsetter",
+        "probability_filter",
+        "quality_adjuster",
+        "ref_comparator",
+        "reformatter",
+        "region_subsampler",
+        "sample_extractor",
+        "sorter",
+        "subsampler",
+        "sv_handler",
+        "validator",
         "AlleleFrequency",
         "InfoSummary",
         "AlleleBalance",
@@ -113,6 +190,9 @@ else:
         "CrossSampleConcordanceRow",
         "AncestryAssignment",
         "DosageRow",
+        "AncestryInference",
+        "DistanceRow",
+        "IndexEntry",
     ]
 
 __version__ = get_version()
@@ -147,6 +227,43 @@ inbreeding_calculator = _tools.inbreeding_calculator
 variant_classifier = _tools.variant_classifier
 cross_sample_concordance = _tools.cross_sample_concordance
 field_extractor = _tools.field_extractor
+ancestry_inferrer = _tools.ancestry_inferrer
+annotation_extractor = _tools.annotation_extractor
+compressor = _tools.compressor
+custom_annotator = _tools.custom_annotator
+diff_tool = _tools.diff_tool
+distance_calculator = _tools.distance_calculator
+file_splitter = _tools.file_splitter
+format_converter = _tools.format_converter
+gl_filter = _tools.gl_filter
+haplotype_extractor = _tools.haplotype_extractor
+haplotype_phaser = _tools.haplotype_phaser
+header_parser = _tools.header_parser
+impact_filter = _tools.impact_filter
+indel_normalizer = _tools.indel_normalizer
+indexer = _tools.indexer
+ld_calculator = _tools.ld_calculator
+merger = _tools.merger
+metadata_summarizer = _tools.metadata_summarizer
+missing_data_handler = _tools.missing_data_handler
+multiallelic_splitter = _tools.multiallelic_splitter
+nonref_filter = _tools.nonref_filter
+outlier_detector = _tools.outlier_detector
+phase_checker = _tools.phase_checker
+phase_quality_filter = _tools.phase_quality_filter
+phred_filter = _tools.phred_filter
+population_filter = _tools.population_filter
+position_subsetter = _tools.position_subsetter
+probability_filter = _tools.probability_filter
+quality_adjuster = _tools.quality_adjuster
+ref_comparator = _tools.ref_comparator
+reformatter = _tools.reformatter
+region_subsampler = _tools.region_subsampler
+sample_extractor = _tools.sample_extractor
+sorter = _tools.sorter
+subsampler = _tools.subsampler
+sv_handler = _tools.sv_handler
+validator = _tools.validator
 from .results import (
     AlleleFrequency,
     InfoSummary,
@@ -158,6 +275,9 @@ from .results import (
     CrossSampleConcordanceRow,
     AncestryAssignment,
     DosageRow,
+    AncestryInference,
+    DistanceRow,
+    IndexEntry,
 )
 
 

--- a/python/results.py
+++ b/python/results.py
@@ -11,6 +11,9 @@ __all__ = [
     "CrossSampleConcordanceRow",
     "AncestryAssignment",
     "DosageRow",
+    "AncestryInference",
+    "DistanceRow",
+    "IndexEntry",
 ]
 
 
@@ -107,3 +110,24 @@ class DosageRow:
     REF: str
     ALT: str
     Dosages: str
+
+
+@dataclass
+class AncestryInference:
+    Sample: str
+    Inferred_Population: str
+
+
+@dataclass
+class DistanceRow:
+    CHROM: str
+    POS: str
+    PREV_POS: str
+    DISTANCE: str
+
+
+@dataclass
+class IndexEntry:
+    CHROM: str
+    POS: str
+    FILE_OFFSET: str

--- a/python/tools.py
+++ b/python/tools.py
@@ -34,6 +34,43 @@ __all__ = [
     "variant_classifier",
     "cross_sample_concordance",
     "field_extractor",
+    "ancestry_inferrer",
+    "annotation_extractor",
+    "compressor",
+    "custom_annotator",
+    "diff_tool",
+    "distance_calculator",
+    "file_splitter",
+    "format_converter",
+    "gl_filter",
+    "haplotype_extractor",
+    "haplotype_phaser",
+    "header_parser",
+    "impact_filter",
+    "indel_normalizer",
+    "indexer",
+    "ld_calculator",
+    "merger",
+    "metadata_summarizer",
+    "missing_data_handler",
+    "multiallelic_splitter",
+    "nonref_filter",
+    "outlier_detector",
+    "phase_checker",
+    "phase_quality_filter",
+    "phred_filter",
+    "population_filter",
+    "position_subsetter",
+    "probability_filter",
+    "quality_adjuster",
+    "ref_comparator",
+    "reformatter",
+    "region_subsampler",
+    "sample_extractor",
+    "sorter",
+    "subsampler",
+    "sv_handler",
+    "validator",
 ]
 
 
@@ -656,6 +693,762 @@ def field_extractor(vcf_file: str, fields: Sequence[str]) -> list[dict]:
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
     return list(reader)
+
+
+def ancestry_inferrer(vcf_file: str, freq_file: str) -> list[dict]:
+    """Infer sample ancestry using population frequencies."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "ancestry_inferrer",
+        "--frequency",
+        freq_file,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def annotation_extractor(vcf_file: str, fields: Sequence[str]) -> list[dict]:
+    """Extract annotation fields into a table."""
+
+    args = ["--annotation-extract", ",".join(fields)]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "annotation_extractor",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def compressor(vcf_file: str, compress: bool = True) -> bytes:
+    """Compress or decompress VCF data."""
+
+    with open(vcf_file, "rb") as fh:
+        inp = fh.read()
+
+    args = ["--compress" if compress else "--decompress"]
+
+    result = run_tool(
+        "compressor",
+        *args,
+        capture_output=True,
+        text=False,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def custom_annotator(vcf_file: str, annotation_file: str) -> str:
+    """Add custom annotations from *annotation_file*."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "custom_annotator",
+        "--add-annotation",
+        annotation_file,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def diff_tool(file1: str, file2: str) -> str:
+    """Compare two VCF files and return the diff text."""
+
+    result = run_tool(
+        "diff_tool",
+        "--file1",
+        file1,
+        "--file2",
+        file2,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.stdout
+
+
+def distance_calculator(vcf_file: str) -> list[dict]:
+    """Calculate distances between consecutive variants."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "distance_calculator",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def file_splitter(
+    vcf_file: str, prefix: str = "split", output_dir: str | None = None
+) -> list[str]:
+    """Split a VCF into per-chromosome files and return their paths."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    cwd = output_dir or os.getcwd()
+
+    result = run_tool(
+        "file_splitter",
+        "--prefix",
+        prefix,
+        capture_output=True,
+        text=True,
+        input=inp,
+        cwd=cwd,
+    )
+
+    # collect generated files
+    files = [
+        os.path.join(cwd, f)
+        for f in sorted(os.listdir(cwd))
+        if f.startswith(prefix) and f.endswith(".vcf")
+    ]
+    return files
+
+
+def format_converter(vcf_file: str, to_format: str) -> str:
+    """Convert a VCF to another format (bed or csv)."""
+
+    if to_format not in {"bed", "csv"}:
+        raise ValueError("to_format must be 'bed' or 'csv'")
+
+    arg = "--to-bed" if to_format == "bed" else "--to-csv"
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "format_converter",
+        arg,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def gl_filter(vcf_file: str, condition: str, mode: str = "all") -> str:
+    """Filter VCF records by genotype likelihood conditions."""
+
+    args = ["--filter", condition]
+    if mode != "all":
+        args.extend(["--mode", mode])
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "gl_filter",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def haplotype_extractor(
+    vcf_file: str,
+    block_size: int = 100000,
+    check_phase_consistency: bool = False,
+) -> list[dict]:
+    """Extract phased haplotype blocks from a VCF."""
+
+    args = ["--block-size", str(block_size)]
+    if check_phase_consistency:
+        args.append("--check-phase-consistency")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "haplotype_extractor",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def haplotype_phaser(vcf_file: str, ld_threshold: float = 0.8) -> str:
+    """Group variants into haplotype blocks based on LD."""
+
+    args = ["--ld-threshold", str(ld_threshold)]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "haplotype_phaser",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def header_parser(vcf_file: str) -> str:
+    """Extract header lines from a VCF."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "header_parser",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def impact_filter(vcf_file: str, level: str) -> str:
+    """Filter variants by functional impact level."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "impact_filter",
+        "--filter-impact",
+        level,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def indel_normalizer(vcf_file: str) -> str:
+    """Normalize indel variants by left-aligning and splitting."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "indel_normalizer",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def indexer(vcf_file: str) -> list[dict]:
+    """Create a byte offset index for a VCF."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "indexer",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def ld_calculator(vcf_file: str, region: str | None = None) -> str:
+    """Calculate pairwise linkage disequilibrium."""
+
+    args: list[str] = []
+    if region:
+        args.extend(["--region", region])
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "ld_calculator",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def merger(vcf_files: Sequence[str]) -> str:
+    """Merge multiple VCF files."""
+
+    args = ["--merge", ",".join(vcf_files)]
+
+    result = run_tool(
+        "merger",
+        *args,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.stdout
+
+
+def metadata_summarizer(vcf_file: str) -> str:
+    """Summarize metadata from a VCF file."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "metadata_summarizer",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def missing_data_handler(
+    vcf_file: str,
+    fill_missing: bool = False,
+    default_genotype: str = "./.",
+) -> str:
+    """Handle or impute missing genotype data."""
+
+    args: list[str] = []
+    if fill_missing:
+        args.append("--fill-missing")
+        args.extend(["--default-genotype", default_genotype])
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "missing_data_handler",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def multiallelic_splitter(vcf_file: str) -> str:
+    """Split multi-allelic variants into bi-allelic records."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "multiallelic_splitter",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def nonref_filter(vcf_file: str) -> str:
+    """Remove homozygous reference variants."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "nonref_filter",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def outlier_detector(
+    vcf_file: str,
+    metric: str,
+    threshold: float,
+    mode: str = "variant",
+) -> list[dict]:
+    """Detect variant or sample outliers based on metrics."""
+
+    args = ["--metric", metric, "--threshold", str(threshold)]
+    if mode == "variant":
+        args.append("--variant")
+    else:
+        args.append("--sample")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "outlier_detector",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    return list(reader)
+
+
+def phase_checker(vcf_file: str) -> str:
+    """Keep only fully phased variants."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "phase_checker",
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def phase_quality_filter(vcf_file: str, condition: str) -> str:
+    """Filter variants by phase quality."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "phase_quality_filter",
+        "--filter-pq",
+        condition,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def phred_filter(
+    vcf_file: str,
+    threshold: float = 30.0,
+    keep_missing_qual: bool = False,
+) -> str:
+    """Filter variants by PHRED quality."""
+
+    args = ["--phred-filter", str(threshold)]
+    if keep_missing_qual:
+        args.append("--keep-missing-qual")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "phred_filter",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def population_filter(vcf_file: str, pop_tag: str, pop_map: str) -> str:
+    """Subset samples by population."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "population_filter",
+        "--population",
+        pop_tag,
+        "--pop-map",
+        pop_map,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def position_subsetter(vcf_file: str, region: str) -> str:
+    """Extract variants within a genomic region."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "position_subsetter",
+        "--region",
+        region,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def probability_filter(vcf_file: str, condition: str) -> str:
+    """Filter variants by genotype probability values."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "probability_filter",
+        "--filter-probability",
+        condition,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def quality_adjuster(
+    vcf_file: str,
+    func: str,
+    no_clamp: bool = False,
+) -> str:
+    """Transform QUAL scores using a mathematical function."""
+
+    args = ["--adjust-qual", func]
+    if no_clamp:
+        args.append("--no-clamp")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "quality_adjuster",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def ref_comparator(vcf_file: str, reference: str) -> str:
+    """Compare variant alleles against a reference genome."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "ref_comparator",
+        "--reference",
+        reference,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def reformatter(
+    vcf_file: str,
+    compress_info: Sequence[str] | None = None,
+    compress_format: Sequence[str] | None = None,
+    reorder_info: Sequence[str] | None = None,
+    reorder_format: Sequence[str] | None = None,
+) -> str:
+    """Reformat INFO and FORMAT fields."""
+
+    args: list[str] = []
+    if compress_info:
+        args.extend(["--compress-info", ",".join(compress_info)])
+    if compress_format:
+        args.extend(["--compress-format", ",".join(compress_format)])
+    if reorder_info:
+        args.extend(["--reorder-info", ",".join(reorder_info)])
+    if reorder_format:
+        args.extend(["--reorder-format", ",".join(reorder_format)])
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "reformatter",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def region_subsampler(vcf_file: str, bed_file: str) -> str:
+    """Subset variants based on a BED file of regions."""
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "region_subsampler",
+        "--region-bed",
+        bed_file,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def sample_extractor(vcf_file: str, samples: Sequence[str]) -> str:
+    """Extract a subset of samples from a VCF."""
+
+    args = ["--samples", " ".join(samples)]
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "sample_extractor",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def sorter(vcf_file: str, natural_chr: bool = False) -> str:
+    """Sort variants lexicographically or using natural chromosome order."""
+
+    args: list[str] = []
+    if natural_chr:
+        args.append("--natural-chr")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "sorter",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def subsampler(vcf_file: str, n: int, seed: int | None = None) -> str:
+    """Randomly subsample a VCF to *n* variants."""
+
+    args = ["--subsample", str(n)]
+    if seed is not None:
+        args.extend(["--seed", str(seed)])
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "subsampler",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def sv_handler(
+    vcf_file: str,
+    sv_filter_only: bool = False,
+    sv_modify: bool = False,
+) -> str:
+    """Filter or modify structural variant annotations."""
+
+    args: list[str] = []
+    if sv_filter_only:
+        args.append("--sv-filter-only")
+    if sv_modify:
+        args.append("--sv-modify")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "sv_handler",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
+
+
+def validator(
+    vcf_file: str,
+    strict: bool = False,
+    report_dups: bool = False,
+) -> str:
+    """Validate a VCF file and return any messages."""
+
+    args: list[str] = []
+    if strict:
+        args.append("--strict")
+    if report_dups:
+        args.append("--report-dups")
+
+    with open(vcf_file, "r", encoding="utf-8") as fh:
+        inp = fh.read()
+
+    result = run_tool(
+        "validator",
+        *args,
+        capture_output=True,
+        text=True,
+        input=inp,
+    )
+
+    return result.stdout
 
 
 # Lazy attribute access for tool wrappers

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -93,5 +93,21 @@ assert assign[0]["Assigned_Population"] == "EUR"
 
 dos = vcfx.dosage_calculator("data/dosage_calculator/basic.vcf")
 assert dos[0]["Dosages"] == "0,1,2"
+
+# Additional wrappers
+inf = vcfx.ancestry_inferrer(
+    "data/ancestry_inferrer/eur_samples.vcf",
+    "data/ancestry_inferrer/population_freqs.txt",
+)
+assert inf[0]["Inferred_Population"] == "EUR"
+
+dist = vcfx.distance_calculator("data/variant_counter_normal.vcf")
+assert dist[0]["DISTANCE"]
+
+norm_text = vcfx.indel_normalizer("data/basic_indel.vcf")
+assert norm_text.startswith("##")
+
+val_msg = vcfx.validator("data/variant_counter_normal.vcf")
+assert "VCF" in val_msg
 print("Python tool wrappers OK")
 PY


### PR DESCRIPTION
## Summary
- extend Python wrappers to cover all documented tools
- export new wrappers and data classes in `__init__`
- document additional helpers
- exercise new helpers in wrapper tests

## Testing
- `bash tests/test_python_tool_wrappers.sh`
- `bash tests/test_python_bindings.sh`