### PR TITLE
Update TSV parsing to dataclasses

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -96,7 +96,9 @@ see [``examples/python_usage.py``](../examples/python_usage.py).
 
 Several tools have Python helpers that run the command line program and
 parse its output into structured data. Many wrappers return dataclasses
-from `vcfx.results` rather than raw dictionaries.
+from `vcfx.results` rather than raw dictionaries. When using these
+helpers numeric columns are automatically converted to ``int`` or ``float``
+based on the dataclass field annotations.
 
 ```python
 import vcfx

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -30,6 +30,7 @@ assert rows and rows[0].Discrepancy_Type == "ALT_MISMATCH"
 
 counts = vcfx.allele_counter("data/allele_counter_A.vcf")
 assert counts[0].Sample == "S1"
+assert isinstance(counts[0].Ref_Count, int)
 
 n = vcfx.variant_counter("data/variant_counter_normal.vcf")
 assert n == 5
@@ -45,6 +46,7 @@ assert parsed[0]["DP"] == "10"
 
 summary = vcfx.info_summarizer("data/info_summarizer/basic.vcf", ["DP"])
 assert abs(summary[0].Mean - 20.0) < 1e-6
+assert isinstance(summary[0].Median, float)
 
 fasta = vcfx.fasta_converter("data/fasta_converter/basic.vcf")
 assert fasta.startswith(">")
@@ -81,6 +83,7 @@ assert classes[0].Classification
 
 xconc = vcfx.cross_sample_concordance("data/concordance_some_mismatch.vcf")
 assert xconc[0].Concordance_Status
+assert isinstance(xconc[0].Num_Samples, int)
 
 fields = vcfx.field_extractor("data/field_extractor_input.vcf", ["CHROM", "POS"])
 assert fields[0]["CHROM"] == "chr1"


### PR DESCRIPTION
## Summary
- enhance `_tsv_to_dataclasses` to auto-convert field values using dataclass annotations
- simplify wrapper implementations and parse TSV outputs directly into dataclasses
- document automatic type conversion in Python API docs
- extend tool wrapper tests for dataclass field types

## Testing
- `tests/test_python_tool_wrappers.sh`
- `tests/test_python_tool_wrappers_extra.sh`
