### PR TITLE
Add version fallback

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -5,6 +5,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
     import gzip
     from pathlib import Path
+    from importlib.metadata import PackageNotFoundError, version
 
     def trim(text: str) -> str:
         """Return *text* without leading/trailing whitespace."""
@@ -27,7 +28,10 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
 
     def get_version() -> str:
         """Return the toolkit version when bindings are unavailable."""
-        return "0.0.0"
+        try:
+            return version(__package__ or "vcfx")
+        except PackageNotFoundError:
+            return "0.0.0"
 
 from . import tools as _tools
 from .tools import TOOL_NAMES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_SCRIPTS
     test_python_bindings.sh
     test_python_tool_wrappers.sh
     test_python_tool_wrappers_extra.sh
+    test_python_version_fallback.sh
 )
 
 foreach(script ${TEST_SCRIPTS})

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -85,6 +85,7 @@ TEST_SCRIPTS=(
     "test_doc_lookup.sh"
     "test_available_tools_fallback.sh"
     "test_python_bindings.sh"
+    "test_python_version_fallback.sh"
 )
 
 # Run all tests

--- a/tests/test_python_version_fallback.sh
+++ b/tests/test_python_version_fallback.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# Determine package version from pyproject.toml
+VERSION=$(grep '^version' "$ROOT_DIR/python/pyproject.toml" | cut -d '"' -f2)
+TMPDIR="$(mktemp -d)"
+mkdir -p "$TMPDIR/vcfx"
+cp "$ROOT_DIR"/python/*.py "$TMPDIR/vcfx"
+cp "$ROOT_DIR"/python/py.typed "$TMPDIR/vcfx"
+mkdir -p "$TMPDIR/vcfx-$VERSION.dist-info"
+cat > "$TMPDIR/vcfx-$VERSION.dist-info/METADATA" <<EOF2
+Metadata-Version: 2.1
+Name: vcfx
+Version: $VERSION
+EOF2
+
+# Provide a dummy vcfx wrapper to satisfy available_tools()
+mkdir -p "$TMPDIR/bin"
+cat <<'SH' > "$TMPDIR/bin/vcfx"
+#!/bin/sh
+exit 0
+SH
+chmod +x "$TMPDIR/bin/vcfx"
+export PATH="$TMPDIR/bin:/usr/bin:/bin"
+
+PYTHONPATH="$TMPDIR" python3 - <<PY
+import vcfx
+expected = "${VERSION}"
+if vcfx.__version__ != expected:
+    raise SystemExit(f"expected {expected}, got {vcfx.__version__}")
+print("\u2713 version fallback passed")
+PY
+
+rm -rf "$TMPDIR"


### PR DESCRIPTION
## Summary
- use importlib.metadata to populate version when `_vcfx` is missing
- expose package version in `__version__` fallback
- test Python fallback version logic

## Testing
- `bash tests/test_available_tools_fallback.sh`
- `bash tests/test_python_version_fallback.sh`
