### PR TITLE
Add py.typed to wheel

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,11 +89,15 @@ jobs:
           export PATH="$PWD/install/bin:$PATH"
           echo "$PWD/install/bin" >> $GITHUB_PATH
           cat <<'EOF' | python -
-          import vcfx
+          import pathlib, vcfx, sys
           print('version:', vcfx.get_version())
           tools = vcfx.available_tools()
           print('tools:', len(tools))
           if tools:
               vcfx.run_tool(tools[0], '--help', check=False)
+          p = pathlib.Path(vcfx.__file__).resolve().parent / 'py.typed'
+          print('py.typed exists:', p.is_file())
+          if not p.is_file():
+              sys.exit('py.typed missing')
           EOF
         shell: bash

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ pip install --no-build-isolation ./python
 When offline, ensure the `setuptools` and `cmake` packages are already installed
 because build isolation is disabled.
 
+#### Building a Wheel
+
+To build a distributable wheel from the local checkout:
+
+```bash
+python3 -m venv venv && source venv/bin/activate
+python3 -m pip wheel ./python -w dist --no-build-isolation
+```
+
+When offline, install `setuptools` and `wheel` beforehand:
+
+```bash
+python3 -m pip install setuptools wheel
+```
+
 ### Python API
 
 VCFX also offers optional Python bindings. See

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,6 +39,7 @@ setup(
     version=read_version(),
     packages=['vcfx'],
     package_dir={'vcfx': '.'},
+    package_data={'vcfx': ['py.typed']},
     ext_modules=[CMakeExtension('vcfx._vcfx')],
     cmdclass={'build_ext': CMakeBuild},
     zip_safe=False,

--- a/tests/test_python_bindings.sh
+++ b/tests/test_python_bindings.sh
@@ -14,6 +14,7 @@ cmake -DPYTHON_BINDINGS=ON ../..
 make -j
 
 cd "$SCRIPT_DIR"
+source "$ROOT_DIR/add_vcfx_tools_to_path.sh"
 
 PYTHONPATH="${BUILD_DIR}/python" python3 - <<'PY'
 import vcfx


### PR DESCRIPTION
## Summary
- include a `py.typed` marker file in the Python package
- package the type info in `setup.py`
- verify the marker is in the installed wheel during CI
- fix python bindings test to add tools to `PATH`
- document building wheels without network access

## Testing
- `bash tests/test_python_bindings.sh` *(fails locally due to long path output but returns success)*
- `python3 -m pip wheel ./python -w dist --no-build-isolation`