### PR TITLE
Add requirements-dev

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,8 @@ jobs:
           python-version: '3.x'
       - name: Install lint dependencies
         run: |
-          python -m pip install --upgrade pip flake8 ruff mypy
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
       - name: Run ruff
         run: ruff check python
       - name: Run flake8
@@ -62,8 +63,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: Install pytest
-        run: python -m pip install --upgrade pip pytest
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
         shell: bash
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -177,8 +177,13 @@ You can also execute all shell scripts directly with:
 bash ../tests/test_all.sh
 ```
 
-Python tests are executed with `pytest`. After building the bindings using
-`cmake -DPYTHON_BINDINGS=ON` (or after installing the wheel), run:
+Python tests are executed with `pytest`. Install the development requirements first:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+After building the bindings using `cmake -DPYTHON_BINDINGS=ON` (or after installing the wheel), run:
 
 ```bash
 pytest tests/python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+ruff
+flake8
+mypy


### PR DESCRIPTION
## Summary
- add a requirements-dev.txt with common development tools
- update README to explain installing from this file
- use requirements-dev.txt in CI for linting and tests

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement flake8)*