### PR TITLE
Ignore Python tooling caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ tests/expected/genotype_query/single_sample_strict_01.vcf
 tests/tmp/
 tests/out/
 tmp/
+# Python tooling caches
+.mypy_cache/
+.ruff_cache/


### PR DESCRIPTION
## Summary
- ignore mypy and ruff caches in `.gitignore`

## Testing
- `bash -lc 'git status --short'`