### PR TITLE
Add pre-commit config and docs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,12 +19,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-      - name: Run ruff
-        run: ruff check python
-      - name: Run flake8
-        run: flake8 python
-      - name: Run mypy
-        run: mypy python
+      - name: Run pre-commit
+        run: pre-commit run --all-files
 
   build-and-test:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff check
+        language: system
+        types: [python]
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+      - id: mypy
+        name: mypy
+        entry: mypy python
+        language: system
+        pass_filenames: false
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ After building the bindings using `cmake -DPYTHON_BINDINGS=ON` (or after install
 pytest tests/python
 ```
 
+To automatically run `ruff`, `flake8`, `mypy`, and `pytest` before each commit,
+install the pre-commit hooks once:
+
+```bash
+pre-commit install
+```
+
 
 ## Contributing
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ ruff
 flake8
 tomli
 mypy
+pre-commit


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml`
- document how to install pre-commit hooks
- run pre-commit in CI
- list pre-commit in dev requirements

## Testing
- `ruff check python`
- `flake8 python` *(fails: command not found)*
- `mypy python`
- `pytest tests/python`