### PR TITLE
Add PEP 621 metadata

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,3 +1,11 @@
 [build-system]
-requires = ["setuptools>=40.8", "cmake"]
+requires = ["setuptools>=61", "cmake"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "vcfx"
+version = "1.0.2"
+description = "Python bindings for the VCFX toolkit"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,20 +1,7 @@
 import pathlib
-import re
 import subprocess
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-
-def read_version():
-    """Extract the project version from the top-level CMakeLists.txt."""
-    root = pathlib.Path(__file__).resolve().parent.parent / "CMakeLists.txt"
-    text = root.read_text()
-    major = re.search(r"set\(VCFX_VERSION_MAJOR\s+([0-9]+)\)", text)
-    minor = re.search(r"set\(VCFX_VERSION_MINOR\s+([0-9]+)\)", text)
-    patch = re.search(r"set\(VCFX_VERSION_PATCH\s+([0-9]+)\)", text)
-    if major and minor and patch:
-        return f"{major.group(1)}.{minor.group(1)}.{patch.group(1)}"
-    m = re.search(r"project\(VCFX.*VERSION\s+([0-9]+\.[0-9]+\.[0-9]+)\b", text)
-    return m.group(1) if m else "0.0.0"
 
 class CMakeExtension(Extension):
     def __init__(self, name):
@@ -35,8 +22,6 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['cmake', '--build', '.', '--target', '_vcfx'], cwd=build_temp)
 
 setup(
-    name='vcfx',
-    version=read_version(),
     packages=['vcfx'],
     package_dir={'vcfx': '.'},
     package_data={'vcfx': ['py.typed']},


### PR DESCRIPTION
## Summary
- expand `python/pyproject.toml` with PEP 621 metadata
- drop redundant version logic from `setup.py`

## Testing
- `python -m pip wheel ./python -w /tmp/wheel` *(fails: could not fetch build dependencies)*