### PR TITLE
Fix version check prerequisites

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,10 +36,6 @@ jobs:
         uses: actions/checkout@v3
 
 
-      - name: Check version consistency
-        run: python scripts/check_version.py
-        shell: bash
-
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -68,6 +64,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
         shell: bash
+      - name: Check version consistency
+        run: python scripts/check_version.py
+        shell: bash
 
       - name: Run tests
         run: |
@@ -87,10 +86,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Check version consistency
-        run: python scripts/check_version.py
-        shell: bash
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -116,7 +111,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+        shell: bash
+      - name: Check version consistency
+        run: python scripts/check_version.py
+        shell: bash
+      
       - name: Build wheel
         run: |
           python -m pip install --upgrade pip wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
 ruff
 flake8
+tomli
 mypy


### PR DESCRIPTION
## Summary
- add `tomli` for Python 3.10 compatibility
- move version check in CI until after dev dependencies are installed

## Testing
- `pytest tests/python`
- `python scripts/check_version.py` with Python 3.10