### PR TITLE
Enhance TSV parsing for Python wrappers

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -208,6 +208,7 @@ assign = vcfx.ancestry_assigner(
     "tests/data/ancestry_assigner/input.vcf",
     "tests/data/ancestry_assigner/freq.tsv",
 )
+# ``assign`` is a list of :class:`vcfx.results.AncestryAssignment` objects
 print(assign[0].Assigned_Population)  # 'EUR'
 ```
 ```python


### PR DESCRIPTION
## Summary
- improve `_tsv_to_dataclasses` to handle headerless TSVs
- parse `ancestry_assigner` output using the new helper
- note AncestryAssignment dataclass usage in the Python API docs

## Testing
- `bash tests/test_python_tool_wrappers.sh`