### PR TITLE
Add packaging metadata to pyproject

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,3 +9,16 @@ description = "Python bindings for the VCFX toolkit"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
+authors = [
+    { name = "Jorge Miguel Silva" },
+    { name = "José Luis Oliveira" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+]
+
+[tool.setuptools.package-data]
+"vcfx" = ["py.typed"]


### PR DESCRIPTION
## Summary
- expand pyproject metadata with authors and classifiers
- ensure `py.typed` is distributed via `tool.setuptools.package-data`

## Testing
- `python3 setup.py build` *(fails: ModuleNotFoundError: No module named 'setuptools')*