### PR TITLE
Improve indexer wrapper dataclass parsing

### DIFF
--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -220,6 +220,12 @@ dosage = vcfx.dosage_calculator("tests/data/dosage_calculator/basic.vcf")
 print(dosage[0].Dosages)  # '0,1,2'
 ```
 
+```python
+# Create a position index
+index_rows = vcfx.indexer("tests/data/indexer/basic.vcf")
+print(index_rows[0].FILE_OFFSET)  # 255
+```
+
 ### Further Wrappers
 
 Additional helper functions mirror the rest of the ``VCFX_*`` tools. They work

--- a/python/tools.py
+++ b/python/tools.py
@@ -1029,8 +1029,16 @@ def indel_normalizer(vcf_file: str) -> str:
     return result.stdout
 
 
-def indexer(vcf_file: str) -> list[IndexEntry]:
-    """Create a byte offset index for a VCF."""
+def indexer(vcf_file: str, header: bool = True) -> list[IndexEntry]:
+    """Create a byte offset index for a VCF.
+
+    Parameters
+    ----------
+    vcf_file : str
+        Path to the VCF file to index.
+    header : bool, optional
+        Set to ``False`` if the output lacks a header row. Defaults to ``True``.
+    """
 
     with open(vcf_file, "r", encoding="utf-8") as fh:
         inp = fh.read()
@@ -1042,7 +1050,9 @@ def indexer(vcf_file: str) -> list[IndexEntry]:
         input=inp,
     )
 
-    return _tsv_to_dataclasses(result.stdout, IndexEntry)
+    fields = ["CHROM", "POS", "FILE_OFFSET"] if not header else None
+
+    return _tsv_to_dataclasses(result.stdout, IndexEntry, fieldnames=fields)
 
 
 def ld_calculator(vcf_file: str, region: str | None = None) -> str:

--- a/tests/test_python_tool_wrappers.sh
+++ b/tests/test_python_tool_wrappers.sh
@@ -107,6 +107,9 @@ assert inf[0].Inferred_Population == "EUR"
 dist = vcfx.distance_calculator("data/variant_counter_normal.vcf")
 assert isinstance(dist[1].DISTANCE, int)
 
+index_rows = vcfx.indexer("data/indexer/basic.vcf")
+assert isinstance(index_rows[0].FILE_OFFSET, int)
+
 norm_text = vcfx.indel_normalizer("data/basic_indel.vcf")
 assert norm_text.startswith("##")
 


### PR DESCRIPTION
## Summary
- parse indexer output into `IndexEntry` dataclasses with optional header flag
- document indexing example in Python API docs
- cover indexer wrapper in python wrapper tests

## Testing
- `bash tests/test_python_tool_wrappers.sh`
- `bash tests/test_python_tool_wrappers_extra.sh`
