### PR TITLE
Fix style issues to restore CI

### DIFF
--- a/examples/python_usage.py
+++ b/examples/python_usage.py
@@ -45,5 +45,3 @@ except FileNotFoundError as exc:
     print("Tool not found:", exc)
 except subprocess.CalledProcessError as exc:
     print("Tool failed with status", exc.returncode)
-
-

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -27,7 +27,12 @@ def parse_pyproject(path: Path, cmake_version: str) -> str:
     if "version" in project:
         return str(project["version"])  # explicit version
     if "dynamic" in project and "version" in project["dynamic"]:
-        dyn = data.get("tool", {}).get("setuptools", {}).get("dynamic", {}).get("version")
+        dyn = (
+            data.get("tool", {})
+            .get("setuptools", {})
+            .get("dynamic", {})
+            .get("version")
+        )
         if isinstance(dyn, dict) and dyn.get("attr") == "vcfx.__version__":
             return cmake_version
     raise RuntimeError("Unable to determine version from pyproject.toml")
@@ -37,7 +42,10 @@ def main() -> int:
     root = Path(__file__).resolve().parents[1]
     citation_version = parse_citation(root / "CITATION.cff")
     cmake_version = extract_version(root / "CMakeLists.txt")
-    pyproject_version = parse_pyproject(root / "python" / "pyproject.toml", cmake_version)
+    pyproject_version = parse_pyproject(
+        root / "python" / "pyproject.toml",
+        cmake_version,
+    )
 
     if citation_version == cmake_version == pyproject_version:
         print(f"Version OK: {citation_version}")

--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -12,7 +12,10 @@ def extract_version(cmake_path: Path | str | None = None) -> str:
     patch = re.search(r"set\(\s*VCFX_VERSION_PATCH\s+(\d+)\s*\)", cmake_text)
     if major and minor and patch:
         return f"{major.group(1)}.{minor.group(1)}.{patch.group(1)}"
-    version = re.search(r"set\(\s*VCFX_VERSION\s+\"([0-9]+\.[0-9]+\.[0-9]+)\"\s*\)", cmake_text)
+    version = re.search(
+        r"set\(\s*VCFX_VERSION\s+\"([0-9]+\.[0-9]+\.[0-9]+)\"\s*\)",
+        cmake_text,
+    )
     if version:
         return version.group(1)
     raise RuntimeError("Unable to parse version from CMakeLists.txt")

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 
+
 @pytest.fixture(scope="session")
 def build_dir(tmp_path_factory):
     build = tmp_path_factory.mktemp("pybuild")
@@ -16,6 +17,7 @@ def build_dir(tmp_path_factory):
     ], cwd=build)
     subprocess.check_call(["cmake", "--build", ".", "--parallel"], cwd=build)
     return build
+
 
 @pytest.fixture()
 def vcfx(build_dir, monkeypatch):
@@ -30,7 +32,10 @@ def vcfx(build_dir, monkeypatch):
             if exe.is_file():
                 tool_dirs.append(str(sub))
     if tool_dirs:
-        monkeypatch.setenv("PATH", os.pathsep.join(tool_dirs + [os.environ.get("PATH", "")]))
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join(tool_dirs + [os.environ.get("PATH", "")]),
+        )
 
     import vcfx as module
     return module

--- a/tests/python/test_tool_wrappers.py
+++ b/tests/python/test_tool_wrappers.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 DATA = Path(__file__).resolve().parents[1] / "data"
 
+
 def test_tool_wrappers(vcfx):
     rows = vcfx.alignment_checker(DATA / "align_Y.vcf", DATA / "align_refY.fa")
     assert rows and rows[0].Discrepancy_Type == "ALT_MISMATCH"
@@ -32,7 +33,11 @@ def test_tool_wrappers(vcfx):
     balance = vcfx.allele_balance_calc(DATA / "allele_balance_calc_A.vcf")
     assert abs(balance[0].Allele_Balance - 1.0) < 1e-6
 
-    conc = vcfx.concordance_checker(DATA / "concordance_input.vcf", "SAMPLE1", "SAMPLE2")
+    conc = vcfx.concordance_checker(
+        DATA / "concordance_input.vcf",
+        "SAMPLE1",
+        "SAMPLE2",
+    )
     assert conc[0].Concordance == "Concordant"
 
     filtered = vcfx.genotype_query(DATA / "genotype_query" / "sample.vcf", "0/1")

--- a/tests/python/test_tool_wrappers_extra.py
+++ b/tests/python/test_tool_wrappers_extra.py
@@ -5,13 +5,13 @@ DATA = Path(__file__).resolve().parents[1] / "data"
 
 def test_tool_wrappers_extra(vcfx):
     tested = {
-        'alignment_checker','allele_counter','variant_counter','allele_freq_calc',
-        'info_aggregator','info_parser','info_summarizer','fasta_converter',
-        'allele_balance_calc','concordance_checker','genotype_query',
-        'duplicate_remover','af_subsetter','missing_detector','hwe_tester',
-        'inbreeding_calculator','variant_classifier','cross_sample_concordance',
-        'field_extractor','ancestry_assigner','dosage_calculator',
-        'ancestry_inferrer','distance_calculator','indel_normalizer','validator'
+        'alignment_checker', 'allele_counter', 'variant_counter', 'allele_freq_calc',
+        'info_aggregator', 'info_parser', 'info_summarizer', 'fasta_converter',
+        'allele_balance_calc', 'concordance_checker', 'genotype_query',
+        'duplicate_remover', 'af_subsetter', 'missing_detector', 'hwe_tester',
+        'inbreeding_calculator', 'variant_classifier', 'cross_sample_concordance',
+        'field_extractor', 'ancestry_assigner', 'dosage_calculator',
+        'ancestry_inferrer', 'distance_calculator', 'indel_normalizer', 'validator',
     }
     all_tools = vcfx.available_tools()
     untested = sorted(set(all_tools) - tested)

--- a/tests/test_run_tool_fallback.py
+++ b/tests/test_run_tool_fallback.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 import importlib.util
@@ -9,6 +8,7 @@ vcfx = importlib.util.module_from_spec(spec)
 sys.modules["vcfx"] = vcfx
 spec.loader.exec_module(vcfx)  # type: ignore
 
+
 def test_run_tool_fallback(tmp_path, monkeypatch):
     wrapper = tmp_path / "vcfx"
     wrapper.write_text("#!/bin/sh\necho $1\n")
@@ -17,4 +17,3 @@ def test_run_tool_fallback(tmp_path, monkeypatch):
 
     proc = vcfx.run_tool("dummytool", capture_output=True, text=True)
     assert proc.stdout.strip() == "dummytool"
-


### PR DESCRIPTION
## Summary
- drop unused import in `test_run_tool_fallback`
- format fixtures and wrappers tests
- wrap long lines in helper scripts
- clean up example script

## Testing
- `mypy python`
- `pytest`
- `ruff check tests/test_run_tool_fallback.py tests/python/conftest.py tests/python/test_tool_wrappers.py tests/python/test_tool_wrappers_extra.py scripts/extract_version.py scripts/check_version.py examples/python_usage.py`
- `ruff check .`

Pre-commit and flake8 were unavailable in this environment.