### PR TITLE
Update Python install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ conda install -c bioconda vcfx
 git clone https://github.com/ieeta-pt/VCFX.git
 cd VCFX
 mkdir -p build && cd build
-cmake ..
+cmake .. -DPYTHON_BINDINGS=ON
 make
 ```
 
+Enabling `PYTHON_BINDINGS` builds the Python module.
 #### Installing Python Bindings from a Local Checkout
 
 ```bash
@@ -88,6 +89,13 @@ When offline, install `setuptools` and `wheel` beforehand:
 
 ```bash
 python3 -m pip install setuptools wheel
+```
+
+#### Installing from PyPI or a Wheel
+
+```bash
+pip install vcfx               # from PyPI
+pip install dist/vcfx-*.whl    # from a local wheel
 ```
 
 ### Python API


### PR DESCRIPTION
## Summary
- show how to enable PYTHON_BINDINGS when building from source
- document installation from PyPI or a wheel

## Testing
- `bash tests/test_all.sh` *(fails: build interrupted)*