### PR TITLE
Use numeric types for Python results

### DIFF
--- a/python/results.py
+++ b/python/results.py
@@ -20,36 +20,36 @@ __all__ = [
 @dataclass
 class AlleleFrequency:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
-    Allele_Frequency: str
+    Allele_Frequency: float
 
 
 @dataclass
 class InfoSummary:
     INFO_Field: str
-    Mean: str
-    Median: str
-    Mode: str
+    Mean: float
+    Median: float
+    Mode: float
 
 
 @dataclass
 class AlleleBalance:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
     Sample: str
-    Allele_Balance: str
+    Allele_Balance: float
 
 
 @dataclass
 class ConcordanceRow:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
@@ -61,23 +61,23 @@ class ConcordanceRow:
 @dataclass
 class HWEResult:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
-    HWE_pvalue: str
+    HWE_pvalue: float
 
 
 @dataclass
 class InbreedingCoefficient:
     Sample: str
-    InbreedingCoefficient: str
+    InbreedingCoefficient: float
 
 
 @dataclass
 class VariantClassification:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
@@ -87,12 +87,12 @@ class VariantClassification:
 @dataclass
 class CrossSampleConcordanceRow:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
-    Num_Samples: str
-    Unique_Normalized_Genotypes: str
+    Num_Samples: int
+    Unique_Normalized_Genotypes: int
     Concordance_Status: str
 
 
@@ -105,7 +105,7 @@ class AncestryAssignment:
 @dataclass
 class DosageRow:
     CHROM: str
-    POS: str
+    POS: int
     ID: str
     REF: str
     ALT: str
@@ -121,13 +121,13 @@ class AncestryInference:
 @dataclass
 class DistanceRow:
     CHROM: str
-    POS: str
-    PREV_POS: str
-    DISTANCE: str
+    POS: int
+    PREV_POS: int
+    DISTANCE: int
 
 
 @dataclass
 class IndexEntry:
     CHROM: str
-    POS: str
-    FILE_OFFSET: str
+    POS: int
+    FILE_OFFSET: int

--- a/python/tools.py
+++ b/python/tools.py
@@ -173,6 +173,18 @@ def run_tool(
     return subprocess.run(cmd, check=check, capture_output=capture_output, text=text, **kwargs)
 
 
+def _convert_fields(rows: list[dict], converters: dict[str, Callable[[str], Any]]) -> list[dict]:
+    """Apply *converters* to fields in each row in *rows*."""
+    for row in rows:
+        for key, func in converters.items():
+            if key in row:
+                try:
+                    row[key] = func(row[key])
+                except ValueError:
+                    row[key] = float("nan")
+    return rows
+
+
 def alignment_checker(vcf_file: str, reference: str) -> list[dict]:
     """Run ``alignment_checker`` and parse the TSV output.
 
@@ -301,7 +313,8 @@ def allele_freq_calc(vcf_file: str) -> list[dict]:
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int, "Allele_Frequency": float})
 
 
 def ancestry_assigner(vcf_file: str, freq_file: str) -> list[dict]:
@@ -387,7 +400,8 @@ def info_summarizer(vcf_file: str, fields: Sequence[str]) -> list[dict]:
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"Mean": float, "Median": float, "Mode": float})
 
 
 def fasta_converter(vcf_file: str) -> str:
@@ -427,7 +441,8 @@ def allele_balance_calc(
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int, "Allele_Balance": float})
 
 
 def dosage_calculator(vcf_file: str) -> list[dict]:
@@ -444,7 +459,8 @@ def dosage_calculator(vcf_file: str) -> list[dict]:
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int})
 
 
 def concordance_checker(
@@ -466,7 +482,8 @@ def concordance_checker(
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int})
 
 
 def genotype_query(
@@ -597,7 +614,8 @@ def hwe_tester(vcf_file: str) -> list[dict]:
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int, "HWE_pvalue": float})
 
 
 def inbreeding_calculator(
@@ -623,7 +641,8 @@ def inbreeding_calculator(
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"InbreedingCoefficient": float})
 
 
 def variant_classifier(
@@ -650,7 +669,8 @@ def variant_classifier(
         return result.stdout
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int})
 
 
 def cross_sample_concordance(
@@ -674,7 +694,11 @@ def cross_sample_concordance(
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(
+        rows,
+        {"POS": int, "Num_Samples": int, "Unique_Normalized_Genotypes": int},
+    )
 
 
 def field_extractor(vcf_file: str, fields: Sequence[str]) -> list[dict]:
@@ -803,7 +827,8 @@ def distance_calculator(vcf_file: str) -> list[dict]:
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int, "PREV_POS": int, "DISTANCE": int})
 
 
 def file_splitter(
@@ -987,7 +1012,8 @@ def indexer(vcf_file: str) -> list[dict]:
     )
 
     reader = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
-    return list(reader)
+    rows = list(reader)
+    return _convert_fields(rows, {"POS": int, "FILE_OFFSET": int})
 
 
 def ld_calculator(vcf_file: str, region: str | None = None) -> str:

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -35,7 +35,7 @@ n = vcfx.variant_counter("data/variant_counter_normal.vcf")
 assert n == 5
 
 freqs = vcfx.allele_freq_calc("data/allele_freq_calc/simple.vcf")
-assert freqs[0]["Allele_Frequency"] == "0.5000"
+assert abs(freqs[0]["Allele_Frequency"] - 0.5) < 1e-6
 
 annotated = vcfx.info_aggregator("data/aggregator/basic.vcf", ["DP"])
 assert "#AGGREGATION_SUMMARY" in annotated
@@ -44,13 +44,13 @@ parsed = vcfx.info_parser("data/info_parser/basic.vcf", ["DP"])
 assert parsed[0]["DP"] == "10"
 
 summary = vcfx.info_summarizer("data/info_summarizer/basic.vcf", ["DP"])
-assert summary[0]["Mean"] == "20.0000"
+assert abs(summary[0]["Mean"] - 20.0) < 1e-6
 
 fasta = vcfx.fasta_converter("data/fasta_converter/basic.vcf")
 assert fasta.startswith(">")
 
 balance = vcfx.allele_balance_calc("data/allele_balance_calc_A.vcf")
-assert balance[0]["Allele_Balance"] == "1.000000"
+assert abs(balance[0]["Allele_Balance"] - 1.0) < 1e-6
 
 conc = vcfx.concordance_checker("data/concordance_input.vcf", "SAMPLE1", "SAMPLE2")
 assert conc[0]["Concordance"] == "Concordant"
@@ -68,13 +68,13 @@ flagged = vcfx.missing_detector("data/concordance_missing_data.vcf")
 assert "MISSING_GENOTYPES=1" in flagged
 
 hwe_rows = vcfx.hwe_tester("data/hwe_tester/basic_hwe.vcf")
-assert hwe_rows[0]["HWE_pvalue"]
+assert isinstance(hwe_rows[0]["HWE_pvalue"], float)
 
 coeff = vcfx.inbreeding_calculator(
     "data/inbreeding_calculator/single_sample_excludeSample_false.vcf",
     freq_mode="excludeSample",
 )
-assert coeff[0]["InbreedingCoefficient"]
+assert isinstance(coeff[0]["InbreedingCoefficient"], float)
 
 classes = vcfx.variant_classifier("data/classifier_mixed.vcf")
 assert classes[0]["Classification"]
@@ -102,7 +102,7 @@ inf = vcfx.ancestry_inferrer(
 assert inf[0]["Inferred_Population"] == "EUR"
 
 dist = vcfx.distance_calculator("data/variant_counter_normal.vcf")
-assert dist[0]["DISTANCE"]
+assert isinstance(dist[1]["DISTANCE"], int)
 
 norm_text = vcfx.indel_normalizer("data/basic_indel.vcf")
 assert norm_text.startswith("##")


### PR DESCRIPTION
## Summary
- update dataclasses so numeric fields are `int` or `float`
- convert parser output to numbers in tool wrappers
- verify numeric types in Python wrapper tests

## Testing
- `tests/test_python_tool_wrappers.sh`
- `tests/test_python_bindings.sh`