### PR TITLE
Use CMake version for python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ make
 ```
 
 Enabling `PYTHON_BINDINGS` builds the Python module.
+
+### Versioning
+
+The version numbers for both the C++ tools and the Python package are defined
+once in `CMakeLists.txt` (`VCFX_VERSION_MAJOR`, `VCFX_VERSION_MINOR`,
+`VCFX_VERSION_PATCH`). The Python build reads these values at install time to
+ensure a single source of truth.
 #### Installing Python Bindings from a Local Checkout
 
 ```bash

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -33,7 +33,15 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for pure Python envs
         try:
             return version(__package__ or "vcfx")
         except PackageNotFoundError:
-            return "0.0.0"
+            try:
+                from pathlib import Path
+                import sys
+                script_dir = Path(__file__).resolve().parent.parent / "scripts"
+                sys.path.insert(0, str(script_dir))
+                from extract_version import extract_version  # type: ignore
+                return extract_version()
+            except Exception:
+                return "0.0.0"
 
 from . import tools as _tools
 from .tools import TOOL_NAMES

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vcfx"
-version = "1.0.2"
+dynamic = ["version"]
 description = "Python bindings for the VCFX toolkit"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,3 +22,6 @@ classifiers = [
 
 [tool.setuptools.package-data]
 "vcfx" = ["py.typed"]
+
+[tool.setuptools.dynamic]
+version = {attr = "vcfx.__version__"}

--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+
+def extract_version(cmake_path: Path | str | None = None) -> str:
+    """Return the toolkit version as defined in CMakeLists.txt."""
+    if cmake_path is None:
+        cmake_path = Path(__file__).resolve().parents[1] / "CMakeLists.txt"
+    cmake_text = Path(cmake_path).read_text()
+    major = re.search(r"set\(\s*VCFX_VERSION_MAJOR\s+(\d+)\s*\)", cmake_text)
+    minor = re.search(r"set\(\s*VCFX_VERSION_MINOR\s+(\d+)\s*\)", cmake_text)
+    patch = re.search(r"set\(\s*VCFX_VERSION_PATCH\s+(\d+)\s*\)", cmake_text)
+    if major and minor and patch:
+        return f"{major.group(1)}.{minor.group(1)}.{patch.group(1)}"
+    version = re.search(r"set\(\s*VCFX_VERSION\s+\"([0-9]+\.[0-9]+\.[0-9]+)\"\s*\)", cmake_text)
+    if version:
+        return version.group(1)
+    raise RuntimeError("Unable to parse version from CMakeLists.txt")
+
+
+if __name__ == "__main__":
+    print(extract_version())

--- a/tests/test_python_version_fallback.sh
+++ b/tests/test_python_version_fallback.sh
@@ -5,8 +5,8 @@ set -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
 
-# Determine package version from pyproject.toml
-VERSION=$(grep '^version' "$ROOT_DIR/python/pyproject.toml" | cut -d '"' -f2)
+# Determine package version from the CMake configuration
+VERSION=$(python "$ROOT_DIR/scripts/extract_version.py")
 TMPDIR="$(mktemp -d)"
 mkdir -p "$TMPDIR/vcfx"
 cp "$ROOT_DIR"/python/*.py "$TMPDIR/vcfx"


### PR DESCRIPTION
## Summary
- parse version from CMakeLists.txt via `scripts/extract_version.py`
- use dynamic version in `pyproject.toml`
- fallback to CMake version in `vcfx.__init__`
- adjust version fallback test
- document single source of truth for version

## Testing
- `bash tests/test_python_version_fallback.sh`