### PR TITLE
Fix clang-format issues

### DIFF
--- a/include/vcfx_core.h
+++ b/include/vcfx_core.h
@@ -1,23 +1,22 @@
 #ifndef VCFX_CORE_H
 #define VCFX_CORE_H
 
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <vector>
-#include <cstring>
 
 namespace vcfx {
 
 // Trim leading and trailing whitespace from a string
-std::string trim(const std::string& str);
+std::string trim(const std::string &str);
 
 // Split a string on the given delimiter
-std::vector<std::string> split(const std::string& str, char delimiter);
+std::vector<std::string> split(const std::string &str, char delimiter);
 
 // Convenience helpers for printing common messages
-void print_error(const std::string& msg, std::ostream& os = std::cerr);
-void print_version(const std::string& tool, const std::string& version,
-                   std::ostream& os = std::cout);
+void print_error(const std::string &msg, std::ostream &os = std::cerr);
+void print_version(const std::string &tool, const std::string &version, std::ostream &os = std::cout);
 
 inline std::string get_version() {
 #ifdef VCFX_VERSION
@@ -27,11 +26,9 @@ inline std::string get_version() {
 #endif
 }
 
-inline bool handle_version_flag(int argc, char* argv[], const std::string& tool,
-                                std::ostream& os = std::cout) {
+inline bool handle_version_flag(int argc, char *argv[], const std::string &tool, std::ostream &os = std::cout) {
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--version") == 0 ||
-            std::strcmp(argv[i], "-v") == 0) {
+        if (std::strcmp(argv[i], "--version") == 0 || std::strcmp(argv[i], "-v") == 0) {
             print_version(tool, get_version(), os);
             return true;
         }
@@ -40,14 +37,14 @@ inline bool handle_version_flag(int argc, char* argv[], const std::string& tool,
 }
 
 // Check if a specific flag (long or short form) is present
-bool flag_present(int argc, char* argv[], const char* long_flag,
-                  const char* short_flag = nullptr);
+bool flag_present(int argc, char *argv[], const char *long_flag, const char *short_flag = nullptr);
 
 // Handle the --help flag using the provided callback. Returns true if the flag
 // was found and handled.
-inline bool handle_help_flag(int argc, char* argv[], void (*print_help)()) {
+inline bool handle_help_flag(int argc, char *argv[], void (*print_help)()) {
     if (flag_present(argc, argv, "--help", "-h")) {
-        if (print_help) print_help();
+        if (print_help)
+            print_help();
         return true;
     }
     return false;
@@ -55,23 +52,23 @@ inline bool handle_help_flag(int argc, char* argv[], void (*print_help)()) {
 
 // Handle both --help and --version flags. Returns true if either flag was found
 // and processed (in which case the caller should exit).
-inline bool handle_common_flags(int argc, char* argv[], const std::string& tool,
-                                void (*print_help)(),
-                                std::ostream& os = std::cout) {
-    if (handle_help_flag(argc, argv, print_help)) return true;
+inline bool handle_common_flags(int argc, char *argv[], const std::string &tool, void (*print_help)(),
+                                std::ostream &os = std::cout) {
+    if (handle_help_flag(argc, argv, print_help))
+        return true;
     return handle_version_flag(argc, argv, tool, os);
 }
 
 // Read entire input stream, automatically decompressing if gzip/BGZF
 // compressed. Returns true on success and stores the resulting text in
 // 'out'.
-bool read_maybe_compressed(std::istream& in, std::string& out);
+bool read_maybe_compressed(std::istream &in, std::string &out);
 
 // Convenience helper to read a file that may be gzip/BGZF compressed. The file
 // is loaded completely into memory and stored in 'out'. Returns true on
 // success.
-bool read_file_maybe_compressed(const std::string& path, std::string& out);
+bool read_file_maybe_compressed(const std::string &path, std::string &out);
 
-}  // namespace vcfx
+} // namespace vcfx
 
 #endif // VCFX_CORE_H

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,15 +1,16 @@
-#include <Python.h>
 #include "vcfx_core.h"
+#include <Python.h>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 // Helper to convert std::vector<std::string> to Python list
-static PyObject* to_py_list(const std::vector<std::string>& vec) {
-    PyObject* list = PyList_New(vec.size());
-    if (!list) return nullptr;
+static PyObject *to_py_list(const std::vector<std::string> &vec) {
+    PyObject *list = PyList_New(vec.size());
+    if (!list)
+        return nullptr;
     for (size_t i = 0; i < vec.size(); ++i) {
-        PyObject* item = PyUnicode_FromString(vec[i].c_str());
+        PyObject *item = PyUnicode_FromString(vec[i].c_str());
         if (!item) {
             Py_DECREF(list);
             return nullptr;
@@ -19,25 +20,25 @@ static PyObject* to_py_list(const std::vector<std::string>& vec) {
     return list;
 }
 
-static PyObject* py_trim(PyObject*, PyObject* args) {
-    const char* text;
+static PyObject *py_trim(PyObject *, PyObject *args) {
+    const char *text;
     if (!PyArg_ParseTuple(args, "s", &text))
         return nullptr;
     std::string result = vcfx::trim(text);
     return PyUnicode_FromString(result.c_str());
 }
 
-static PyObject* py_split(PyObject*, PyObject* args) {
-    const char* text;
-    const char* delim;
+static PyObject *py_split(PyObject *, PyObject *args) {
+    const char *text;
+    const char *delim;
     if (!PyArg_ParseTuple(args, "ss", &text, &delim))
         return nullptr;
     std::vector<std::string> parts = vcfx::split(text, delim[0]);
     return to_py_list(parts);
 }
 
-static PyObject* py_read_file(PyObject*, PyObject* args) {
-    const char* path;
+static PyObject *py_read_file(PyObject *, PyObject *args) {
+    const char *path;
     if (!PyArg_ParseTuple(args, "s", &path))
         return nullptr;
     std::string out;
@@ -48,16 +49,16 @@ static PyObject* py_read_file(PyObject*, PyObject* args) {
     return PyBytes_FromStringAndSize(out.data(), out.size());
 }
 
-static PyObject* py_get_version(PyObject*, PyObject*) {
+static PyObject *py_get_version(PyObject *, PyObject *) {
     std::string ver = vcfx::get_version();
     return PyUnicode_FromString(ver.c_str());
 }
 
-static PyObject* py_read_stream(PyObject*, PyObject* args) {
+static PyObject *py_read_stream(PyObject *, PyObject *args) {
     Py_buffer buf;
     if (!PyArg_ParseTuple(args, "y*", &buf))
         return nullptr;
-    std::string data(static_cast<const char*>(buf.buf), buf.len);
+    std::string data(static_cast<const char *>(buf.buf), buf.len);
     PyBuffer_Release(&buf);
     std::istringstream ss(data);
     std::string out;
@@ -73,20 +74,11 @@ static PyMethodDef VcfxMethods[] = {
     {"split", py_split, METH_VARARGS, "Split a string on the given delimiter"},
     {"read_file_maybe_compressed", py_read_file, METH_VARARGS,
      "Read a (possibly compressed) file and return its contents"},
-    {"read_maybe_compressed", py_read_stream, METH_VARARGS,
-     "Decompress bytes if needed and return the contents"},
+    {"read_maybe_compressed", py_read_stream, METH_VARARGS, "Decompress bytes if needed and return the contents"},
     {"get_version", py_get_version, METH_NOARGS, "Return VCFX version string"},
-    {nullptr, nullptr, 0, nullptr}
-};
+    {nullptr, nullptr, 0, nullptr}};
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_vcfx",
-    "Python bindings for VCFX helper functions",
-    -1,
-    VcfxMethods
-};
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT, "_vcfx", "Python bindings for VCFX helper functions", -1,
+                                       VcfxMethods};
 
-PyMODINIT_FUNC PyInit__vcfx(void) {
-    return PyModule_Create(&moduledef);
-}
+PyMODINIT_FUNC PyInit__vcfx(void) { return PyModule_Create(&moduledef); }

--- a/src/VCFX_af_subsetter/VCFX_af_subsetter.cpp
+++ b/src/VCFX_af_subsetter/VCFX_af_subsetter.cpp
@@ -1,12 +1,12 @@
-#include "vcfx_core.h"
 #include "VCFX_af_subsetter.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 
-int VCFXAfSubsetter::run(int argc, char* argv[]) {
+int VCFXAfSubsetter::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
@@ -14,39 +14,37 @@ int VCFXAfSubsetter::run(int argc, char* argv[]) {
     double maxAF = 1.0;
 
     static struct option long_options[] = {
-        {"help",      no_argument,       0, 'h'},
-        {"af-filter", required_argument, 0, 'a'},
-        {0,           0,                 0,  0 }
-    };
+        {"help", no_argument, 0, 'h'}, {"af-filter", required_argument, 0, 'a'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "ha:", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'a': {
-                std::string range(optarg);
-                size_t dashPos = range.find('-');
-                if (dashPos == std::string::npos) {
-                    std::cerr << "Error: Invalid AF range format. Use <minAF>-<maxAF>.\n";
-                    displayHelp();
-                    return 1;
-                }
-                try {
-                    minAF = std::stod(range.substr(0, dashPos));
-                    maxAF = std::stod(range.substr(dashPos + 1));
-                    if (minAF < 0.0 || maxAF > 1.0 || minAF > maxAF) {
-                        throw std::invalid_argument("AF values out of range or minAF > maxAF.");
-                    }
-                } catch (const std::invalid_argument&) {
-                    std::cerr << "Error: Invalid AF range values. Ensure they are numbers between 0.0 and 1.0 with minAF <= maxAF.\n";
-                    displayHelp();
-                    return 1;
-                }
-                break;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'a': {
+            std::string range(optarg);
+            size_t dashPos = range.find('-');
+            if (dashPos == std::string::npos) {
+                std::cerr << "Error: Invalid AF range format. Use <minAF>-<maxAF>.\n";
+                displayHelp();
+                return 1;
             }
-            default:
-                showHelp = true;
+            try {
+                minAF = std::stod(range.substr(0, dashPos));
+                maxAF = std::stod(range.substr(dashPos + 1));
+                if (minAF < 0.0 || maxAF > 1.0 || minAF > maxAF) {
+                    throw std::invalid_argument("AF values out of range or minAF > maxAF.");
+                }
+            } catch (const std::invalid_argument &) {
+                std::cerr << "Error: Invalid AF range values. Ensure they are numbers between 0.0 and 1.0 with minAF "
+                             "<= maxAF.\n";
+                displayHelp();
+                return 1;
+            }
+            break;
+        }
+        default:
+            showHelp = true;
         }
     }
 
@@ -72,7 +70,7 @@ void VCFXAfSubsetter::displayHelp() {
               << "  VCFX_af_subsetter --af-filter 0.01-0.05 < input.vcf > subsetted.vcf\n";
 }
 
-bool VCFXAfSubsetter::parseAF(const std::string& infoField, std::vector<double>& afValues) {
+bool VCFXAfSubsetter::parseAF(const std::string &infoField, std::vector<double> &afValues) {
     // Find "AF=" in the INFO string
     size_t pos = infoField.find("AF=");
     if (pos == std::string::npos) {
@@ -82,9 +80,7 @@ bool VCFXAfSubsetter::parseAF(const std::string& infoField, std::vector<double>&
     // Extract substring up to the next semicolon or end of string
     size_t start = pos + 3; // skip 'AF='
     size_t end = infoField.find(';', start);
-    std::string afStr = (end == std::string::npos)
-                        ? infoField.substr(start)
-                        : infoField.substr(start, end - start);
+    std::string afStr = (end == std::string::npos) ? infoField.substr(start) : infoField.substr(start, end - start);
 
     // Split by comma (to handle multi-allelic AF like "0.2,0.8")
     std::stringstream ss(afStr);
@@ -100,7 +96,7 @@ bool VCFXAfSubsetter::parseAF(const std::string& infoField, std::vector<double>&
     return !afValues.empty();
 }
 
-void VCFXAfSubsetter::subsetByAlleleFrequency(std::istream& in, std::ostream& out, double minAF, double maxAF) {
+void VCFXAfSubsetter::subsetByAlleleFrequency(std::istream &in, std::ostream &out, double minAF, double maxAF) {
     std::string line;
     while (std::getline(in, line)) {
         if (line.empty()) {
@@ -124,8 +120,7 @@ void VCFXAfSubsetter::subsetByAlleleFrequency(std::istream& in, std::ostream& ou
         }
 
         if (fields.size() < 8) {
-            std::cerr << "Warning: Skipping invalid VCF line (less than 8 fields): "
-                      << line << "\n";
+            std::cerr << "Warning: Skipping invalid VCF line (less than 8 fields): " << line << "\n";
             continue;
         }
 
@@ -133,8 +128,7 @@ void VCFXAfSubsetter::subsetByAlleleFrequency(std::istream& in, std::ostream& ou
         std::string info = fields[7];
         std::vector<double> afValues;
         if (!parseAF(info, afValues)) {
-            std::cerr << "Warning: AF not found or invalid in INFO field. Skipping variant: "
-                      << line << "\n";
+            std::cerr << "Warning: AF not found or invalid in INFO field. Skipping variant: " << line << "\n";
             continue;
         }
 
@@ -156,10 +150,17 @@ void VCFXAfSubsetter::subsetByAlleleFrequency(std::istream& in, std::ostream& ou
 //
 // Typical main():
 //
-static void show_help() { VCFXAfSubsetter obj; char arg0[] = "VCFX_af_subsetter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXAfSubsetter obj;
+    char arg0[] = "VCFX_af_subsetter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_af_subsetter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_af_subsetter", show_help))
+        return 0;
     VCFXAfSubsetter afSubsetter;
     return afSubsetter.run(argc, argv);
 }

--- a/src/VCFX_af_subsetter/VCFX_af_subsetter.h
+++ b/src/VCFX_af_subsetter/VCFX_af_subsetter.h
@@ -7,19 +7,19 @@
 
 // VCFXAfSubsetter: Header file for Alternate Allele Frequency Subsetter Tool
 class VCFXAfSubsetter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Subsets VCF input based on alternate allele frequency range
-    void subsetByAlleleFrequency(std::istream& in, std::ostream& out, double minAF, double maxAF);
+    void subsetByAlleleFrequency(std::istream &in, std::ostream &out, double minAF, double maxAF);
 
     // Parses the AF values from the INFO field (handles multi-allelic AF as comma-delimited)
-    bool parseAF(const std::string& infoField, std::vector<double>& afValues);
+    bool parseAF(const std::string &infoField, std::vector<double> &afValues);
 };
 
 #endif // VCFX_AF_SUBSETTER_H

--- a/src/VCFX_alignment_checker/VCFX_alignment_checker.h
+++ b/src/VCFX_alignment_checker/VCFX_alignment_checker.h
@@ -1,37 +1,37 @@
 #ifndef VCFX_ALIGNMENT_CHECKER_H
 #define VCFX_ALIGNMENT_CHECKER_H
 
+#include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
-#include <fstream>
+#include <vector>
 
 // VCFXAlignmentChecker: Header file for Reference Alignment Discrepancy Finder Tool
 class VCFXAlignmentChecker {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Loads the reference genome from a FASTA file
-    bool loadReferenceGenome(const std::string& path);
+    bool loadReferenceGenome(const std::string &path);
 
     // Checks discrepancies between VCF variants and the in-memory reference genome
-    void checkDiscrepancies(std::istream& vcfIn, std::ostream& out);
+    void checkDiscrepancies(std::istream &vcfIn, std::ostream &out);
 
     // Retrieves the reference base(s) from the reference genome at a specific position
-    std::string getReferenceBases(const std::string& chrom, int pos, int length = 1);
+    std::string getReferenceBases(const std::string &chrom, int pos, int length = 1);
 
     // Stores the reference genome sequences, keyed by normalized chromosome name
     struct FastaIndexEntry {
-        std::streampos offset = 0;     // file offset to first base
-        std::size_t   length = 0;      // total bases in sequence
-        std::size_t   basesPerLine = 0;    // number of bases per line in FASTA
-        std::size_t   bytesPerLine = 0;    // bytes per line including newline
+        std::streampos offset = 0;    // file offset to first base
+        std::size_t length = 0;       // total bases in sequence
+        std::size_t basesPerLine = 0; // number of bases per line in FASTA
+        std::size_t bytesPerLine = 0; // bytes per line including newline
     };
 
     std::unordered_map<std::string, FastaIndexEntry> referenceIndex;
@@ -39,7 +39,7 @@ private:
     std::string referencePath;
 
     // Helper function to convert chromosome names to a consistent format
-    std::string normalizeChromosome(const std::string& chrom);
+    std::string normalizeChromosome(const std::string &chrom);
 };
 
 #endif // VCFX_ALIGNMENT_CHECKER_H

--- a/src/VCFX_allele_balance_calc/VCFX_allele_balance_calc.cpp
+++ b/src/VCFX_allele_balance_calc/VCFX_allele_balance_calc.cpp
@@ -1,12 +1,12 @@
 #include "vcfx_core.h"
 // VCFX_allele_balance_calc.cpp
 
-#include <iostream>
-#include <string>
-#include <sstream>
-#include <vector>
-#include <unordered_map>
 #include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // ---------------------------------------------------------------
 // Header / Declarations
@@ -17,14 +17,14 @@ struct AlleleBalanceArguments {
 
 // Forward declarations
 void printHelp();
-bool parseArguments(int argc, char* argv[], AlleleBalanceArguments& args);
-bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBalanceArguments& args);
-double computeAlleleBalance(const std::string& genotype);
+bool parseArguments(int argc, char *argv[], AlleleBalanceArguments &args);
+bool calculateAlleleBalance(std::istream &in, std::ostream &out, const AlleleBalanceArguments &args);
+double computeAlleleBalance(const std::string &genotype);
 
 // ---------------------------------------------------------------
 // Utility Functions
 // ---------------------------------------------------------------
-static std::vector<std::string> splitString(const std::string& str, char delimiter) {
+static std::vector<std::string> splitString(const std::string &str, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string temp;
@@ -36,26 +36,25 @@ static std::vector<std::string> splitString(const std::string& str, char delimit
 
 // Print help message
 void printHelp() {
-    std::cout 
-        << "VCFX_allele_balance_calc\n"
-        << "Usage: VCFX_allele_balance_calc [OPTIONS] < input.vcf > allele_balance.tsv\n\n"
-        << "Options:\n"
-        << "  --samples, -s \"Sample1 Sample2\"   Specify the sample names to calculate allele balance for.\n"
-        << "  --help, -h                        Display this help message and exit.\n\n"
-        << "Description:\n"
-        << "  Calculates the allele balance (ratio of reference to alternate alleles) for each sample.\n"
-        << "  Allele balance is computed as (#RefAlleles / #AltAlleles), using the genotype field.\n"
-        << "  This simple logic treats all non-zero alleles as 'alt' and 0 as 'ref',\n"
-        << "  so multi-allelic sites are lumped into an overall alt count.\n\n"
-        << "Examples:\n"
-        << "  1) Calculate allele balance for SampleA and SampleB:\n"
-        << "     ./VCFX_allele_balance_calc --samples \"SampleA SampleB\" < input.vcf > allele_balance.tsv\n\n"
-        << "  2) Calculate allele balance for all samples:\n"
-        << "     ./VCFX_allele_balance_calc < input.vcf > allele_balance_all.tsv\n\n";
+    std::cout << "VCFX_allele_balance_calc\n"
+              << "Usage: VCFX_allele_balance_calc [OPTIONS] < input.vcf > allele_balance.tsv\n\n"
+              << "Options:\n"
+              << "  --samples, -s \"Sample1 Sample2\"   Specify the sample names to calculate allele balance for.\n"
+              << "  --help, -h                        Display this help message and exit.\n\n"
+              << "Description:\n"
+              << "  Calculates the allele balance (ratio of reference to alternate alleles) for each sample.\n"
+              << "  Allele balance is computed as (#RefAlleles / #AltAlleles), using the genotype field.\n"
+              << "  This simple logic treats all non-zero alleles as 'alt' and 0 as 'ref',\n"
+              << "  so multi-allelic sites are lumped into an overall alt count.\n\n"
+              << "Examples:\n"
+              << "  1) Calculate allele balance for SampleA and SampleB:\n"
+              << "     ./VCFX_allele_balance_calc --samples \"SampleA SampleB\" < input.vcf > allele_balance.tsv\n\n"
+              << "  2) Calculate allele balance for all samples:\n"
+              << "     ./VCFX_allele_balance_calc < input.vcf > allele_balance_all.tsv\n\n";
 }
 
 // Parse command-line arguments
-bool parseArguments(int argc, char* argv[], AlleleBalanceArguments& args) {
+bool parseArguments(int argc, char *argv[], AlleleBalanceArguments &args) {
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if ((arg == "--samples" || arg == "-s") && i + 1 < argc) {
@@ -69,12 +68,10 @@ bool parseArguments(int argc, char* argv[], AlleleBalanceArguments& args) {
                 // right trim
                 sample.erase(sample.find_last_not_of(" \t\n\r\f\v") + 1);
             }
-        }
-        else if (arg == "--help" || arg == "-h") {
+        } else if (arg == "--help" || arg == "-h") {
             printHelp();
             std::exit(0);
-        }
-        else {
+        } else {
             std::cerr << "Warning: Unrecognized argument '" << arg << "'.\n";
         }
     }
@@ -85,7 +82,7 @@ bool parseArguments(int argc, char* argv[], AlleleBalanceArguments& args) {
 // If genotype is "0/0", result= ref_count / alt_count => 2 / 0 => 0.0
 // If genotype is "0/1", result= 1 / 1 => 1.0
 // If genotype is "1/2", result= 0 / 2 => 0.0, etc.
-double computeAlleleBalance(const std::string& genotype) {
+double computeAlleleBalance(const std::string &genotype) {
     if (genotype.empty() || genotype == "." || genotype == "./." || genotype == ".|.") {
         return -1.0; // missing genotype
     }
@@ -93,13 +90,14 @@ double computeAlleleBalance(const std::string& genotype) {
     // Split by '/' or '|'. For a simple approach, we can replace '|' with '/' and split on '/':
     std::string g = genotype;
     for (auto &ch : g) {
-        if (ch == '|') ch = '/';
+        if (ch == '|')
+            ch = '/';
     }
     auto alleles = splitString(g, '/');
 
     int ref_count = 0;
     int alt_count = 0;
-    for (const auto& allele : alleles) {
+    for (const auto &allele : alleles) {
         if (allele == "0") {
             ++ref_count;
         } else if (allele != "." && !allele.empty()) {
@@ -108,15 +106,17 @@ double computeAlleleBalance(const std::string& genotype) {
     }
 
     // If alt_count is 0 but we have some reference calls, ratio is 0.0
-    if (alt_count == 0 && ref_count > 0) return 0.0;
+    if (alt_count == 0 && ref_count > 0)
+        return 0.0;
     // If no meaningful data, return -1
-    if (ref_count + alt_count == 0) return -1.0;
+    if (ref_count + alt_count == 0)
+        return -1.0;
 
     return static_cast<double>(ref_count) / alt_count;
 }
 
 // Main function to read VCF, parse genotypes, and calculate allele balance
-bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBalanceArguments& args) {
+bool calculateAlleleBalance(std::istream &in, std::ostream &out, const AlleleBalanceArguments &args) {
     std::string line;
     bool headerFound = false;
     std::vector<std::string> headerFields;
@@ -144,7 +144,7 @@ bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBal
                 }
                 // If user specified samples, pick them out; otherwise take all
                 if (!args.samples.empty()) {
-                    for (const auto& sample : args.samples) {
+                    for (const auto &sample : args.samples) {
                         auto it = sampleMap.find(sample);
                         if (it == sampleMap.end()) {
                             std::cerr << "Error: Sample '" << sample << "' not found in VCF header.\n";
@@ -178,10 +178,10 @@ bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBal
 
         // Basic VCF columns
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
-        const std::string &id    = fields[2];
-        const std::string &ref   = fields[3];
-        const std::string &alt   = fields[4];
+        const std::string &pos = fields[1];
+        const std::string &id = fields[2];
+        const std::string &ref = fields[3];
+        const std::string &alt = fields[4];
         // The genotype info starts at index 9
 
         // Calculate AB for each requested sample
@@ -192,9 +192,9 @@ bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBal
             }
             const std::string &genotypeStr = fields[idx];
             // genotype is typically the first colon-delimited field
-            // e.g. genotypeStr = "0/1:..." 
+            // e.g. genotypeStr = "0/1:..."
             // but we only need the actual genotype for computing ratio
-            // split on ':' 
+            // split on ':'
             auto subFields = splitString(genotypeStr, ':');
             if (subFields.empty()) {
                 continue;
@@ -205,16 +205,10 @@ bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBal
             std::string abStr = (ab < 0.0) ? "NA" : std::to_string(ab);
 
             // The sample name is from the VCF header
-            std::string sampleName = (idx < static_cast<int>(headerFields.size()))
-                                     ? headerFields[idx]
-                                     : ("Sample_" + std::to_string(idx));
+            std::string sampleName =
+                (idx < static_cast<int>(headerFields.size())) ? headerFields[idx] : ("Sample_" + std::to_string(idx));
 
-            out << chrom << "\t"
-                << pos   << "\t"
-                << id    << "\t"
-                << ref   << "\t"
-                << alt   << "\t"
-                << sampleName << "\t"
+            out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << sampleName << "\t"
                 << abStr << "\n";
         }
     }
@@ -226,8 +220,9 @@ bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBal
 // ---------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_balance_calc", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_balance_calc", show_help))
+        return 0;
     AlleleBalanceArguments args;
     parseArguments(argc, argv, args);
 

--- a/src/VCFX_allele_balance_calc/VCFX_allele_balance_calc.h
+++ b/src/VCFX_allele_balance_calc/VCFX_allele_balance_calc.h
@@ -14,18 +14,18 @@ struct AlleleBalanceArguments {
 };
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], AlleleBalanceArguments& args);
+bool parseArguments(int argc, char *argv[], AlleleBalanceArguments &args);
 
 // Function to split a string by a delimiter
-std::vector<std::string> splitString(const std::string& str, char delimiter);
+std::vector<std::string> splitString(const std::string &str, char delimiter);
 
 // Function to process VCF and calculate allele balance
-bool calculateAlleleBalance(std::istream& in, std::ostream& out, const AlleleBalanceArguments& args);
+bool calculateAlleleBalance(std::istream &in, std::ostream &out, const AlleleBalanceArguments &args);
 
 // Function to extract genotype from genotype string
-std::string extractGenotype(const std::string& genotype_str);
+std::string extractGenotype(const std::string &genotype_str);
 
 // Function to calculate allele balance ratio
-double computeAlleleBalance(const std::string& genotype);
+double computeAlleleBalance(const std::string &genotype);
 
 #endif // VCFX_ALLELE_BALANCE_CALC_H

--- a/src/VCFX_allele_balance_filter/VCFX_allele_balance_filter.h
+++ b/src/VCFX_allele_balance_filter/VCFX_allele_balance_filter.h
@@ -2,25 +2,25 @@
 #define VCFX_ALLELE_BALANCE_FILTER_H
 
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 // VCFXAlleleBalanceFilter: Header file for Allele Balance Filter Tool
 class VCFXAlleleBalanceFilter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Filters VCF input based on allele balance threshold
-    void filterByAlleleBalance(std::istream& in, std::ostream& out, double threshold);
+    void filterByAlleleBalance(std::istream &in, std::ostream &out, double threshold);
 
     // Parses the genotype to calculate allele balance
-    double calculateAlleleBalance(const std::string& genotype);
+    double calculateAlleleBalance(const std::string &genotype);
 };
 
 #endif // VCFX_ALLELE_BALANCE_FILTER_H

--- a/src/VCFX_allele_counter/VCFX_allele_counter.cpp
+++ b/src/VCFX_allele_counter/VCFX_allele_counter.cpp
@@ -1,10 +1,10 @@
 #include "vcfx_core.h"
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <unordered_map>
-#include <cstdlib>
+#include <vector>
 
 // ---------------------------------------------------------------------
 // Structures and Declarations
@@ -14,56 +14,53 @@ struct AlleleCounterArguments {
 };
 
 static void printHelp();
-static bool parseArguments(int argc, char* argv[], AlleleCounterArguments& args);
-static std::vector<std::string> splitString(const std::string& str, char delimiter);
-static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounterArguments& args);
+static bool parseArguments(int argc, char *argv[], AlleleCounterArguments &args);
+static std::vector<std::string> splitString(const std::string &str, char delimiter);
+static bool countAlleles(std::istream &in, std::ostream &out, const AlleleCounterArguments &args);
 
 // ---------------------------------------------------------------------
 // printHelp
 // ---------------------------------------------------------------------
 static void printHelp() {
-    std::cout
-        << "VCFX_allele_counter\n"
-        << "Usage: VCFX_allele_counter [OPTIONS] < input.vcf > allele_counts.tsv\n\n"
-        << "Options:\n"
-        << "  --samples, -s \"Sample1 Sample2\"   Specify the sample names to include.\n"
-        << "                                     If not specified, all samples are processed.\n"
-        << "  --help, -h                        Display this help message and exit.\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin and outputs a TSV file with the columns:\n"
-        << "    CHROM  POS  ID  REF  ALT  Sample  Ref_Count  Alt_Count\n\n"
-        << "  Each sample for each variant is listed. Alleles are determined by\n"
-        << "  genotype strings (GT). This code treats any numeric allele that is\n"
-        << "  not '0' as ALT, e.g. '1' or '2' or '3' => alt.\n\n"
-        << "Examples:\n"
-        << "  1) Count alleles for SampleA and SampleB:\n"
-        << "     VCFX_allele_counter --samples \"SampleA SampleB\" < input.vcf > allele_counts.tsv\n\n"
-        << "  2) Count alleles for all samples:\n"
-        << "     VCFX_allele_counter < input.vcf > allele_counts_all.tsv\n";
+    std::cout << "VCFX_allele_counter\n"
+              << "Usage: VCFX_allele_counter [OPTIONS] < input.vcf > allele_counts.tsv\n\n"
+              << "Options:\n"
+              << "  --samples, -s \"Sample1 Sample2\"   Specify the sample names to include.\n"
+              << "                                     If not specified, all samples are processed.\n"
+              << "  --help, -h                        Display this help message and exit.\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin and outputs a TSV file with the columns:\n"
+              << "    CHROM  POS  ID  REF  ALT  Sample  Ref_Count  Alt_Count\n\n"
+              << "  Each sample for each variant is listed. Alleles are determined by\n"
+              << "  genotype strings (GT). This code treats any numeric allele that is\n"
+              << "  not '0' as ALT, e.g. '1' or '2' or '3' => alt.\n\n"
+              << "Examples:\n"
+              << "  1) Count alleles for SampleA and SampleB:\n"
+              << "     VCFX_allele_counter --samples \"SampleA SampleB\" < input.vcf > allele_counts.tsv\n\n"
+              << "  2) Count alleles for all samples:\n"
+              << "     VCFX_allele_counter < input.vcf > allele_counts_all.tsv\n";
 }
 
 // ---------------------------------------------------------------------
 // parseArguments
 // ---------------------------------------------------------------------
-static bool parseArguments(int argc, char* argv[], AlleleCounterArguments& args) {
+static bool parseArguments(int argc, char *argv[], AlleleCounterArguments &args) {
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if ((arg == "--samples" || arg == "-s") && i + 1 < argc) {
             std::string samplesStr = argv[++i];
             args.samples = splitString(samplesStr, ' ');
             // Trim whitespace from each sample name
-            for (auto& sample : args.samples) {
+            for (auto &sample : args.samples) {
                 // left trim
                 sample.erase(0, sample.find_first_not_of(" \t\n\r\f\v"));
                 // right trim
                 sample.erase(sample.find_last_not_of(" \t\n\r\f\v") + 1);
             }
-        }
-        else if (arg == "--help" || arg == "-h") {
+        } else if (arg == "--help" || arg == "-h") {
             printHelp();
             std::exit(0);
-        }
-        else {
+        } else {
             std::cerr << "Warning: Unrecognized argument '" << arg << "'.\n";
         }
     }
@@ -73,7 +70,7 @@ static bool parseArguments(int argc, char* argv[], AlleleCounterArguments& args)
 // ---------------------------------------------------------------------
 // splitString
 // ---------------------------------------------------------------------
-static std::vector<std::string> splitString(const std::string& str, char delimiter) {
+static std::vector<std::string> splitString(const std::string &str, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string temp;
@@ -86,7 +83,7 @@ static std::vector<std::string> splitString(const std::string& str, char delimit
 // ---------------------------------------------------------------------
 // countAlleles
 // ---------------------------------------------------------------------
-static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounterArguments& args) {
+static bool countAlleles(std::istream &in, std::ostream &out, const AlleleCounterArguments &args) {
     std::string line;
     std::vector<std::string> headerFields;
     bool foundChromHeader = false;
@@ -120,7 +117,7 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
                 // Decide which samples to process
                 if (!args.samples.empty()) {
                     // Use only user-specified samples
-                    for (const auto& s : args.samples) {
+                    for (const auto &s : args.samples) {
                         auto it = sampleMap.find(s);
                         if (it == sampleMap.end()) {
                             std::cerr << "Error: Sample '" << s << "' not found in VCF header.\n";
@@ -149,36 +146,33 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
         // Split VCF data line
         auto fields = splitString(line, '\t');
         if (fields.size() < 9) {
-            std::cerr << "Warning: Skipping invalid VCF line with fewer than 9 fields:\n" 
-                      << line << "\n";
+            std::cerr << "Warning: Skipping invalid VCF line with fewer than 9 fields:\n" << line << "\n";
             continue;
         }
 
         // Basic columns
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
-        const std::string &id    = fields[2];
-        const std::string &ref   = fields[3];
-        const std::string &alt   = fields[4];
+        const std::string &pos = fields[1];
+        const std::string &id = fields[2];
+        const std::string &ref = fields[3];
+        const std::string &alt = fields[4];
 
         // For each chosen sample, parse genotype
         for (int sIndex : sampleIndices) {
             if (sIndex >= (int)fields.size()) {
-                std::cerr << "Warning: Sample index " << sIndex << " out of range for line:\n"
-                          << line << "\n";
+                std::cerr << "Warning: Sample index " << sIndex << " out of range for line:\n" << line << "\n";
                 continue;
             }
             const std::string &sampleField = fields[sIndex];
 
             // genotype is the portion before the first ':'
             size_t colonPos = sampleField.find(':');
-            std::string gt = (colonPos == std::string::npos)
-                             ? sampleField
-                             : sampleField.substr(0, colonPos);
+            std::string gt = (colonPos == std::string::npos) ? sampleField : sampleField.substr(0, colonPos);
 
             // Replace '|' with '/' for a uniform split
             for (auto &c : gt) {
-                if (c == '|') c = '/';
+                if (c == '|')
+                    c = '/';
             }
             auto alleles = splitString(gt, '/');
             if (alleles.empty()) {
@@ -188,7 +182,7 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
 
             int refCount = 0;
             int altCount = 0;
-            for (auto & allele : alleles) {
+            for (auto &allele : alleles) {
                 // Skip empty or '.' allele
                 if (allele.empty() || allele == ".") {
                     continue;
@@ -196,7 +190,10 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
                 // If numeric & "0" => ref, else alt
                 bool numeric = true;
                 for (char c : allele) {
-                    if (!isdigit(c)) { numeric = false; break; }
+                    if (!isdigit(c)) {
+                        numeric = false;
+                        break;
+                    }
                 }
                 if (!numeric) {
                     // e.g. unknown character => skip
@@ -211,19 +208,12 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
             }
 
             // The sample's name
-            std::string sampleName = (sIndex < (int)headerFields.size())
-                                     ? headerFields[sIndex]
-                                     : ("Sample_"+std::to_string(sIndex));
+            std::string sampleName =
+                (sIndex < (int)headerFields.size()) ? headerFields[sIndex] : ("Sample_" + std::to_string(sIndex));
 
             // Output as TSV row
-            out << chrom << "\t"
-                << pos   << "\t"
-                << id    << "\t"
-                << ref   << "\t"
-                << alt   << "\t"
-                << sampleName << "\t"
-                << refCount   << "\t"
-                << altCount   << "\n";
+            out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << sampleName << "\t"
+                << refCount << "\t" << altCount << "\n";
         }
     }
     return true;
@@ -234,8 +224,9 @@ static bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounte
 // ---------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_counter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_counter", show_help))
+        return 0;
     AlleleCounterArguments args;
     parseArguments(argc, argv, args);
 

--- a/src/VCFX_allele_counter/VCFX_allele_counter.h
+++ b/src/VCFX_allele_counter/VCFX_allele_counter.h
@@ -14,15 +14,15 @@ struct AlleleCounterArguments {
 };
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], AlleleCounterArguments& args);
+bool parseArguments(int argc, char *argv[], AlleleCounterArguments &args);
 
 // Function to split a string by a delimiter
-std::vector<std::string> splitString(const std::string& str, char delimiter);
+std::vector<std::string> splitString(const std::string &str, char delimiter);
 
 // Function to process VCF and count alleles
-bool countAlleles(std::istream& in, std::ostream& out, const AlleleCounterArguments& args);
+bool countAlleles(std::istream &in, std::ostream &out, const AlleleCounterArguments &args);
 
 // Function to extract genotype from genotype string
-std::string extractGenotype(const std::string& genotype_str);
+std::string extractGenotype(const std::string &genotype_str);
 
 #endif // VCFX_ALLELE_COUNTER_H

--- a/src/VCFX_allele_freq_calc/VCFX_allele_freq_calc.cpp
+++ b/src/VCFX_allele_freq_calc/VCFX_allele_freq_calc.cpp
@@ -1,34 +1,33 @@
 #include "vcfx_core.h"
+#include <cctype>
+#include <cstdlib>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
-#include <iomanip>
-#include <cstdlib>
-#include <cctype>
 
 // ---------------------------------------------------------
 // Print help message
 // ---------------------------------------------------------
 static void printHelp() {
-    std::cout 
-        << "VCFX_allele_freq_calc\n"
-        << "Usage: VCFX_allele_freq_calc [OPTIONS]\n\n"
-        << "Options:\n"
-        << "  --help, -h   Display this help message and exit.\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin and outputs a TSV file:\n"
-        << "    CHROM  POS  ID  REF  ALT  Allele_Frequency\n\n"
-        << "  Allele frequency is computed as (#ALT alleles / total #alleles),\n"
-        << "  counting any non-zero numeric allele (1,2,3,...) as ALT.\n\n"
-        << "Example:\n"
-        << "  ./VCFX_allele_freq_calc < input.vcf > allele_frequencies.tsv\n";
+    std::cout << "VCFX_allele_freq_calc\n"
+              << "Usage: VCFX_allele_freq_calc [OPTIONS]\n\n"
+              << "Options:\n"
+              << "  --help, -h   Display this help message and exit.\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin and outputs a TSV file:\n"
+              << "    CHROM  POS  ID  REF  ALT  Allele_Frequency\n\n"
+              << "  Allele frequency is computed as (#ALT alleles / total #alleles),\n"
+              << "  counting any non-zero numeric allele (1,2,3,...) as ALT.\n\n"
+              << "Example:\n"
+              << "  ./VCFX_allele_freq_calc < input.vcf > allele_frequencies.tsv\n";
 }
 
 // ---------------------------------------------------------
 // Utility: split a string by a delimiter
 // ---------------------------------------------------------
-static std::vector<std::string> split(const std::string& s, char delimiter) {
+static std::vector<std::string> split(const std::string &s, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(s);
     std::string token;
@@ -41,18 +40,19 @@ static std::vector<std::string> split(const std::string& s, char delimiter) {
 // ---------------------------------------------------------
 // parseGenotype: counts how many are alt vs total among numeric alleles
 // ---------------------------------------------------------
-static void parseGenotype(const std::string& genotype, int &alt_count, int &total_count) {
+static void parseGenotype(const std::string &genotype, int &alt_count, int &total_count) {
     // e.g. genotype might be "0/1" or "2|3", etc.
     // First, unify the separators by replacing '|' with '/'
     std::string gt = genotype;
     for (char &c : gt) {
-        if (c == '|') c = '/';
+        if (c == '|')
+            c = '/';
     }
 
     // Split on '/'
     auto alleles = split(gt, '/');
 
-    for (const auto & allele : alleles) {
+    for (const auto &allele : alleles) {
         if (allele.empty() || allele == ".") {
             // Skip missing
             continue;
@@ -84,7 +84,7 @@ static void parseGenotype(const std::string& genotype, int &alt_count, int &tota
 // ---------------------------------------------------------
 // Main calculation: read VCF from 'in', write results to 'out'
 // ---------------------------------------------------------
-static void calculateAlleleFrequency(std::istream& in, std::ostream& out) {
+static void calculateAlleleFrequency(std::istream &in, std::ostream &out) {
     std::string line;
 
     // We'll track how many samples are in the VCF, though we only need it
@@ -115,27 +115,25 @@ static void calculateAlleleFrequency(std::istream& in, std::ostream& out) {
 
         // We expect #CHROM line before actual data lines
         if (!foundChromHeader) {
-            std::cerr << "Warning: Data line encountered before #CHROM header. Skipping line:\n"
-                      << line << "\n";
+            std::cerr << "Warning: Data line encountered before #CHROM header. Skipping line:\n" << line << "\n";
             continue;
         }
 
         // Split the data line
         auto fields = split(line, '\t');
         if (fields.size() < 9) {
-            std::cerr << "Warning: Skipping invalid VCF line (fewer than 9 fields):\n"
-                      << line << "\n";
+            std::cerr << "Warning: Skipping invalid VCF line (fewer than 9 fields):\n" << line << "\n";
             continue;
         }
 
         // Standard VCF columns:
         //  0:CHROM, 1:POS, 2:ID, 3:REF, 4:ALT, 5:QUAL, 6:FILTER, 7:INFO, 8:FORMAT, 9+:samples
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
-        const std::string &id    = fields[2];
-        const std::string &ref   = fields[3];
-        const std::string &alt   = fields[4];
-        const std::string &fmt   = fields[8];
+        const std::string &pos = fields[1];
+        const std::string &id = fields[2];
+        const std::string &ref = fields[3];
+        const std::string &alt = fields[4];
+        const std::string &fmt = fields[8];
 
         // Look for the "GT" field index in the FORMAT column
         auto formatFields = split(fmt, ':');
@@ -174,9 +172,8 @@ static void calculateAlleleFrequency(std::istream& in, std::ostream& out) {
         }
 
         // Print the row with a fixed decimal precision
-        out << chrom << "\t" << pos << "\t" << id << "\t"
-            << ref   << "\t" << alt << "\t"
-            << std::fixed << std::setprecision(4) << freq << "\n";
+        out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << std::fixed
+            << std::setprecision(4) << freq << "\n";
     }
 }
 
@@ -185,8 +182,9 @@ static void calculateAlleleFrequency(std::istream& in, std::ostream& out) {
 // ---------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_freq_calc", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_allele_freq_calc", show_help))
+        return 0;
     // Parse arguments for help
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_allele_freq_calc/VCFX_allele_freq_calc.h
+++ b/src/VCFX_allele_freq_calc/VCFX_allele_freq_calc.h
@@ -8,6 +8,6 @@
 void printHelp();
 
 // Function to perform allele frequency calculation on VCF records
-void calculateAlleleFrequency(std::istream& in, std::ostream& out);
+void calculateAlleleFrequency(std::istream &in, std::ostream &out);
 
 #endif // VCFX_ALLELE_FREQ_CALC_H

--- a/src/VCFX_ancestry_assigner/VCFX_ancestry_assigner.h
+++ b/src/VCFX_ancestry_assigner/VCFX_ancestry_assigner.h
@@ -3,27 +3,29 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 // VCFXAncestryAssigner: Header file for Ancestry Assignment Tool
 class VCFXAncestryAssigner {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Parses a single line from the frequency file
-    bool parseFrequencyLine(const std::string& line, std::string& chrom, int& pos, char& ref, char& alt, std::unordered_map<std::string, double>& freqMap, const std::vector<std::string>& populations);
+    bool parseFrequencyLine(const std::string &line, std::string &chrom, int &pos, char &ref, char &alt,
+                            std::unordered_map<std::string, double> &freqMap,
+                            const std::vector<std::string> &populations);
 
     // Loads ancestral frequencies from the provided input stream
-    bool loadAncestralFrequencies(std::istream& in);
+    bool loadAncestralFrequencies(std::istream &in);
 
     // Assigns ancestry to samples based on VCF input
-    void assignAncestry(std::istream& vcfIn, std::ostream& out);
+    void assignAncestry(std::istream &vcfIn, std::ostream &out);
 
     // Stores populations
     std::vector<std::string> populations;

--- a/src/VCFX_ancestry_inferrer/VCFX_ancestry_inferrer.cpp
+++ b/src/VCFX_ancestry_inferrer/VCFX_ancestry_inferrer.cpp
@@ -1,14 +1,14 @@
 #include "vcfx_core.h"
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <string>
-#include <vector>
-#include <unordered_map>
 #include <algorithm>
 #include <cstdlib>
+#include <fstream>
 #include <getopt.h>
+#include <iostream>
 #include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // ----------------------------------------------------
 // A helper struct for storing freq data by population
@@ -32,21 +32,21 @@ typedef std::unordered_map<std::string, std::unordered_map<std::string, double>>
 // Class: VCFXAncestryInferrer
 // ----------------------------------------------------
 class VCFXAncestryInferrer {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Show usage
     void displayHelp();
 
     // Load population frequencies from a file that has lines:
     // CHROM  POS  REF  ALT  POPULATION  FREQUENCY
-    bool loadPopulationFrequencies(const std::string& freqFilePath);
+    bool loadPopulationFrequencies(const std::string &freqFilePath);
 
     // Infer ancestry from VCF, returns true if successful
-    bool inferAncestry(std::istream& vcfInput, std::ostream& output);
+    bool inferAncestry(std::istream &vcfInput, std::ostream &output);
 
-private:
+  private:
     // Frequencies keyed by "chr:pos:ref:alt:pop"
     FrequencyMap freqData;
     // More efficient structure: variant key -> (pop -> freq)
@@ -58,10 +58,17 @@ private:
 // ----------------------------------------------------
 // main() - create the inferrer and run
 // ----------------------------------------------------
-static void show_help() { VCFXAncestryInferrer obj; char arg0[] = "VCFX_ancestry_inferrer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXAncestryInferrer obj;
+    char arg0[] = "VCFX_ancestry_inferrer";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_ancestry_inferrer", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ancestry_inferrer", show_help))
+        return 0;
     VCFXAncestryInferrer inferrer;
     return inferrer.run(argc, argv);
 }
@@ -69,27 +76,24 @@ int main(int argc, char* argv[]) {
 // ----------------------------------------------------
 // run() - parse arguments, load freq, run inference
 // ----------------------------------------------------
-int VCFXAncestryInferrer::run(int argc, char* argv[]) {
+int VCFXAncestryInferrer::run(int argc, char *argv[]) {
     int opt;
     bool showHelp = false;
     std::string freqFilePath;
 
     static struct option longOpts[] = {
-        {"help",       no_argument,       0, 'h'},
-        {"frequency",  required_argument, 0, 'f'},
-        {0, 0, 0, 0}
-    };
+        {"help", no_argument, 0, 'h'}, {"frequency", required_argument, 0, 'f'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "hf:", longOpts, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'f':
-                freqFilePath = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'f':
+            freqFilePath = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -117,27 +121,26 @@ int VCFXAncestryInferrer::run(int argc, char* argv[]) {
 // displayHelp
 // ----------------------------------------------------
 void VCFXAncestryInferrer::displayHelp() {
-    std::cout 
-        << "VCFX_ancestry_inferrer: Infer population ancestry based on allele frequencies.\n\n"
-        << "Usage:\n"
-        << "  VCFX_ancestry_inferrer --frequency <freq_file> [options]\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from standard input and outputs a 2-column table:\n"
-        << "    Sample  Inferred_Population\n\n"
-        << "  The frequency file must have lines of the form:\n"
-        << "    CHROM  POS  REF  ALT  POPULATION  FREQUENCY\n"
-        << "  (tab-separated). For multi-allelic VCF sites, an ALT allele index 1\n"
-        << "  corresponds to the first item in the comma-separated ALT list,\n"
-        << "  index 2 => second ALT, etc.\n\n"
-        << "Example:\n"
-        << "  VCFX_ancestry_inferrer --frequency pop_frequencies.txt < input.vcf > ancestry_results.txt\n";
+    std::cout << "VCFX_ancestry_inferrer: Infer population ancestry based on allele frequencies.\n\n"
+              << "Usage:\n"
+              << "  VCFX_ancestry_inferrer --frequency <freq_file> [options]\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from standard input and outputs a 2-column table:\n"
+              << "    Sample  Inferred_Population\n\n"
+              << "  The frequency file must have lines of the form:\n"
+              << "    CHROM  POS  REF  ALT  POPULATION  FREQUENCY\n"
+              << "  (tab-separated). For multi-allelic VCF sites, an ALT allele index 1\n"
+              << "  corresponds to the first item in the comma-separated ALT list,\n"
+              << "  index 2 => second ALT, etc.\n\n"
+              << "Example:\n"
+              << "  VCFX_ancestry_inferrer --frequency pop_frequencies.txt < input.vcf > ancestry_results.txt\n";
 }
 
 // ----------------------------------------------------
 // loadPopulationFrequencies
 //   freq file lines: CHROM, POS, REF, ALT, POP, FREQUENCY
 // ----------------------------------------------------
-bool VCFXAncestryInferrer::loadPopulationFrequencies(const std::string& freqFilePath) {
+bool VCFXAncestryInferrer::loadPopulationFrequencies(const std::string &freqFilePath) {
     std::ifstream freqFile(freqFilePath);
     if (!freqFile.is_open()) {
         std::cerr << "Error: Cannot open frequency file: " << freqFilePath << "\n";
@@ -172,11 +175,11 @@ bool VCFXAncestryInferrer::loadPopulationFrequencies(const std::string& freqFile
         // Build a key: "chr:pos:ref:alt:pop"
         std::string key = chrom + ":" + pos + ":" + ref + ":" + alt + ":" + pop;
         freqData[key] = freq;
-        
+
         // Also store in the more efficient structure
         std::string variantKey = chrom + ":" + pos + ":" + ref + ":" + alt;
         variantPopFreqs[variantKey][pop] = freq;
-        
+
         // Add to the set of known populations
         populations.insert(pop);
     }
@@ -197,7 +200,7 @@ bool VCFXAncestryInferrer::loadPopulationFrequencies(const std::string& freqFile
 //      population score = sum of freq for each ALT allele
 //   4) after all lines, pick population with highest score
 // ----------------------------------------------------
-bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& out) {
+bool VCFXAncestryInferrer::inferAncestry(std::istream &vcfInput, std::ostream &out) {
     std::string line;
     bool foundChromHeader = false;
     std::vector<std::string> headerFields;
@@ -233,18 +236,18 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
                         headerFields.push_back(tok);
                     }
                 }
-                
+
                 // Validate header has at least the required fields
                 if (headerFields.size() < 9) {
                     std::cerr << "Error: Invalid VCF header format. Expected at least 9 columns.\n";
                     return false;
                 }
-                
+
                 // sample columns start at index 9
                 for (size_t c = 9; c < headerFields.size(); ++c) {
                     sampleNames.push_back(headerFields[c]);
                     // Initialize scores for each known population to 0
-                    for (const auto& pop : populations) {
+                    for (const auto &pop : populations) {
                         sampleScores[headerFields[c]][pop] = 0.0;
                     }
                 }
@@ -274,14 +277,14 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
             std::cerr << "Warning: Line " << lineNum << " has fewer than 10 columns, skipping.\n";
             continue;
         }
-        
+
         // Indices: 0=CHROM, 1=POS, 2=ID, 3=REF, 4=ALT, 5=QUAL, 6=FILTER, 7=INFO, 8=FORMAT, 9+ = samples
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
+        const std::string &pos = fields[1];
         // skip ID
-        const std::string &ref   = fields[3];
-        const std::string &altStr= fields[4];
-        const std::string &format= fields[8];
+        const std::string &ref = fields[3];
+        const std::string &altStr = fields[4];
+        const std::string &format = fields[8];
 
         // Split ALT by comma for multi-allelic
         std::vector<std::string> altAlleles;
@@ -292,7 +295,7 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
                 altAlleles.push_back(altTok);
             }
         }
-        
+
         // Validate ALT field
         if (altAlleles.empty()) {
             std::cerr << "Warning: Line " << lineNum << " has empty ALT field, skipping.\n";
@@ -327,7 +330,7 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
             // sample data is fields[9 + s]
             size_t sampleCol = 9 + s;
             if (sampleCol >= fields.size()) {
-                continue; 
+                continue;
             }
             const std::string &sampleData = fields[sampleCol];
 
@@ -360,13 +363,13 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
             if (alleleNums.empty()) {
                 continue;
             }
-            
+
             // For each allele: 0 => REF, 1 => altAlleles[0], 2 => altAlleles[1], etc.
             for (auto &aStr : alleleNums) {
                 if (aStr.empty() || aStr == ".") {
                     continue; // missing
                 }
-                
+
                 // Validate allele is numeric
                 bool numeric = true;
                 for (char c : aStr) {
@@ -378,42 +381,42 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
                 if (!numeric) {
                     continue;
                 }
-                
+
                 int aVal = std::stoi(aStr);
                 if (aVal == 0) {
-                    // REF allele, skip 
+                    // REF allele, skip
                     continue;
                 }
-                
+
                 if (aVal > 0 && (size_t)aVal <= altAlleles.size()) {
                     // This is an ALT allele
                     std::string actualAlt = altAlleles[aVal - 1];
-                    
+
                     // Build the variant key for lookup
                     std::string variantKey = chrom + ":" + pos + ":" + ref + ":" + actualAlt;
-                    
+
                     // Use the more efficient lookup structure
                     auto variantIt = variantPopFreqs.find(variantKey);
                     if (variantIt != variantPopFreqs.end()) {
-                        const auto& popFreqs = variantIt->second;
-                        
+                        const auto &popFreqs = variantIt->second;
+
                         // Find the population with the highest frequency
                         double bestFreq = -1.0;
                         std::string bestPop;
-                        
-                        for (const auto& popFreq : popFreqs) {
+
+                        for (const auto &popFreq : popFreqs) {
                             if (popFreq.second > bestFreq) {
                                 bestFreq = popFreq.second;
                                 bestPop = popFreq.first;
                             }
                         }
-                        
+
                         if (!bestPop.empty() && bestFreq >= 0.0) {
                             // Add the bestFreq to the sample's population score
                             sampleScores[sampleNames[s]][bestPop] += bestFreq;
                         }
                     }
-                } 
+                }
                 // Skip if aVal > altAlleles.size()
             }
         }
@@ -435,22 +438,20 @@ bool VCFXAncestryInferrer::inferAncestry(std::istream& vcfInput, std::ostream& o
             out << sName << "\tUnknown\n";
             continue;
         }
-        
+
         const auto &popMap = it->second;
         std::string bestPop = "Unknown";
         double bestScore = -1.0;
-        
+
         for (auto &ps : popMap) {
             if (ps.second > bestScore) {
                 bestScore = ps.second;
                 bestPop = ps.first;
             }
         }
-        
+
         out << sName << "\t" << bestPop << "\n";
     }
-    
+
     return true;
 }
-
-

--- a/src/VCFX_ancestry_inferrer/VCFX_ancestry_inferrer.h
+++ b/src/VCFX_ancestry_inferrer/VCFX_ancestry_inferrer.h
@@ -8,19 +8,19 @@
 
 // VCFXAncestryInferer: Header file for Ancestry Inference tool
 class VCFXAncestryInferer {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Loads population allele frequencies from a file
-    bool loadPopulationFrequencies(const std::string& freqFilePath);
+    bool loadPopulationFrequencies(const std::string &freqFilePath);
 
     // Infers ancestry for each sample based on allele frequencies
-    void inferAncestry(std::istream& vcfInput, std::ostream& ancestryOutput);
+    void inferAncestry(std::istream &vcfInput, std::ostream &ancestryOutput);
 
     // Structure to hold allele frequencies per population
     struct PopulationFrequencies {

--- a/src/VCFX_annotation_extractor/VCFX_annotation_extractor.cpp
+++ b/src/VCFX_annotation_extractor/VCFX_annotation_extractor.cpp
@@ -1,12 +1,12 @@
 #include "vcfx_core.h"
-#include <iostream>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <unordered_map>
 #include <algorithm>
 #include <cstdlib>
 #include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // --------------------------------------------------------------
 // A small struct to store command-line options
@@ -59,57 +59,54 @@ static std::unordered_map<std::string, std::string> parseInfoToMap(const std::st
 // Show usage/help
 // --------------------------------------------------------------
 static void printHelp() {
-    std::cout 
-        << "VCFX_annotation_extractor: Extract variant annotations from a VCF file.\n\n"
-        << "Usage:\n"
-        << "  VCFX_annotation_extractor --annotation-extract \"ANN,Gene\" < input.vcf > out.tsv\n\n"
-        << "Options:\n"
-        << "  -a, --annotation-extract   Comma-separated list of annotations to extract (e.g., ANN,Gene)\n"
-        << "  -h, --help                 Display this help message and exit\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin and prints a tab-delimited output. For multi-ALT\n"
-        << "  lines, each ALT allele is printed on its own line. If an annotation field (like\n"
-        << "  'ANN=') has multiple comma-separated sub-entries, we attempt to align them with\n"
-        << "  the ALT alleles in order.\n\n"
-        << "Example:\n"
-        << "  VCFX_annotation_extractor --annotation-extract \"ANN,Gene\" < input.vcf > out.tsv\n";
+    std::cout << "VCFX_annotation_extractor: Extract variant annotations from a VCF file.\n\n"
+              << "Usage:\n"
+              << "  VCFX_annotation_extractor --annotation-extract \"ANN,Gene\" < input.vcf > out.tsv\n\n"
+              << "Options:\n"
+              << "  -a, --annotation-extract   Comma-separated list of annotations to extract (e.g., ANN,Gene)\n"
+              << "  -h, --help                 Display this help message and exit\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin and prints a tab-delimited output. For multi-ALT\n"
+              << "  lines, each ALT allele is printed on its own line. If an annotation field (like\n"
+              << "  'ANN=') has multiple comma-separated sub-entries, we attempt to align them with\n"
+              << "  the ALT alleles in order.\n\n"
+              << "Example:\n"
+              << "  VCFX_annotation_extractor --annotation-extract \"ANN,Gene\" < input.vcf > out.tsv\n";
 }
 
 // --------------------------------------------------------------
 // parseArguments: fill in AnnotationOptions
 // --------------------------------------------------------------
-static bool parseArguments(int argc, char* argv[], AnnotationOptions &opts) {
+static bool parseArguments(int argc, char *argv[], AnnotationOptions &opts) {
     bool showHelp = false;
 
     static struct option long_options[] = {
-        {"annotation-extract", required_argument, 0, 'a'},
-        {"help",               no_argument,       0, 'h'},
-        {0,                    0,                 0,  0 }
-    };
+        {"annotation-extract", required_argument, 0, 'a'}, {"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while (true) {
         int optIdx = 0;
         int c = getopt_long(argc, argv, "a:h", long_options, &optIdx);
-        if (c == -1) break;
+        if (c == -1)
+            break;
         switch (c) {
-            case 'a': {
-                // comma-separated annotation names
-                auto items = split(optarg, ',');
-                for (auto &it : items) {
-                    // trim spaces
-                    while (!it.empty() && (it.front() == ' ' || it.front() == '\t')) {
-                        it.erase(it.begin());
-                    }
-                    while (!it.empty() && (it.back() == ' ' || it.back() == '\t')) {
-                        it.pop_back();
-                    }
-                    opts.annotations.push_back(it);
+        case 'a': {
+            // comma-separated annotation names
+            auto items = split(optarg, ',');
+            for (auto &it : items) {
+                // trim spaces
+                while (!it.empty() && (it.front() == ' ' || it.front() == '\t')) {
+                    it.erase(it.begin());
                 }
-            } break;
-            case 'h':
-            default:
-                showHelp = true;
-                break;
+                while (!it.empty() && (it.back() == ' ' || it.back() == '\t')) {
+                    it.pop_back();
+                }
+                opts.annotations.push_back(it);
+            }
+        } break;
+        case 'h':
+        default:
+            showHelp = true;
+            break;
         }
     }
 
@@ -154,8 +151,8 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
 
         // If header line
         if (line[0] == '#') {
-            // If you want to preserve VCF headers, you can print them. 
-            // But here we do NOT, since we produce a new TSV. 
+            // If you want to preserve VCF headers, you can print them.
+            // But here we do NOT, since we produce a new TSV.
             // If you prefer, uncomment below:
             // std::cout << line << "\n";
             if (!foundChromHeader && line.rfind("#CHROM", 0) == 0) {
@@ -180,12 +177,12 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
         }
 
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
-        const std::string &id    = fields[2];
-        const std::string &ref   = fields[3];
-        const std::string &altStr= fields[4];
+        const std::string &pos = fields[1];
+        const std::string &id = fields[2];
+        const std::string &ref = fields[3];
+        const std::string &altStr = fields[4];
         // skip fields[5]=QUAL, fields[6]=FILTER
-        const std::string &info  = fields[7];
+        const std::string &info = fields[7];
 
         // Split ALT on comma for multiple alt alleles
         std::vector<std::string> alts = split(altStr, ',');
@@ -197,8 +194,8 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
         // BUT if the annotation might have multiple comma-separated sub-entries (like ANN=),
         // we handle that separately:
         // We'll do a 2-phase approach:
-        //   1) gather strings for each annotation 
-        //   2) if it's something like "ANN" that has multiple commas, we split them 
+        //   1) gather strings for each annotation
+        //   2) if it's something like "ANN" that has multiple commas, we split them
         //      and try to align them with ALT alleles.
         std::unordered_map<std::string, std::string> rawAnnValues;
         for (auto &annName : opts.annotations) {
@@ -207,7 +204,7 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
                 rawAnnValues[annName] = "NA";
             } else {
                 // entire string for that annotation
-                rawAnnValues[annName] = it->second; 
+                rawAnnValues[annName] = it->second;
             }
         }
 
@@ -218,7 +215,7 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
         for (auto &annName : opts.annotations) {
             std::string val = rawAnnValues[annName];
             if (val == "NA") {
-                // no annotation => just store empty vector 
+                // no annotation => just store empty vector
                 splittedAnnValues[annName] = {};
                 continue;
             }
@@ -239,8 +236,7 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
             // For each annotation, we see if splittedAnnValues[annName].size() > altIndex
             // If yes, output that sub-value, else "NA"
             std::ostringstream outLine;
-            outLine << chrom << "\t" << pos << "\t" << id << "\t" 
-                    << ref << "\t" << thisAlt;
+            outLine << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << thisAlt;
 
             // For each requested annotation
             for (auto &annName : opts.annotations) {
@@ -275,8 +271,9 @@ static void processVCF(std::istream &in, const AnnotationOptions &opts) {
 // --------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_annotation_extractor", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_annotation_extractor", show_help))
+        return 0;
     AnnotationOptions opts;
     if (!parseArguments(argc, argv, opts)) {
         // parseArguments already printed help if needed

--- a/src/VCFX_annotation_extractor/VCFX_annotation_extractor.h
+++ b/src/VCFX_annotation_extractor/VCFX_annotation_extractor.h
@@ -7,22 +7,23 @@
 
 // VCFX_annotation_extractor: Header file for variant annotation extraction tool
 class VCFXAnnotationExtractor {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Processes VCF input from the given stream
-    void processVCF(std::istream& in, const std::vector<std::string>& annotations);
+    void processVCF(std::istream &in, const std::vector<std::string> &annotations);
 
     // Parses annotations from the INFO field
-    std::vector<std::string> parseINFO(const std::string& info);
+    std::vector<std::string> parseINFO(const std::string &info);
 
     // Extracts specified annotations
-    std::vector<std::string> extractAnnotations(const std::vector<std::string>& info_fields, const std::vector<std::string>& annotations);
+    std::vector<std::string> extractAnnotations(const std::vector<std::string> &info_fields,
+                                                const std::vector<std::string> &annotations);
 };
 
 #endif // VCFX_ANNOTATION_EXTRACTOR_H

--- a/src/VCFX_compressor/VCFX_compressor.cpp
+++ b/src/VCFX_compressor/VCFX_compressor.cpp
@@ -1,30 +1,29 @@
 #include "vcfx_core.h"
+#include <cstring>
+#include <getopt.h>
 #include <iostream>
 #include <string>
 #include <zlib.h>
-#include <cstring>
-#include <getopt.h>
 
 // ---------------------------------------------------------------------------
 // Show help
 // ---------------------------------------------------------------------------
 static void printHelp() {
-    std::cout 
-        << "VCFX_compressor\n"
-        << "Usage: VCFX_compressor [OPTIONS]\n\n"
-        << "Options:\n"
-        << "  --compress, -c         Compress the input VCF file (to stdout).\n"
-        << "  --decompress, -d       Decompress the input VCF file (from stdin).\n"
-        << "  --help, -h             Display this help message and exit.\n\n"
-        << "Description:\n"
-        << "  Compresses or decompresses data using zlib's raw DEFLATE (similar to gzip).\n"
-        << "  Note that for .vcf.gz indexing via tabix, one typically needs BGZF blocks,\n"
-        << "  which is not implemented here.\n\n"
-        << "Examples:\n"
-        << "  Compress:\n"
-        << "    ./VCFX_compressor --compress < input.vcf > output.vcf.gz\n\n"
-        << "  Decompress:\n"
-        << "    ./VCFX_compressor --decompress < input.vcf.gz > output.vcf\n";
+    std::cout << "VCFX_compressor\n"
+              << "Usage: VCFX_compressor [OPTIONS]\n\n"
+              << "Options:\n"
+              << "  --compress, -c         Compress the input VCF file (to stdout).\n"
+              << "  --decompress, -d       Decompress the input VCF file (from stdin).\n"
+              << "  --help, -h             Display this help message and exit.\n\n"
+              << "Description:\n"
+              << "  Compresses or decompresses data using zlib's raw DEFLATE (similar to gzip).\n"
+              << "  Note that for .vcf.gz indexing via tabix, one typically needs BGZF blocks,\n"
+              << "  which is not implemented here.\n\n"
+              << "Examples:\n"
+              << "  Compress:\n"
+              << "    ./VCFX_compressor --compress < input.vcf > output.vcf.gz\n\n"
+              << "  Decompress:\n"
+              << "    ./VCFX_compressor --decompress < input.vcf.gz > output.vcf\n";
 }
 
 // ---------------------------------------------------------------------------
@@ -32,7 +31,7 @@ static void printHelp() {
 //   compress = true  => read from 'in', produce gzip to 'out'
 //   compress = false => read gzip from 'in', produce plain text to 'out'
 // ---------------------------------------------------------------------------
-static bool compressDecompressVCF(std::istream& in, std::ostream& out, bool compress) {
+static bool compressDecompressVCF(std::istream &in, std::ostream &out, bool compress) {
     constexpr int CHUNK = 16384;
     char inBuffer[CHUNK];
     char outBuffer[CHUNK];
@@ -54,12 +53,12 @@ static bool compressDecompressVCF(std::istream& in, std::ostream& out, bool comp
             flush = in.eof() ? Z_FINISH : Z_NO_FLUSH;
 
             strm.avail_in = static_cast<uInt>(bytesRead);
-            strm.next_in  = reinterpret_cast<Bytef*>(inBuffer);
+            strm.next_in = reinterpret_cast<Bytef *>(inBuffer);
 
             // compress until input is used up
             do {
                 strm.avail_out = CHUNK;
-                strm.next_out  = reinterpret_cast<Bytef*>(outBuffer);
+                strm.next_out = reinterpret_cast<Bytef *>(outBuffer);
 
                 int ret = deflate(&strm, flush);
                 if (ret == Z_STREAM_ERROR) {
@@ -107,17 +106,15 @@ static bool compressDecompressVCF(std::istream& in, std::ostream& out, bool comp
                 }
             }
             strm.avail_in = static_cast<uInt>(bytesRead);
-            strm.next_in  = reinterpret_cast<Bytef*>(inBuffer);
+            strm.next_in = reinterpret_cast<Bytef *>(inBuffer);
 
             // decompress until output buffer not needed
             do {
                 strm.avail_out = CHUNK;
-                strm.next_out  = reinterpret_cast<Bytef*>(outBuffer);
+                strm.next_out = reinterpret_cast<Bytef *>(outBuffer);
 
                 ret = inflate(&strm, Z_NO_FLUSH);
-                if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT ||
-                    ret == Z_DATA_ERROR || ret == Z_MEM_ERROR)
-                {
+                if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR) {
                     std::cerr << "Error: inflate failed with code " << ret << "\n";
                     inflateEnd(&strm);
                     return false;
@@ -151,28 +148,36 @@ static bool compressDecompressVCF(std::istream& in, std::ostream& out, bool comp
 // ---------------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_compressor", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_compressor", show_help))
+        return 0;
     bool compress = false;
     bool decompress = false;
 
-    static struct option long_options[] = {
-        {"compress",   no_argument, 0, 'c'},
-        {"decompress", no_argument, 0, 'd'},
-        {"help",       no_argument, 0, 'h'},
-        {0, 0, 0, 0}
-    };
+    static struct option long_options[] = {{"compress", no_argument, 0, 'c'},
+                                           {"decompress", no_argument, 0, 'd'},
+                                           {"help", no_argument, 0, 'h'},
+                                           {0, 0, 0, 0}};
 
     while (true) {
         int optIndex = 0;
         int c = getopt_long(argc, argv, "cdh", long_options, &optIndex);
-        if (c == -1) break;
+        if (c == -1)
+            break;
 
         switch (c) {
-            case 'c': compress = true;       break;
-            case 'd': decompress = true;     break;
-            case 'h': printHelp(); return 0;
-            default:  printHelp(); return 1;
+        case 'c':
+            compress = true;
+            break;
+        case 'd':
+            decompress = true;
+            break;
+        case 'h':
+            printHelp();
+            return 0;
+        default:
+            printHelp();
+            return 1;
         }
     }
 

--- a/src/VCFX_compressor/VCFX_compressor.h
+++ b/src/VCFX_compressor/VCFX_compressor.h
@@ -8,6 +8,6 @@
 void printHelp();
 
 // Function to perform compression or decompression
-bool compressDecompressVCF(std::istream& in, std::ostream& out, bool compress);
+bool compressDecompressVCF(std::istream &in, std::ostream &out, bool compress);
 
 #endif // VCFX_COMPRESSOR_H

--- a/src/VCFX_concordance_checker/VCFX_concordance_checker.cpp
+++ b/src/VCFX_concordance_checker/VCFX_concordance_checker.cpp
@@ -1,12 +1,12 @@
 #include "vcfx_core.h"
-#include <iostream>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <unordered_map>
 #include <algorithm>
 #include <cstdlib>
 #include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // ---------------------------------------------------------
 // Data structure for command-line arguments
@@ -20,17 +20,16 @@ struct ConcordanceArguments {
 // Print help
 // ---------------------------------------------------------
 static void printHelp() {
-    std::cout 
-        << "VCFX_concordance_checker\n"
-        << "Usage: VCFX_concordance_checker [OPTIONS] < input.vcf > concordance_report.tsv\n\n"
-        << "Options:\n"
-        << "  --samples, -s \"Sample1 Sample2\"  Specify exactly two sample names to compare.\n"
-        << "  --help, -h                        Display this help message and exit.\n\n"
-        << "Description:\n"
-        << "  Compares genotypes between two specified samples in a VCF file, including multi-allelic\n"
-        << "  variants, and outputs per-variant concordance (Concordant or Discordant).\n\n"
-        << "Example:\n"
-        << "  ./VCFX_concordance_checker --samples \"SampleA SampleB\" < input.vcf > concordance_report.tsv\n";
+    std::cout << "VCFX_concordance_checker\n"
+              << "Usage: VCFX_concordance_checker [OPTIONS] < input.vcf > concordance_report.tsv\n\n"
+              << "Options:\n"
+              << "  --samples, -s \"Sample1 Sample2\"  Specify exactly two sample names to compare.\n"
+              << "  --help, -h                        Display this help message and exit.\n\n"
+              << "Description:\n"
+              << "  Compares genotypes between two specified samples in a VCF file, including multi-allelic\n"
+              << "  variants, and outputs per-variant concordance (Concordant or Discordant).\n\n"
+              << "Example:\n"
+              << "  ./VCFX_concordance_checker --samples \"SampleA SampleB\" < input.vcf > concordance_report.tsv\n";
 }
 
 // ---------------------------------------------------------
@@ -49,7 +48,7 @@ static std::vector<std::string> splitString(const std::string &str, char delimit
 // ---------------------------------------------------------
 // parseArguments: fill ConcordanceArguments
 // ---------------------------------------------------------
-static bool parseArguments(int argc, char* argv[], ConcordanceArguments& args) {
+static bool parseArguments(int argc, char *argv[], ConcordanceArguments &args) {
     bool showHelp = false;
 
     for (int i = 1; i < argc; ++i) {
@@ -63,11 +62,9 @@ static bool parseArguments(int argc, char* argv[], ConcordanceArguments& args) {
             }
             args.sample1 = samples[0];
             args.sample2 = samples[1];
-        }
-        else if (arg == "--help" || arg == "-h") {
+        } else if (arg == "--help" || arg == "-h") {
             showHelp = true;
-        }
-        else {
+        } else {
             std::cerr << "Warning: Unrecognized argument '" << arg << "'.\n";
         }
     }
@@ -93,14 +90,14 @@ static bool parseArguments(int argc, char* argv[], ConcordanceArguments& args) {
 //   2 => "2" (meaning altAlleles[1]), etc.
 // We'll store them as strings "0","1","2" for comparison
 // ---------------------------------------------------------
-static std::string normalizeDiploidGenotype(const std::string& genotypeField,
-                                            const std::vector<std::string> &altAlleles)
-{
+static std::string normalizeDiploidGenotype(const std::string &genotypeField,
+                                            const std::vector<std::string> &altAlleles) {
     // genotypeField might be "0/1", "2|3", ".", ...
     // Step 1: replace '|' with '/'
     std::string gt = genotypeField;
     for (char &c : gt) {
-        if (c == '|') c = '/';
+        if (c == '|')
+            c = '/';
     }
     // split by '/'
     auto alleles = splitString(gt, '/');
@@ -138,10 +135,10 @@ static std::string normalizeDiploidGenotype(const std::string& genotypeField,
         }
         numericAll.push_back(val);
     }
-    // We produce a string "x/y" sorted or not? Typically for genotype comparison, 
-    // "1/0" is same as "0/1", but let's keep the original order. It's also common 
-    // to store them in numeric order. We'll store them in sorted numeric order 
-    // so that "0/1" == "1/0". Then we join with "/". 
+    // We produce a string "x/y" sorted or not? Typically for genotype comparison,
+    // "1/0" is same as "0/1", but let's keep the original order. It's also common
+    // to store them in numeric order. We'll store them in sorted numeric order
+    // so that "0/1" == "1/0". Then we join with "/".
     std::sort(numericAll.begin(), numericAll.end());
     std::ostringstream oss;
     oss << numericAll[0] << "/" << numericAll[1];
@@ -169,9 +166,7 @@ static bool calculateConcordance(std::istream &in, std::ostream &out, const Conc
 
     // Print a TSV header:
     // CHROM POS ID REF ALT(S) Sample1_GT Sample2_GT Concordance
-    out << "CHROM\tPOS\tID\tREF\tALT\t" 
-        << args.sample1 << "_GT\t" 
-        << args.sample2 << "_GT\tConcordance\n";
+    out << "CHROM\tPOS\tID\tREF\tALT\t" << args.sample1 << "_GT\t" << args.sample2 << "_GT\tConcordance\n";
 
     while (std::getline(in, line)) {
         if (line.empty()) {
@@ -216,18 +211,16 @@ static bool calculateConcordance(std::istream &in, std::ostream &out, const Conc
             continue;
         }
         // check we have sample columns for sample1, sample2
-        if ((size_t)sample1_index >= fields.size() || 
-            (size_t)sample2_index >= fields.size()) 
-        {
+        if ((size_t)sample1_index >= fields.size() || (size_t)sample2_index >= fields.size()) {
             // line doesn't have enough columns
             continue;
         }
 
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
-        const std::string &id    = fields[2];
-        const std::string &ref   = fields[3];
-        const std::string &alt   = fields[4];
+        const std::string &pos = fields[1];
+        const std::string &id = fields[2];
+        const std::string &ref = fields[3];
+        const std::string &alt = fields[4];
         // sample columns:
         const std::string &sample1_field = fields[sample1_index];
         const std::string &sample2_field = fields[sample2_index];
@@ -254,14 +247,8 @@ static bool calculateConcordance(std::istream &in, std::ostream &out, const Conc
         std::string cc = same ? "Concordant" : "Discordant";
 
         // Print the row
-        out << chrom << "\t" 
-            << pos   << "\t" 
-            << id    << "\t" 
-            << ref   << "\t" 
-            << alt   << "\t"
-            << s1_gt << "\t"
-            << s2_gt << "\t"
-            << cc    << "\n";
+        out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << s1_gt << "\t" << s2_gt
+            << "\t" << cc << "\n";
     }
 
     // Print summary to stderr so we don't break the TSV
@@ -277,8 +264,9 @@ static bool calculateConcordance(std::istream &in, std::ostream &out, const Conc
 // ---------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_concordance_checker", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_concordance_checker", show_help))
+        return 0;
     ConcordanceArguments args;
     if (!parseArguments(argc, argv, args)) {
         // parseArguments prints error/help if needed

--- a/src/VCFX_concordance_checker/VCFX_concordance_checker.h
+++ b/src/VCFX_concordance_checker/VCFX_concordance_checker.h
@@ -15,15 +15,15 @@ struct ConcordanceArguments {
 };
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], ConcordanceArguments& args);
+bool parseArguments(int argc, char *argv[], ConcordanceArguments &args);
 
 // Function to split a string by a delimiter
-std::vector<std::string> splitString(const std::string& str, char delimiter);
+std::vector<std::string> splitString(const std::string &str, char delimiter);
 
 // Function to process VCF and calculate concordance
-bool calculateConcordance(std::istream& in, std::ostream& out, const ConcordanceArguments& args);
+bool calculateConcordance(std::istream &in, std::ostream &out, const ConcordanceArguments &args);
 
 // Function to extract genotype from genotype string
-std::string extractGenotype(const std::string& genotype_str);
+std::string extractGenotype(const std::string &genotype_str);
 
 #endif // VCFX_CONCORDANCE_CHECKER_H

--- a/src/VCFX_cross_sample_concordance/VCFX_cross_sample_concordance.cpp
+++ b/src/VCFX_cross_sample_concordance/VCFX_cross_sample_concordance.cpp
@@ -1,32 +1,31 @@
 #include "vcfx_core.h"
-#include <iostream>
-#include <string>
-#include <vector>
-#include <unordered_map>
-#include <unordered_set>
-#include <sstream>
 #include <algorithm>
 #include <cctype>
 #include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 // --------------------------------------------------------------------------
 // A helper function to print usage/help
 // --------------------------------------------------------------------------
 static void displayHelp() {
-    std::cout
-        << "VCFX_cross_sample_concordance: Check variant concordance across multiple samples.\n\n"
-        << "Usage:\n"
-        << "  VCFX_cross_sample_concordance [options] < input.vcf > concordance_results.txt\n\n"
-        << "Options:\n"
-        << "  -h, --help              Display this help message and exit\n"
-        << "  -s, --samples LIST      Comma-separated list of samples to check\n\n"
-        << "Description:\n"
-        << "  Reads a multi-sample VCF from stdin, normalizes each sample's genotype\n"
-        << "  (including multi-allelic variants), and determines if all samples that\n"
-        << "  have a parseable genotype are in complete agreement. Prints one row per\n"
-        << "  variant to stdout and a final summary to stderr.\n\n"
-        << "Example:\n"
-        << "  VCFX_cross_sample_concordance < input.vcf > results.tsv\n\n";
+    std::cout << "VCFX_cross_sample_concordance: Check variant concordance across multiple samples.\n\n"
+              << "Usage:\n"
+              << "  VCFX_cross_sample_concordance [options] < input.vcf > concordance_results.txt\n\n"
+              << "Options:\n"
+              << "  -h, --help              Display this help message and exit\n"
+              << "  -s, --samples LIST      Comma-separated list of samples to check\n\n"
+              << "Description:\n"
+              << "  Reads a multi-sample VCF from stdin, normalizes each sample's genotype\n"
+              << "  (including multi-allelic variants), and determines if all samples that\n"
+              << "  have a parseable genotype are in complete agreement. Prints one row per\n"
+              << "  variant to stdout and a final summary to stderr.\n\n"
+              << "Example:\n"
+              << "  VCFX_cross_sample_concordance < input.vcf > results.tsv\n\n";
 }
 
 // --------------------------------------------------------------------------
@@ -51,9 +50,7 @@ static std::vector<std::string> split(const std::string &str, char delim) {
 //   - Sort so "2/1" => "1/2"
 //   - Return e.g. "1/2"
 // --------------------------------------------------------------------------
-static std::string normalizeGenotype(const std::string &sampleField,
-                                     const std::vector<std::string> &altAlleles)
-{
+static std::string normalizeGenotype(const std::string &sampleField, const std::vector<std::string> &altAlleles) {
     // sampleField might be something like "0/1:.." or just "0/1"
     // We only care about the genotype portion (first colon-delimited field).
     auto parts = split(sampleField, ':');
@@ -64,7 +61,8 @@ static std::string normalizeGenotype(const std::string &sampleField,
 
     // unify separators
     for (char &c : gt) {
-        if (c == '|') c = '/';
+        if (c == '|')
+            c = '/';
     }
     // split by '/'
     auto alleleStrs = split(gt, '/');
@@ -104,7 +102,8 @@ static std::string normalizeGenotype(const std::string &sampleField,
     // Build a normalized string
     std::stringstream out;
     for (size_t i = 0; i < alleleInts.size(); ++i) {
-        if (i > 0) out << "/";
+        if (i > 0)
+            out << "/";
         out << alleleInts[i];
     }
     return out.str();
@@ -113,8 +112,7 @@ static std::string normalizeGenotype(const std::string &sampleField,
 // --------------------------------------------------------------------------
 // The main function to process the VCF and produce cross-sample concordance
 // --------------------------------------------------------------------------
-static void calculateConcordance(std::istream &in, std::ostream &out,
-                                 const std::vector<std::string> &subset) {
+static void calculateConcordance(std::istream &in, std::ostream &out, const std::vector<std::string> &subset) {
     std::string line;
     std::vector<std::string> sampleNames;
     bool gotChromHeader = false;
@@ -180,10 +178,10 @@ static void calculateConcordance(std::istream &in, std::ostream &out,
 
         // parse standard columns
         const std::string &chrom = fields[0];
-        const std::string &pos   = fields[1];
-        const std::string &id    = fields[2];
-        const std::string &ref   = fields[3];
-        const std::string &alt   = fields[4];
+        const std::string &pos = fields[1];
+        const std::string &id = fields[2];
+        const std::string &ref = fields[3];
+        const std::string &alt = fields[4];
         // we can skip qual/filter/info/format => we only need sample columns
         // sample columns start at index=9
         if (fields.size() < (9 + sampleNames.size())) {
@@ -214,9 +212,8 @@ static void calculateConcordance(std::istream &in, std::ostream &out,
         if (sampleCountHere == 0) {
             skippedBecauseNoGenotypes++;
             // Output with NO_GENOTYPES status instead of skipping
-            out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt
-                << "\t" << sampleCountHere 
-                << "\t" << 0  // No unique genotypes
+            out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << sampleCountHere << "\t"
+                << 0 // No unique genotypes
                 << "\t" << "NO_GENOTYPES"
                 << "\n";
             continue;
@@ -241,11 +238,8 @@ static void calculateConcordance(std::istream &in, std::ostream &out,
 
         std::string status = allConcordant ? "CONCORDANT" : "DISCORDANT";
         // Print row
-        out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt
-            << "\t" << sampleCountHere 
-            << "\t" << uniqueGtCount
-            << "\t" << status
-            << "\n";
+        out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << sampleCountHere << "\t"
+            << uniqueGtCount << "\t" << status << "\n";
     }
 
     // Summaries to stderr so as not to pollute the TSV
@@ -260,25 +254,30 @@ static void calculateConcordance(std::istream &in, std::ostream &out,
 // --------------------------------------------------------------------------
 static void show_help() { displayHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_cross_sample_concordance", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_cross_sample_concordance", show_help))
+        return 0;
     bool showHelp = false;
     std::string samplesArg;
 
     static struct option longOpts[] = {
-        {"help", no_argument, 0, 'h'},
-        {"samples", required_argument, 0, 's'},
-        {0,0,0,0}
-    };
+        {"help", no_argument, 0, 'h'}, {"samples", required_argument, 0, 's'}, {0, 0, 0, 0}};
 
     while (true) {
-        int optIndex=0;
+        int optIndex = 0;
         int c = getopt_long(argc, argv, "hs:", longOpts, &optIndex);
-        if (c == -1) break;
+        if (c == -1)
+            break;
         switch (c) {
-            case 'h': showHelp = true; break;
-            case 's': samplesArg = optarg; break;
-            default:  showHelp = true; break;
+        case 'h':
+            showHelp = true;
+            break;
+        case 's':
+            samplesArg = optarg;
+            break;
+        default:
+            showHelp = true;
+            break;
         }
     }
 

--- a/src/VCFX_cross_sample_concordance/VCFX_cross_sample_concordance.h
+++ b/src/VCFX_cross_sample_concordance/VCFX_cross_sample_concordance.h
@@ -3,21 +3,21 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 // VCFXCrossSampleConcordance: Header file for Cross-Sample Variant Concordance Tool
 class VCFXCrossSampleConcordance {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Processes the VCF input and calculates concordance
-    void calculateConcordance(std::istream& in, std::ostream& out);
+    void calculateConcordance(std::istream &in, std::ostream &out);
 
     // Structure to hold variant information
     struct Variant {

--- a/src/VCFX_custom_annotator/VCFX_custom_annotator.h
+++ b/src/VCFX_custom_annotator/VCFX_custom_annotator.h
@@ -7,22 +7,25 @@
 
 // VCFXCustomAnnotator: Header file for Custom Annotation Addition Tool
 class VCFXCustomAnnotator {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Loads annotations from a file into a map
-    bool loadAnnotations(const std::string& annotationFilePath, std::unordered_map<std::string, std::string>& annotations);
+    bool loadAnnotations(const std::string &annotationFilePath,
+                         std::unordered_map<std::string, std::string> &annotations);
 
     // Adds annotations to the VCF input
-    void addAnnotations(std::istream& in, std::ostream& out, const std::unordered_map<std::string, std::string>& annotations);
+    void addAnnotations(std::istream &in, std::ostream &out,
+                        const std::unordered_map<std::string, std::string> &annotations);
 
     // Generates a unique key for a variant based on chromosome, position, ref, and alt
-    std::string generateVariantKey(const std::string& chrom, const std::string& pos, const std::string& ref, const std::string& alt);
+    std::string generateVariantKey(const std::string &chrom, const std::string &pos, const std::string &ref,
+                                   const std::string &alt);
 };
 
 #endif // VCFX_CUSTOM_ANNOTATOR_H

--- a/src/VCFX_diff_tool/VCFX_diff_tool.cpp
+++ b/src/VCFX_diff_tool/VCFX_diff_tool.cpp
@@ -1,13 +1,13 @@
 #include "vcfx_core.h"
-#include <iostream>
-#include <string>
-#include <fstream>
-#include <unordered_set>
-#include <vector>
-#include <sstream>
 #include <algorithm>
 #include <cstdlib>
+#include <fstream>
 #include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 // ----------------------------------------------------------------------
 // A helper function to split a string by a delimiter
@@ -26,22 +26,19 @@ static std::vector<std::string> split(const std::string &str, char delim) {
 // Class: VCFXDiffTool
 // ----------------------------------------------------------------------
 class VCFXDiffTool {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
-    bool loadVariants(const std::string& filePath,
-                      std::unordered_set<std::string>& variants);
+    bool loadVariants(const std::string &filePath, std::unordered_set<std::string> &variants);
 
     // We unify multi-allelic lines by splitting ALT on commas,
-    // sorting them, and rejoining them. 
+    // sorting them, and rejoining them.
     // The final key is "chrom:pos:ref:sortedAltString"
-    std::string generateVariantKey(const std::string& chrom,
-                                   const std::string& pos,
-                                   const std::string& ref,
-                                   const std::string& altField);
+    std::string generateVariantKey(const std::string &chrom, const std::string &pos, const std::string &ref,
+                                   const std::string &altField);
 };
 
 // ----------------------------------------------------------------------
@@ -65,18 +62,16 @@ void VCFXDiffTool::displayHelp() {
 //   - We split on commas, sort them, rejoin => e.g. "G,T"
 //   - Then produce "chrom:pos:ref:thatSortedAlt"
 // ----------------------------------------------------------------------
-std::string VCFXDiffTool::generateVariantKey(const std::string& chrom,
-                                             const std::string& pos,
-                                             const std::string& ref,
-                                             const std::string& altField)
-{
+std::string VCFXDiffTool::generateVariantKey(const std::string &chrom, const std::string &pos, const std::string &ref,
+                                             const std::string &altField) {
     auto alts = split(altField, ',');
     // sort them lexicographically
     std::sort(alts.begin(), alts.end());
     // rejoin
     std::ostringstream altSS;
     for (size_t i = 0; i < alts.size(); ++i) {
-        if (i > 0) altSS << ",";
+        if (i > 0)
+            altSS << ",";
         altSS << alts[i];
     }
     std::string sortedAlt = altSS.str();
@@ -90,9 +85,7 @@ std::string VCFXDiffTool::generateVariantKey(const std::string& chrom,
 //   - parse CHROM, POS, ID, REF, ALT
 //   - generate key => add to set
 // ----------------------------------------------------------------------
-bool VCFXDiffTool::loadVariants(const std::string& filePath,
-                                std::unordered_set<std::string>& variants)
-{
+bool VCFXDiffTool::loadVariants(const std::string &filePath, std::unordered_set<std::string> &variants) {
     std::ifstream infile(filePath);
     if (!infile.is_open()) {
         std::cerr << "Error: Unable to open file " << filePath << "\n";
@@ -127,32 +120,30 @@ bool VCFXDiffTool::loadVariants(const std::string& filePath,
 //   - load sets from file1, file2
 //   - compare => print differences
 // ----------------------------------------------------------------------
-int VCFXDiffTool::run(int argc, char* argv[]) {
+int VCFXDiffTool::run(int argc, char *argv[]) {
     int opt;
     bool showHelp = false;
     std::string file1Path;
     std::string file2Path;
 
-    static struct option long_options[] = {
-        {"help",  no_argument,       0, 'h'},
-        {"file1", required_argument, 0, 'a'},
-        {"file2", required_argument, 0, 'b'},
-        {0,0,0,0}
-    };
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'},
+                                           {"file1", required_argument, 0, 'a'},
+                                           {"file2", required_argument, 0, 'b'},
+                                           {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "ha:b:", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'a':
-                file1Path = optarg;
-                break;
-            case 'b':
-                file2Path = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'a':
+            file1Path = optarg;
+            break;
+        case 'b':
+            file2Path = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -205,10 +196,17 @@ int VCFXDiffTool::run(int argc, char* argv[]) {
 // ----------------------------------------------------------------------
 // main
 // ----------------------------------------------------------------------
-static void show_help() { VCFXDiffTool obj; char arg0[] = "VCFX_diff_tool"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXDiffTool obj;
+    char arg0[] = "VCFX_diff_tool";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_diff_tool", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_diff_tool", show_help))
+        return 0;
     VCFXDiffTool diffTool;
     return diffTool.run(argc, argv);
 }

--- a/src/VCFX_diff_tool/VCFX_diff_tool.h
+++ b/src/VCFX_diff_tool/VCFX_diff_tool.h
@@ -1,27 +1,28 @@
 #ifndef VCFX_DIFF_TOOL_H
 #define VCFX_DIFF_TOOL_H
 
+#include <fstream>
 #include <iostream>
 #include <string>
-#include <fstream>
 #include <unordered_set>
 #include <vector>
 
 // VCFXDiffTool: Header file for VCF Diff Tool
 class VCFXDiffTool {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Loads variants from a VCF file into a set
-    bool loadVariants(const std::string& filePath, std::unordered_set<std::string>& variants);
+    bool loadVariants(const std::string &filePath, std::unordered_set<std::string> &variants);
 
     // Generates a unique key for a variant based on chromosome, position, ref, and alt
-    std::string generateVariantKey(const std::string& chrom, const std::string& pos, const std::string& ref, const std::string& alt);
+    std::string generateVariantKey(const std::string &chrom, const std::string &pos, const std::string &ref,
+                                   const std::string &alt);
 };
 
 #endif // VCFX_DIFF_TOOL_H

--- a/src/VCFX_distance_calculator/VCFX_distance_calculator.cpp
+++ b/src/VCFX_distance_calculator/VCFX_distance_calculator.cpp
@@ -1,12 +1,12 @@
 #include "vcfx_core.h"
 // VCFX_distance_calculator.cpp
 #include "VCFX_distance_calculator.h"
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
 #include <sstream>
 #include <unordered_map>
 #include <vector>
-#include <limits>
-#include <algorithm>
-#include <cstdlib>
 
 // --------------------------------------------------------------------------
 // printHelp: Displays usage information.
@@ -29,7 +29,7 @@ void printHelp() {
 // parseVCFLine: Parses a VCF data line and extracts CHROM and POS.
 // Returns false if the line is a header or cannot be parsed.
 // --------------------------------------------------------------------------
-bool parseVCFLine(const std::string& line, VCFVariant& variant) {
+bool parseVCFLine(const std::string &line, VCFVariant &variant) {
     // Skip header lines or empty lines.
     if (line.empty() || line[0] == '#')
         return false;
@@ -46,8 +46,7 @@ bool parseVCFLine(const std::string& line, VCFVariant& variant) {
     std::string chrom, pos_str;
 
     // We expect at least two tab-delimited columns: CHROM and POS.
-    if (!std::getline(ss, chrom, '\t') ||
-        !std::getline(ss, pos_str, '\t')) {
+    if (!std::getline(ss, chrom, '\t') || !std::getline(ss, pos_str, '\t')) {
         return false;
     }
 
@@ -70,20 +69,18 @@ bool parseVCFLine(const std::string& line, VCFVariant& variant) {
 // Structure to hold per-chromosome summary statistics.
 // --------------------------------------------------------------------------
 struct ChromStats {
-    int count;             // Number of inter-variant distances computed
-    long totalDistance;    // Sum of all distances
-    int minDistance;       // Minimum distance seen
-    int maxDistance;       // Maximum distance seen
-    ChromStats() : count(0), totalDistance(0),
-                   minDistance(std::numeric_limits<int>::max()),
-                   maxDistance(0) {}
+    int count;          // Number of inter-variant distances computed
+    long totalDistance; // Sum of all distances
+    int minDistance;    // Minimum distance seen
+    int maxDistance;    // Maximum distance seen
+    ChromStats() : count(0), totalDistance(0), minDistance(std::numeric_limits<int>::max()), maxDistance(0) {}
 };
 
 // --------------------------------------------------------------------------
 // calculateDistances: Reads a VCF stream, calculates inter-variant distances,
 // outputs a TSV line per variant, and writes summary statistics to stderr.
 // --------------------------------------------------------------------------
-bool calculateDistances(std::istream& in, std::ostream& out) {
+bool calculateDistances(std::istream &in, std::ostream &out) {
     std::string line;
     bool headerFound = false;
 
@@ -162,8 +159,9 @@ bool calculateDistances(std::istream& in, std::ostream& out) {
 // --------------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_distance_calculator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_distance_calculator", show_help))
+        return 0;
     // Check for help option.
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_distance_calculator/VCFX_distance_calculator.h
+++ b/src/VCFX_distance_calculator/VCFX_distance_calculator.h
@@ -15,11 +15,11 @@ struct VCFVariant {
 };
 
 // Function to parse a VCF line into a VCFVariant structure
-bool parseVCFLine(const std::string& line, VCFVariant& variant);
+bool parseVCFLine(const std::string &line, VCFVariant &variant);
 
 // Function to calculate distances between consecutive variants
 // Writes one output line per variant (with distance from the previous variant on that chromosome)
 // and returns true on success.
-bool calculateDistances(std::istream& in, std::ostream& out);
+bool calculateDistances(std::istream &in, std::ostream &out);
 
 #endif // VCFX_DISTANCE_CALCULATOR_H

--- a/src/VCFX_dosage_calculator/VCFX_dosage_calculator.cpp
+++ b/src/VCFX_dosage_calculator/VCFX_dosage_calculator.cpp
@@ -1,11 +1,11 @@
-#include "vcfx_core.h"
 #include "VCFX_dosage_calculator.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iomanip>
-#include <cstdlib>
 #include <cctype>
+#include <cstdlib>
+#include <getopt.h>
+#include <iomanip>
+#include <sstream>
 
 // ---------------------------------------------------------------------------
 // displayHelp: Prints usage information to standard output.
@@ -31,22 +31,19 @@ void VCFXDosageCalculator::displayHelp() {
 // ---------------------------------------------------------------------------
 // run: Parses command-line arguments and calls calculateDosage.
 // ---------------------------------------------------------------------------
-int VCFXDosageCalculator::run(int argc, char* argv[]) {
+int VCFXDosageCalculator::run(int argc, char *argv[]) {
     int opt;
     bool showHelp = false;
 
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},
-        {0,      0,           0,  0}
-    };
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "h", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
     if (showHelp) {
@@ -64,7 +61,7 @@ int VCFXDosageCalculator::run(int argc, char* argv[]) {
 // calculateDosage: Processes the VCF line by line, computes dosage for each sample,
 // and outputs a tab-delimited line per variant.
 // ---------------------------------------------------------------------------
-void VCFXDosageCalculator::calculateDosage(std::istream& in, std::ostream& out) {
+void VCFXDosageCalculator::calculateDosage(std::istream &in, std::ostream &out) {
     std::string line;
     bool headerParsed = false;
     std::vector<std::string> headerFields;
@@ -165,7 +162,7 @@ void VCFXDosageCalculator::calculateDosage(std::istream& in, std::ostream& out) 
             bool validGenotype = true;
             int dosage = 0;
             // For each allele, if it is "0", count 0; if it is any numeric >0, count 1.
-            for (const std::string& a : alleles) {
+            for (const std::string &a : alleles) {
                 if (a == "." || a.empty()) {
                     validGenotype = false;
                     break;
@@ -198,15 +195,14 @@ void VCFXDosageCalculator::calculateDosage(std::istream& in, std::ostream& out) 
         }
 
         // Output one line per variant with dosage information.
-        out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t"
-            << dosagesOSS.str() << "\n";
+        out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << dosagesOSS.str() << "\n";
     }
 }
 
 // ---------------------------------------------------------------------------
 // split: Helper function to split a string by a delimiter
 // ---------------------------------------------------------------------------
-std::vector<std::string> VCFXDosageCalculator::split(const std::string& str, char delimiter) {
+std::vector<std::string> VCFXDosageCalculator::split(const std::string &str, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string token;
@@ -216,10 +212,17 @@ std::vector<std::string> VCFXDosageCalculator::split(const std::string& str, cha
     return tokens;
 }
 
-static void show_help() { VCFXDosageCalculator obj; char arg0[] = "VCFX_dosage_calculator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXDosageCalculator obj;
+    char arg0[] = "VCFX_dosage_calculator";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_dosage_calculator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_dosage_calculator", show_help))
+        return 0;
     VCFXDosageCalculator dosageCalculator;
     return dosageCalculator.run(argc, argv);
 }

--- a/src/VCFX_dosage_calculator/VCFX_dosage_calculator.h
+++ b/src/VCFX_dosage_calculator/VCFX_dosage_calculator.h
@@ -7,19 +7,19 @@
 
 // VCFX_dosage_calculator: Header file for Genotype Dosage Calculation tool
 class VCFXDosageCalculator {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Calculates genotype dosage from VCF input and writes output
-    void calculateDosage(std::istream& in, std::ostream& out);
+    void calculateDosage(std::istream &in, std::ostream &out);
 
     // Helper function to split a string by a delimiter
-    std::vector<std::string> split(const std::string& str, char delimiter);
+    std::vector<std::string> split(const std::string &str, char delimiter);
 };
 
 #endif // VCFX_DOSAGE_CALCULATOR_H

--- a/src/VCFX_duplicate_remover/VCFX_duplicate_remover.cpp
+++ b/src/VCFX_duplicate_remover/VCFX_duplicate_remover.cpp
@@ -1,11 +1,11 @@
-#include "vcfx_core.h"
 #include "VCFX_duplicate_remover.h"
+#include "vcfx_core.h"
+#include <algorithm>
 #include <sstream>
 #include <vector>
-#include <algorithm>
 
 // Utility function: Splits a string by a given delimiter.
-static std::vector<std::string> splitString(const std::string& str, char delimiter) {
+static std::vector<std::string> splitString(const std::string &str, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string token;
@@ -32,10 +32,8 @@ void printHelp() {
 
 // Generates a unique key for a variant based on chrom, pos, ref, and alt.
 // For multi-allelic ALT fields, the ALT alleles are split, sorted, and rejoined.
-std::string generateNormalizedVariantKey(const std::string& chrom,
-                                          const std::string& pos,
-                                          const std::string& ref,
-                                          const std::string& alt) {
+std::string generateNormalizedVariantKey(const std::string &chrom, const std::string &pos, const std::string &ref,
+                                         const std::string &alt) {
     // Split ALT field on commas.
     std::vector<std::string> alts = splitString(alt, ',');
     // Sort alleles lexicographically.
@@ -53,10 +51,8 @@ std::string generateNormalizedVariantKey(const std::string& chrom,
 }
 
 // Helper function to generate a VariantKey from parsed values.
-static VariantKey generateVariantKey(const std::string& chrom,
-                                     const std::string& pos,
-                                     const std::string& ref,
-                                     const std::string& alt) {
+static VariantKey generateVariantKey(const std::string &chrom, const std::string &pos, const std::string &ref,
+                                     const std::string &alt) {
     VariantKey key;
     key.chrom = chrom;
     try {
@@ -83,7 +79,7 @@ static VariantKey generateVariantKey(const std::string& chrom,
 }
 
 // Function to remove duplicate variants from a VCF file.
-bool removeDuplicates(std::istream& in, std::ostream& out) {
+bool removeDuplicates(std::istream &in, std::ostream &out) {
     std::string line;
     // Print header lines as-is.
     // Use an unordered_set with our custom hash function to track seen variants.
@@ -125,8 +121,9 @@ bool removeDuplicates(std::istream& in, std::ostream& out) {
 // ----------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_duplicate_remover", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_duplicate_remover", show_help))
+        return 0;
     // Simple argument parsing: if --help or -h is provided, print help.
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_duplicate_remover/VCFX_duplicate_remover.h
+++ b/src/VCFX_duplicate_remover/VCFX_duplicate_remover.h
@@ -15,17 +15,14 @@ struct VariantKey {
     std::string ref;
     std::string alt; // normalized: sorted, comma-separated alleles
 
-    bool operator==(const VariantKey& other) const {
-        return chrom == other.chrom &&
-               pos == other.pos &&
-               ref == other.ref &&
-               alt == other.alt;
+    bool operator==(const VariantKey &other) const {
+        return chrom == other.chrom && pos == other.pos && ref == other.ref && alt == other.alt;
     }
 };
 
 // Custom hash function for VariantKey using a hash-combine approach
 struct VariantKeyHash {
-    std::size_t operator()(const VariantKey& k) const {
+    std::size_t operator()(const VariantKey &k) const {
         std::size_t h1 = std::hash<std::string>()(k.chrom);
         std::size_t h2 = std::hash<int>()(k.pos);
         std::size_t h3 = std::hash<std::string>()(k.ref);
@@ -39,6 +36,6 @@ struct VariantKeyHash {
 };
 
 // Function to remove duplicate variants from a VCF file
-bool removeDuplicates(std::istream& in, std::ostream& out);
+bool removeDuplicates(std::istream &in, std::ostream &out);
 
 #endif // VCFX_DUPLICATE_REMOVER_H

--- a/src/VCFX_fasta_converter/VCFX_fasta_converter.cpp
+++ b/src/VCFX_fasta_converter/VCFX_fasta_converter.cpp
@@ -1,30 +1,22 @@
-#include "vcfx_core.h"
 #include "VCFX_fasta_converter.h"
+#include "vcfx_core.h"
+#include <algorithm>
+#include <cctype>
 #include <getopt.h>
+#include <iomanip>
+#include <map>
 #include <sstream>
 #include <unordered_map>
-#include <algorithm>
-#include <iomanip>
-#include <cctype>
-#include <map>
 
 // A small map from two distinct bases to an IUPAC ambiguity code
 // e.g. A + G => R, C + T => Y, etc.
-static const std::map<std::string, char> IUPAC_ambiguities = {
-    {"AG", 'R'}, {"GA", 'R'},
-    {"CT", 'Y'}, {"TC", 'Y'},
-    {"AC", 'M'}, {"CA", 'M'},
-    {"GT", 'K'}, {"TG", 'K'},
-    {"AT", 'W'}, {"TA", 'W'},
-    {"CG", 'S'}, {"GC", 'S'}
-};
+static const std::map<std::string, char> IUPAC_ambiguities = {{"AG", 'R'}, {"GA", 'R'}, {"CT", 'Y'}, {"TC", 'Y'},
+                                                              {"AC", 'M'}, {"CA", 'M'}, {"GT", 'K'}, {"TG", 'K'},
+                                                              {"AT", 'W'}, {"TA", 'W'}, {"CG", 'S'}, {"GC", 'S'}};
 
 // Utility to convert a single numeric allele index into the corresponding base
 // returns '\0' on failure
-static char alleleIndexToBase(int alleleIndex,
-                              const std::string& ref,
-                              const std::vector<std::string>& altAlleles)
-{
+static char alleleIndexToBase(int alleleIndex, const std::string &ref, const std::vector<std::string> &altAlleles) {
     // 0 => ref, 1 => altAlleles[0], 2 => altAlleles[1], etc.
     if (alleleIndex == 0) {
         if (ref.size() == 1) {
@@ -53,7 +45,7 @@ static char alleleIndexToBase(int alleleIndex,
 // Otherwise returns 'N'
 static char combineBasesIUPAC(char b1, char b2) {
     if (b1 == b2) {
-        return b1;  // e.g. A + A => A
+        return b1; // e.g. A + A => A
     }
     // build 2-char string in alphabetical order
     std::string pair;
@@ -66,21 +58,18 @@ static char combineBasesIUPAC(char b1, char b2) {
     return 'N'; // unknown combination
 }
 
-int VCFXFastaConverter::run(int argc, char* argv[]) {
+int VCFXFastaConverter::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
 
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},
-        {0,      0,           0,  0 }
-    };
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "h", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-            default:
-                showHelp = true;
+        case 'h':
+        default:
+            showHelp = true;
         }
     }
 
@@ -108,7 +97,7 @@ void VCFXFastaConverter::displayHelp() {
               << "  VCFX_fasta_converter < input.vcf > output.fasta\n\n";
 }
 
-void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) {
+void VCFXFastaConverter::convertVCFtoFasta(std::istream &in, std::ostream &out) {
     std::string line;
     std::vector<std::string> sampleNames;
     // Each sampleName -> sequence string
@@ -170,7 +159,7 @@ void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) 
         // const std::string &id  = fields[2];
         const std::string &ref = fields[3];
         const std::string &altField = fields[4];
-        const std::string &format   = fields[8];
+        const std::string &format = fields[8];
 
         // Split alt on commas
         std::vector<std::string> altAlleles;
@@ -233,7 +222,8 @@ void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) 
             std::string genotype = sampleParts[gtIndex];
             // unify separators
             for (char &c : genotype) {
-                if (c == '|') c = '/';
+                if (c == '|')
+                    c = '/';
             }
             if (genotype.empty() || genotype == ".") {
                 sampleSequences[sampleName] += "N";
@@ -269,16 +259,24 @@ void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) 
                 // parse first allele
                 {
                     for (char c : alleles[0]) {
-                        if (!std::isdigit(c)) {okA1=false; break;}
+                        if (!std::isdigit(c)) {
+                            okA1 = false;
+                            break;
+                        }
                     }
-                    if (okA1) a1 = std::stoi(alleles[0]);
+                    if (okA1)
+                        a1 = std::stoi(alleles[0]);
                 }
                 // parse second allele
                 {
                     for (char c : alleles[1]) {
-                        if (!std::isdigit(c)) {okA2=false; break;}
+                        if (!std::isdigit(c)) {
+                            okA2 = false;
+                            break;
+                        }
                     }
-                    if (okA2) a2 = std::stoi(alleles[1]);
+                    if (okA2)
+                        a2 = std::stoi(alleles[1]);
                 }
                 if (!okA1 || !okA2) {
                     sampleSequences[sampleName] += "N";
@@ -298,11 +296,12 @@ void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) 
             // If different => try IUPAC
             char finalBase = '\0';
             if (b1 == b2) {
-                finalBase = b1;  // e.g. both 'A'
+                finalBase = b1; // e.g. both 'A'
             } else {
                 finalBase = combineBasesIUPAC(b1, b2); // might yield R, Y, etc., or 'N'
             }
-            if (finalBase == '\0') finalBase = 'N';
+            if (finalBase == '\0')
+                finalBase = 'N';
             sampleSequences[sampleName] += finalBase;
         }
     }
@@ -320,10 +319,17 @@ void VCFXFastaConverter::convertVCFtoFasta(std::istream& in, std::ostream& out) 
     }
 }
 
-static void show_help() { VCFXFastaConverter obj; char arg0[] = "VCFX_fasta_converter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXFastaConverter obj;
+    char arg0[] = "VCFX_fasta_converter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_fasta_converter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_fasta_converter", show_help))
+        return 0;
     VCFXFastaConverter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_fasta_converter/VCFX_fasta_converter.h
+++ b/src/VCFX_fasta_converter/VCFX_fasta_converter.h
@@ -7,16 +7,16 @@
 
 // VCFXFastaConverter: Tool for converting a "variant-only" VCF into per-sample FASTA sequences
 class VCFXFastaConverter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Converts VCF input to FASTA format
-    void convertVCFtoFasta(std::istream& in, std::ostream& out);
+    void convertVCFtoFasta(std::istream &in, std::ostream &out);
 };
 
 #endif // VCFX_FASTA_CONVERTER_H

--- a/src/VCFX_field_extractor/VCFX_field_extractor.cpp
+++ b/src/VCFX_field_extractor/VCFX_field_extractor.cpp
@@ -1,36 +1,35 @@
-#include "vcfx_core.h"
 #include "VCFX_field_extractor.h"
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <unordered_map>
 #include <cctype>
+#include <sstream>
+#include <unordered_map>
 
 // ------------------------------------------------------------------------
 // printHelp
 // ------------------------------------------------------------------------
 void printHelp() {
-    std::cout
-        << "VCFX_field_extractor\n"
-        << "Usage: VCFX_field_extractor --fields \"FIELD1,FIELD2,...\" [OPTIONS]\n\n"
-        << "Description:\n"
-        << "  Extracts specified fields from each VCF record. Fields can be:\n"
-        << "    - Standard fields: CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO\n"
-        << "    - Subkeys in INFO (e.g. DP, AF, ANN). These are extracted from the INFO column.\n"
-        << "    - Sample subfields: e.g. SampleName:GT or S2:DP, referencing the second sample's DP.\n"
-        << "      You can use sample name as it appears in #CHROM line, or 'S' plus 1-based sample index.\n"
-        << "If a requested field is not found or invalid, '.' is output.\n\n"
-        << "Example:\n"
-        << "  VCFX_field_extractor --fields \"CHROM,POS,ID,REF,ALT,DP,Sample1:GT\" < input.vcf > out.tsv\n\n"
-        << "Options:\n"
-        << "  --fields, -f   Comma-separated list of fields to extract\n"
-        << "  --help, -h     Show this help message\n";
+    std::cout << "VCFX_field_extractor\n"
+              << "Usage: VCFX_field_extractor --fields \"FIELD1,FIELD2,...\" [OPTIONS]\n\n"
+              << "Description:\n"
+              << "  Extracts specified fields from each VCF record. Fields can be:\n"
+              << "    - Standard fields: CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO\n"
+              << "    - Subkeys in INFO (e.g. DP, AF, ANN). These are extracted from the INFO column.\n"
+              << "    - Sample subfields: e.g. SampleName:GT or S2:DP, referencing the second sample's DP.\n"
+              << "      You can use sample name as it appears in #CHROM line, or 'S' plus 1-based sample index.\n"
+              << "If a requested field is not found or invalid, '.' is output.\n\n"
+              << "Example:\n"
+              << "  VCFX_field_extractor --fields \"CHROM,POS,ID,REF,ALT,DP,Sample1:GT\" < input.vcf > out.tsv\n\n"
+              << "Options:\n"
+              << "  --fields, -f   Comma-separated list of fields to extract\n"
+              << "  --help, -h     Show this help message\n";
 }
 
 // ------------------------------------------------------------------------
 // A utility function to parse "INFO" key-value pairs into a map.
 // "INFO" might look like "DP=100;AF=0.5;ANN=some|stuff"
 // ------------------------------------------------------------------------
-static std::unordered_map<std::string, std::string> parseInfo(const std::string& infoField) {
+static std::unordered_map<std::string, std::string> parseInfo(const std::string &infoField) {
     std::unordered_map<std::string, std::string> infoMap;
     if (infoField == "." || infoField.empty()) {
         return infoMap;
@@ -62,11 +61,9 @@ static std::unordered_map<std::string, std::string> parseInfo(const std::string&
 //  - If it is an INFO subkey => parse info map
 //  - If it is "SampleName:SUBFIELD" or "S<int>:SUBFIELD" => parse the genotype subfield
 // ------------------------------------------------------------------------
-static std::vector<std::string> parseLineExtract(
-    const std::vector<std::string>& vcfCols,
-    const std::vector<std::string>& fields,
-    const std::unordered_map<std::string, int>& sampleNameToIndex)
-{
+static std::vector<std::string> parseLineExtract(const std::vector<std::string> &vcfCols,
+                                                 const std::vector<std::string> &fields,
+                                                 const std::unordered_map<std::string, int> &sampleNameToIndex) {
     // The first 8 standard columns
     // 0:CHROM,1:POS,2:ID,3:REF,4:ALT,5:QUAL,6:FILTER,7:INFO,8:FORMAT,9+:samples
     std::vector<std::string> out;
@@ -95,21 +92,29 @@ static std::vector<std::string> parseLineExtract(
 
         // Check if it's a standard field
         if (fld == "CHROM") {
-            if (vcfCols.size() > 0) value = vcfCols[0];
+            if (vcfCols.size() > 0)
+                value = vcfCols[0];
         } else if (fld == "POS") {
-            if (vcfCols.size() > 1) value = vcfCols[1];
+            if (vcfCols.size() > 1)
+                value = vcfCols[1];
         } else if (fld == "ID") {
-            if (vcfCols.size() > 2) value = vcfCols[2];
+            if (vcfCols.size() > 2)
+                value = vcfCols[2];
         } else if (fld == "REF") {
-            if (vcfCols.size() > 3) value = vcfCols[3];
+            if (vcfCols.size() > 3)
+                value = vcfCols[3];
         } else if (fld == "ALT") {
-            if (vcfCols.size() > 4) value = vcfCols[4];
+            if (vcfCols.size() > 4)
+                value = vcfCols[4];
         } else if (fld == "QUAL") {
-            if (vcfCols.size() > 5) value = vcfCols[5];
+            if (vcfCols.size() > 5)
+                value = vcfCols[5];
         } else if (fld == "FILTER") {
-            if (vcfCols.size() > 6) value = vcfCols[6];
+            if (vcfCols.size() > 6)
+                value = vcfCols[6];
         } else if (fld == "INFO") {
-            if (vcfCols.size() > 7) value = vcfCols[7];
+            if (vcfCols.size() > 7)
+                value = vcfCols[7];
         } else {
             // Possibly an INFO subkey?
             if (infoMap.find(fld) != infoMap.end()) {
@@ -124,9 +129,8 @@ static std::vector<std::string> parseLineExtract(
                     std::string subfield = fld.substr(colonPos + 1);
                     // find sample index
                     int sampleColIndex = -1;
-                    if (!sampleNameOrID.empty() && sampleNameOrID[0] == 'S'
-                        && std::all_of(sampleNameOrID.begin()+1, sampleNameOrID.end(), ::isdigit))
-                    {
+                    if (!sampleNameOrID.empty() && sampleNameOrID[0] == 'S' &&
+                        std::all_of(sampleNameOrID.begin() + 1, sampleNameOrID.end(), ::isdigit)) {
                         // format S<int>
                         int idx = std::stoi(sampleNameOrID.substr(1));
                         // sample columns start at col=9 in the VCF, but idx is 1-based
@@ -151,7 +155,7 @@ static std::vector<std::string> parseLineExtract(
                         }
                         // find subfield in the FORMAT
                         int subIx = -1;
-                        for (int i=0; i<(int)formatTokens.size(); i++) {
+                        for (int i = 0; i < (int)formatTokens.size(); i++) {
                             if (formatTokens[i] == subfield) {
                                 subIx = i;
                                 break;
@@ -177,22 +181,23 @@ static std::vector<std::string> parseLineExtract(
 }
 
 // ------------------------------------------------------------------------
-// extractFields: 
+// extractFields:
 //   1) parse #CHROM line to identify sample names => build map sample->VCFcolumnIndex
 //   2) for each data line, parse columns, parse info, parse sample subfields => output
 // ------------------------------------------------------------------------
-void extractFields(std::istream& in, std::ostream& out, const std::vector<std::string>& fields) {
+void extractFields(std::istream &in, std::ostream &out, const std::vector<std::string> &fields) {
     // Print the header row (the requested field names)
     for (size_t i = 0; i < fields.size(); i++) {
         out << fields[i];
-        if (i + 1 < fields.size()) out << "\t";
+        if (i + 1 < fields.size())
+            out << "\t";
     }
     out << "\n";
 
     std::string line;
 
     // We'll store sampleName -> columnIndex in this map
-    std::unordered_map<std::string,int> sampleNameToIndex;
+    std::unordered_map<std::string, int> sampleNameToIndex;
     bool foundChromHeader = false;
 
     while (std::getline(in, line)) {
@@ -234,9 +239,10 @@ void extractFields(std::istream& in, std::ostream& out, const std::vector<std::s
         std::vector<std::string> extracted = parseLineExtract(vcfCols, fields, sampleNameToIndex);
 
         // print them as TSV
-        for (size_t i=0; i<extracted.size(); i++) {
+        for (size_t i = 0; i < extracted.size(); i++) {
             out << extracted[i];
-            if (i+1 < extracted.size()) out << "\t";
+            if (i + 1 < extracted.size())
+                out << "\t";
         }
         out << "\n";
     }
@@ -247,22 +253,23 @@ void extractFields(std::istream& in, std::ostream& out, const std::vector<std::s
 // ------------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_field_extractor", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_field_extractor", show_help))
+        return 0;
     std::vector<std::string> fields;
     bool showHelp = false;
 
     // Basic argument parsing
-    for (int i=1; i<argc; i++) {
+    for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-        if (arg=="--help" || arg=="-h") {
+        if (arg == "--help" || arg == "-h") {
             showHelp = true;
-        } else if (arg.rfind("--fields",0)==0 || arg.rfind("-f",0)==0) {
+        } else if (arg.rfind("--fields", 0) == 0 || arg.rfind("-f", 0) == 0) {
             // parse next argument or after '='
             size_t eqPos = arg.find('=');
             if (eqPos != std::string::npos) {
                 // e.g. --fields=CHROM,POS,ID
-                std::string fieldsStr = arg.substr(eqPos+1);
+                std::string fieldsStr = arg.substr(eqPos + 1);
                 std::stringstream sss(fieldsStr);
                 std::string f;
                 while (std::getline(sss, f, ',')) {
@@ -270,7 +277,7 @@ int main(int argc, char* argv[]) {
                 }
             } else {
                 // next argument
-                if (i+1<argc) {
+                if (i + 1 < argc) {
                     i++;
                     std::string fieldsStr = argv[i];
                     std::stringstream sss(fieldsStr);

--- a/src/VCFX_field_extractor/VCFX_field_extractor.h
+++ b/src/VCFX_field_extractor/VCFX_field_extractor.h
@@ -1,16 +1,16 @@
 #ifndef VCFX_FIELD_EXTRACTOR_H
 #define VCFX_FIELD_EXTRACTOR_H
 
-#include <string>
-#include <vector>
 #include <iostream>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 // Displays usage/help
 void printHelp();
 
 // Main extraction function that reads from 'in', writes to 'out', extracting
 // user-specified fields (including standard fields, INFO subfields, and sample subfields).
-void extractFields(std::istream& in, std::ostream& out, const std::vector<std::string>& fields);
+void extractFields(std::istream &in, std::ostream &out, const std::vector<std::string> &fields);
 
 #endif // VCFX_FIELD_EXTRACTOR_H

--- a/src/VCFX_file_splitter/VCFX_file_splitter.cpp
+++ b/src/VCFX_file_splitter/VCFX_file_splitter.cpp
@@ -1,41 +1,38 @@
-#include "vcfx_core.h"
 #include "VCFX_file_splitter.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
+#include <algorithm>
 #include <fstream>
+#include <getopt.h>
+#include <iostream>
+#include <memory>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
-#include <algorithm>
-#include <memory>
-#include <iostream>
 
 struct ChromFile {
     std::unique_ptr<std::ofstream> ofs;
     bool headerWritten;
 };
 
-int VCFXFileSplitter::run(int argc, char* argv[]) {
+int VCFXFileSplitter::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
     std::string outputPrefix = "split";
 
     static struct option long_options[] = {
-        {"help",   no_argument,       0, 'h'},
-        {"prefix", required_argument, 0, 'p'},
-        {0,        0,                 0,  0}
-    };
+        {"help", no_argument, 0, 'h'}, {"prefix", required_argument, 0, 'p'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "hp:", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'p':
-                outputPrefix = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'p':
+            outputPrefix = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -60,8 +57,7 @@ void VCFXFileSplitter::displayHelp() {
 }
 
 // Splits the VCF by chromosome, writing the full header to each file.
-void VCFXFileSplitter::splitVCFByChromosome(std::istream& in,
-                                            const std::string& outputPrefix) {
+void VCFXFileSplitter::splitVCFByChromosome(std::istream &in, const std::string &outputPrefix) {
     std::unordered_map<std::string, ChromFile> chromFiles;
 
     // We'll store all lines that begin with '#' (the header lines) until we hit
@@ -159,10 +155,17 @@ void VCFXFileSplitter::splitVCFByChromosome(std::istream& in,
     }
 }
 
-static void show_help() { VCFXFileSplitter obj; char arg0[] = "VCFX_file_splitter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXFileSplitter obj;
+    char arg0[] = "VCFX_file_splitter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_file_splitter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_file_splitter", show_help))
+        return 0;
     VCFXFileSplitter splitter;
     return splitter.run(argc, argv);
 }

--- a/src/VCFX_file_splitter/VCFX_file_splitter.h
+++ b/src/VCFX_file_splitter/VCFX_file_splitter.h
@@ -6,16 +6,16 @@
 
 // VCFXFileSplitter: Splits a VCF file by chromosome into multiple smaller VCFs.
 class VCFXFileSplitter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Splits the input VCF by chromosome using the specified prefix
-    void splitVCFByChromosome(std::istream& in, const std::string& outputPrefix);
+    void splitVCFByChromosome(std::istream &in, const std::string &outputPrefix);
 };
 
 #endif // VCFX_FILE_SPLITTER_H

--- a/src/VCFX_format_converter/VCFX_format_converter.cpp
+++ b/src/VCFX_format_converter/VCFX_format_converter.cpp
@@ -1,8 +1,8 @@
-#include "vcfx_core.h"
 #include "VCFX_format_converter.h"
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cctype>
+#include <sstream>
 
 // -----------------------------------------------------------------------
 // printHelp
@@ -24,7 +24,7 @@ void printHelp() {
 // -----------------------------------------------------------------------
 // parseArguments
 // -----------------------------------------------------------------------
-bool parseArguments(int argc, char* argv[], OutputFormat& format) {
+bool parseArguments(int argc, char *argv[], OutputFormat &format) {
     format = OutputFormat::UNKNOWN;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -41,10 +41,10 @@ bool parseArguments(int argc, char* argv[], OutputFormat& format) {
 
 // -----------------------------------------------------------------------
 // convertVCFtoBED
-//   - For each variant line, output a single BED line: 
+//   - For each variant line, output a single BED line:
 //     chrom, start=(pos-1 clamped to >=0), end=(pos-1 + ref.size()), name=id
 // -----------------------------------------------------------------------
-void convertVCFtoBED(std::istream& in, std::ostream& out) {
+void convertVCFtoBED(std::istream &in, std::ostream &out) {
     std::string line;
     while (std::getline(in, line)) {
         if (line.empty() || line[0] == '#') {
@@ -69,19 +69,19 @@ void convertVCFtoBED(std::istream& in, std::ostream& out) {
         const std::string &chrom = fields[0];
         int pos = 0;
         try {
-            pos = std::stoi(fields[1]); 
+            pos = std::stoi(fields[1]);
         } catch (...) {
             // invalid pos => skip
             continue;
         }
-        const std::string &id  = fields[2];
+        const std::string &id = fields[2];
         const std::string &ref = fields[3];
         // alt = fields[4] if needed, but not used in basic bed
 
         // Start coordinate
         // If pos==1 => start=0
-        int start = std::max(0, pos - 1); // clamp to >=0
-        int end   = start + (int)ref.size(); // simplistic approach if ref is multi-base
+        int start = std::max(0, pos - 1);  // clamp to >=0
+        int end = start + (int)ref.size(); // simplistic approach if ref is multi-base
 
         // Format: chrom, start, end, name
         out << chrom << "\t" << start << "\t" << end << "\t" << id << "\n";
@@ -89,15 +89,13 @@ void convertVCFtoBED(std::istream& in, std::ostream& out) {
 }
 
 // -----------------------------------------------------------------------
-// Helper function: CSV-escape a single field. 
+// Helper function: CSV-escape a single field.
 //   - If field has comma or quote, enclose in quotes and double the quotes.
 // -----------------------------------------------------------------------
 static std::string csvEscape(const std::string &field) {
     bool needQuotes = false;
     // check if it contains a comma or a quote
-    if (field.find(',') != std::string::npos ||
-        field.find('"') != std::string::npos) 
-    {
+    if (field.find(',') != std::string::npos || field.find('"') != std::string::npos) {
         needQuotes = true;
     }
     // if it has any control chars or whitespace, you might also consider quoting
@@ -129,7 +127,7 @@ static std::string csvEscape(const std::string &field) {
 //   - We do minimal CSV: if a field has comma or quote, we enclose in quotes
 //     and double any quotes inside.
 // -----------------------------------------------------------------------
-void convertVCFtoCSV(std::istream& in, std::ostream& out) {
+void convertVCFtoCSV(std::istream &in, std::ostream &out) {
     std::string line;
     bool wroteHeader = false;
     std::vector<std::string> headerCols; // from #CHROM line if we want to produce a CSV header
@@ -141,7 +139,7 @@ void convertVCFtoCSV(std::istream& in, std::ostream& out) {
         if (line[0] == '#') {
             // Optionally parse #CHROM line to produce a CSV header.
             // If you'd like a CSV header row, you can do something like:
-            if (!wroteHeader && line.rfind("#CHROM",0) == 0) {
+            if (!wroteHeader && line.rfind("#CHROM", 0) == 0) {
                 // parse the columns
                 std::stringstream ss(line.substr(1)); // drop '#'
                 std::vector<std::string> hdrTokens;
@@ -152,9 +150,10 @@ void convertVCFtoCSV(std::istream& in, std::ostream& out) {
                     }
                 }
                 // output as CSV header
-                for (size_t i=0; i<hdrTokens.size(); i++) {
+                for (size_t i = 0; i < hdrTokens.size(); i++) {
                     out << csvEscape(hdrTokens[i]);
-                    if (i+1 < hdrTokens.size()) out << ",";
+                    if (i + 1 < hdrTokens.size())
+                        out << ",";
                 }
                 out << "\n";
                 wroteHeader = true;
@@ -174,9 +173,10 @@ void convertVCFtoCSV(std::istream& in, std::ostream& out) {
         }
 
         // Join them as CSV, escaping if needed
-        for (size_t i=0; i<fields.size(); i++) {
+        for (size_t i = 0; i < fields.size(); i++) {
             out << csvEscape(fields[i]);
-            if (i+1 < fields.size()) out << ",";
+            if (i + 1 < fields.size())
+                out << ",";
         }
         out << "\n";
     }
@@ -187,15 +187,16 @@ void convertVCFtoCSV(std::istream& in, std::ostream& out) {
 // -----------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_format_converter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_format_converter", show_help))
+        return 0;
     OutputFormat format;
     bool valid = parseArguments(argc, argv, format);
 
     // Check if user asked for help
-    for (int i=1; i<argc; i++) {
+    for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
-        if (a=="--help" || a=="-h") {
+        if (a == "--help" || a == "-h") {
             printHelp();
             return 0;
         }
@@ -208,15 +209,15 @@ int main(int argc, char* argv[]) {
     }
 
     switch (format) {
-        case OutputFormat::BED:
-            convertVCFtoBED(std::cin, std::cout);
-            break;
-        case OutputFormat::CSV:
-            convertVCFtoCSV(std::cin, std::cout);
-            break;
-        default:
-            std::cerr << "Unsupported output format.\n";
-            return 1;
+    case OutputFormat::BED:
+        convertVCFtoBED(std::cin, std::cout);
+        break;
+    case OutputFormat::CSV:
+        convertVCFtoCSV(std::cin, std::cout);
+        break;
+    default:
+        std::cerr << "Unsupported output format.\n";
+        return 1;
     }
 
     return 0;

--- a/src/VCFX_format_converter/VCFX_format_converter.h
+++ b/src/VCFX_format_converter/VCFX_format_converter.h
@@ -6,20 +6,16 @@
 #include <vector>
 
 // Enumeration for output formats
-enum class OutputFormat {
-    BED,
-    CSV,
-    UNKNOWN
-};
+enum class OutputFormat { BED, CSV, UNKNOWN };
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], OutputFormat& format);
+bool parseArguments(int argc, char *argv[], OutputFormat &format);
 
 // Function to convert VCF to BED
-void convertVCFtoBED(std::istream& in, std::ostream& out);
+void convertVCFtoBED(std::istream &in, std::ostream &out);
 
 // Function to convert VCF to CSV
-void convertVCFtoCSV(std::istream& in, std::ostream& out);
+void convertVCFtoCSV(std::istream &in, std::ostream &out);
 
 // Function to display help message
 void printHelp();

--- a/src/VCFX_genotype_query/VCFX_genotype_query.cpp
+++ b/src/VCFX_genotype_query/VCFX_genotype_query.cpp
@@ -1,44 +1,43 @@
-#include "vcfx_core.h"
 #include "VCFX_genotype_query.h"
-#include <sstream>
-#include <vector>
+#include "vcfx_core.h"
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <iostream>
-#include <cctype>
+#include <sstream>
+#include <vector>
 
 // ------------------------------------------------------------------
 // printHelp
 // ------------------------------------------------------------------
 void printHelp() {
-    std::cout 
-        << "VCFX_genotype_query\n"
-        << "Usage: VCFX_genotype_query [OPTIONS]\n\n"
-        << "Options:\n"
-        << "  --genotype-query, -g \"GENOTYPE\"  Specify the genotype to query (e.g., \"0/1\", \"1/1\").\n"
-        << "  --strict                        Use strict string compare (no phasing unify or allele sorting).\n"
-        << "  --help, -h                      Display this help message and exit.\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin, outputs only the lines (plus all header lines) where\n"
-        << "  at least one sample has the specified genotype in the 'GT' subfield.\n\n"
-        << "Examples:\n"
-        << "  # Flexible matching 0/1 or 0|1 => both become 0/1\n"
-        << "  ./VCFX_genotype_query --genotype-query \"0/1\" < input.vcf > out.vcf\n\n"
-        << "  # Strict matching => \"0|1\" won't match \"0/1\"\n"
-        << "  ./VCFX_genotype_query --genotype-query \"0|1\" --strict < input.vcf > out.vcf\n";
+    std::cout << "VCFX_genotype_query\n"
+              << "Usage: VCFX_genotype_query [OPTIONS]\n\n"
+              << "Options:\n"
+              << "  --genotype-query, -g \"GENOTYPE\"  Specify the genotype to query (e.g., \"0/1\", \"1/1\").\n"
+              << "  --strict                        Use strict string compare (no phasing unify or allele sorting).\n"
+              << "  --help, -h                      Display this help message and exit.\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin, outputs only the lines (plus all header lines) where\n"
+              << "  at least one sample has the specified genotype in the 'GT' subfield.\n\n"
+              << "Examples:\n"
+              << "  # Flexible matching 0/1 or 0|1 => both become 0/1\n"
+              << "  ./VCFX_genotype_query --genotype-query \"0/1\" < input.vcf > out.vcf\n\n"
+              << "  # Strict matching => \"0|1\" won't match \"0/1\"\n"
+              << "  ./VCFX_genotype_query --genotype-query \"0|1\" --strict < input.vcf > out.vcf\n";
 }
 
 // ------------------------------------------------------------------
 // parseArguments
 // ------------------------------------------------------------------
-bool parseArguments(int argc, char* argv[], std::string& genotype_query, bool &strictCompare) {
+bool parseArguments(int argc, char *argv[], std::string &genotype_query, bool &strictCompare) {
     genotype_query.clear();
     strictCompare = false;
-    for (int i=1; i<argc; i++) {
+    for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-        if ((arg == "--genotype-query" || arg == "-g") && i+1<argc) {
+        if ((arg == "--genotype-query" || arg == "-g") && i + 1 < argc) {
             genotype_query = argv[++i];
-        } else if (arg.rfind("--genotype-query=",0)==0) {
+        } else if (arg.rfind("--genotype-query=", 0) == 0) {
             // e.g. --genotype-query=0/1
             genotype_query = arg.substr(17);
         } else if (arg == "--strict") {
@@ -58,7 +57,8 @@ bool parseArguments(int argc, char* argv[], std::string& genotype_query, bool &s
 //   - Return empty if malformed
 // ------------------------------------------------------------------
 static std::string unifyGenotype(const std::string &gt, bool strict) {
-    if (gt.empty()) return "";
+    if (gt.empty())
+        return "";
 
     // If user wants strict compare, do no changes
     if (strict) {
@@ -68,7 +68,8 @@ static std::string unifyGenotype(const std::string &gt, bool strict) {
     // unify phasing
     std::string g = gt;
     for (char &c : g) {
-        if (c=='|') c = '/';
+        if (c == '|')
+            c = '/';
     }
 
     // Split on '/'
@@ -76,7 +77,7 @@ static std::string unifyGenotype(const std::string &gt, bool strict) {
     {
         std::stringstream ss(g);
         std::string t;
-        while (std::getline(ss,t,'/')) {
+        while (std::getline(ss, t, '/')) {
             tokens.push_back(t);
         }
     }
@@ -88,7 +89,7 @@ static std::string unifyGenotype(const std::string &gt, bool strict) {
     // Check numeric; if not numeric or ".", leave as is
     std::vector<int> vals;
     for (auto &tk : tokens) {
-        if (tk=="." || tk.empty()) {
+        if (tk == "." || tk.empty()) {
             // missing
             return g;
         }
@@ -111,10 +112,7 @@ static std::string unifyGenotype(const std::string &gt, bool strict) {
 // ------------------------------------------------------------------
 // genotypeQuery: stream-based approach
 // ------------------------------------------------------------------
-void genotypeQuery(std::istream& in, std::ostream& out,
-                   const std::string& genotype_query,
-                   bool strictCompare) 
-{
+void genotypeQuery(std::istream &in, std::ostream &out, const std::string &genotype_query, bool strictCompare) {
     bool foundChrom = false;
     bool printedHeader = false;
     std::vector<std::string> headerLines;
@@ -183,7 +181,7 @@ void genotypeQuery(std::istream& in, std::ostream& out,
                 }
             }
             int gtIndex = -1;
-            for (int i=0; i<(int)fmts.size(); i++) {
+            for (int i = 0; i < (int)fmts.size(); i++) {
                 if (fmts[i] == "GT") {
                     gtIndex = i;
                     break;
@@ -206,7 +204,7 @@ void genotypeQuery(std::istream& in, std::ostream& out,
                     }
                 }
                 if (gtIndex >= (int)sampleTokens.size()) {
-                    continue; 
+                    continue;
                 }
                 // unify genotype
                 std::string gtVal = unifyGenotype(sampleTokens[gtIndex], strictCompare);
@@ -241,8 +239,9 @@ void genotypeQuery(std::istream& in, std::ostream& out,
 // ------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_genotype_query", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_genotype_query", show_help))
+        return 0;
     std::string genotypeQueryStr;
     bool strictCompare = false;
     if (!parseArguments(argc, argv, genotypeQueryStr, strictCompare)) {

--- a/src/VCFX_genotype_query/VCFX_genotype_query.h
+++ b/src/VCFX_genotype_query/VCFX_genotype_query.h
@@ -5,12 +5,12 @@
 #include <string>
 
 // Parses command-line arguments to get the desired genotype query and a 'strict' flag
-bool parseArguments(int argc, char* argv[], std::string& genotype_query, bool &strictCompare);
+bool parseArguments(int argc, char *argv[], std::string &genotype_query, bool &strictCompare);
 
 // Prints usage/help
 void printHelp();
 
 // Filters a VCF from 'in', writing only records that contain at least one sample with the requested genotype
-void genotypeQuery(std::istream& in, std::ostream& out, const std::string& genotype_query, bool strictCompare);
+void genotypeQuery(std::istream &in, std::ostream &out, const std::string &genotype_query, bool strictCompare);
 
 #endif // VCFX_GENOTYPE_QUERY_H

--- a/src/VCFX_gl_filter/VCFX_gl_filter.h
+++ b/src/VCFX_gl_filter/VCFX_gl_filter.h
@@ -6,18 +6,16 @@
 
 // VCFXGLFilter: Filters VCF records by a genotype-likelihood field (e.g. "GQ>20").
 class VCFXGLFilter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Filters VCF input based on genotype-likelihood expression
-    void filterByGL(std::istream& in, std::ostream& out, 
-                    const std::string& filterCondition,
-                    bool anyMode);
+    void filterByGL(std::istream &in, std::ostream &out, const std::string &filterCondition, bool anyMode);
 };
 
 #endif // VCFX_GL_FILTER_H

--- a/src/VCFX_haplotype_extractor/VCFX_haplotype_extractor.cpp
+++ b/src/VCFX_haplotype_extractor/VCFX_haplotype_extractor.cpp
@@ -1,10 +1,10 @@
-#include "vcfx_core.h"
 #include "VCFX_haplotype_extractor.h"
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <stdexcept>
 #include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
 
 // Constructor not needed here, we do no special initialization
 // HaplotypeExtractor::HaplotypeExtractor() {}
@@ -17,10 +17,10 @@ void printHelp() {
               << "Usage: VCFX_haplotype_extractor [OPTIONS]\n\n"
               << "Options:\n"
               << "  --help, -h                 Display this help message and exit.\n"
-             << "  --block-size <int>         Maximum distance for grouping consecutive variants (default 100000).\n"
-             << "  --check-phase-consistency  If set, try a minimal check across variants.\n"
-             << "  --debug                   Output verbose debug information.\n\n"
-             << "Description:\n"
+              << "  --block-size <int>         Maximum distance for grouping consecutive variants (default 100000).\n"
+              << "  --check-phase-consistency  If set, try a minimal check across variants.\n"
+              << "  --debug                   Output verbose debug information.\n\n"
+              << "Description:\n"
               << "  Extracts phased haplotype blocks from genotype data in a VCF file. "
               << "It reconstructs haplotypes for each sample by analyzing phased genotype fields.\n\n"
               << "Examples:\n"
@@ -31,7 +31,7 @@ void printHelp() {
 // ---------------------------------------------------------------------
 // parseHeader: parse #CHROM line => sample columns
 // ---------------------------------------------------------------------
-bool HaplotypeExtractor::parseHeader(const std::string& headerLine) {
+bool HaplotypeExtractor::parseHeader(const std::string &headerLine) {
     auto fields = splitString(headerLine, '\t');
     if (fields.size() <= 8) {
         std::cerr << "Error: VCF header does not contain sample columns.\n";
@@ -46,7 +46,7 @@ bool HaplotypeExtractor::parseHeader(const std::string& headerLine) {
 // ---------------------------------------------------------------------
 // splitString
 // ---------------------------------------------------------------------
-std::vector<std::string> HaplotypeExtractor::splitString(const std::string& str, char delimiter) {
+std::vector<std::string> HaplotypeExtractor::splitString(const std::string &str, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string tmp;
@@ -59,7 +59,7 @@ std::vector<std::string> HaplotypeExtractor::splitString(const std::string& str,
 // ---------------------------------------------------------------------
 // areAllSamplesPhased: checks each genotype for '|'
 // ---------------------------------------------------------------------
-bool HaplotypeExtractor::areAllSamplesPhased(const std::vector<std::string>& genotypes) {
+bool HaplotypeExtractor::areAllSamplesPhased(const std::vector<std::string> &genotypes) {
     for (auto &g : genotypes) {
         if (g.find('|') == std::string::npos) {
             return false;
@@ -71,13 +71,11 @@ bool HaplotypeExtractor::areAllSamplesPhased(const std::vector<std::string>& gen
 // ---------------------------------------------------------------------
 // phaseIsConsistent: minimal check across variants
 //   e.g. if new variant has "0|1" but existing block's last variant for that sample was "1|0"
-//   we might call that inconsistent if we want a simplistic approach. 
+//   we might call that inconsistent if we want a simplistic approach.
 //   This logic is trivially commented out or replaced with a more advanced approach.
 // ---------------------------------------------------------------------
-bool HaplotypeExtractor::phaseIsConsistent(const HaplotypeBlock& block,
-                                           const std::vector<std::string>& newGenotypes)
-{
-    // We'll do a naive check: if the new genotype is e.g. "0|1" 
+bool HaplotypeExtractor::phaseIsConsistent(const HaplotypeBlock &block, const std::vector<std::string> &newGenotypes) {
+    // We'll do a naive check: if the new genotype is e.g. "0|1"
     // but the last appended genotype portion for the sample is "1|0", we call it inconsistent.
     // Actually, we store haplotypes with each variant appended by "|" + newGT?
     // We'll parse the last variant's GT for each sample from the block's haplotypes.
@@ -87,17 +85,17 @@ bool HaplotypeExtractor::phaseIsConsistent(const HaplotypeBlock& block,
         // mismatch in #samples => inconsistent
         return false;
     }
-    
+
     // Optional debugging output
     if (debugMode) {
         std::cerr << "Checking phase consistency\n";
     }
 
-    for (size_t s=0; s<block.haplotypes.size(); s++) {
+    for (size_t s = 0; s < block.haplotypes.size(); s++) {
         // block's haplotypes[s] is a big string with variants separated by '|', e.g. "0|1|0|1"
         // let's get the last chunk after the last '|'
         const std::string &allVar = block.haplotypes[s];
-        
+
         // The haplotype string is stored like: "0|1|1|0|0|1" where each pair is one genotype
         // We need to extract the last genotype, which is the last 3 characters
         std::string lastGT;
@@ -114,7 +112,7 @@ bool HaplotypeExtractor::phaseIsConsistent(const HaplotypeBlock& block,
                 lastGT = allVar.substr(lastPipePos - 1);
             }
         }
-        
+
         if (debugMode) {
             std::cerr << "Sample " << s << " last GT: " << lastGT << " new GT: " << newGenotypes[s] << "\n";
         }
@@ -124,25 +122,25 @@ bool HaplotypeExtractor::phaseIsConsistent(const HaplotypeBlock& block,
         // e.g. lastGT="0|1", new="1|0"
         // We'll interpret them as numeric pairs, ignoring '.' or weirdness
         // If can't parse => skip checking
-        if (lastGT.size()<3 || newGenotypes[s].size()<3) {
+        if (lastGT.size() < 3 || newGenotypes[s].size() < 3) {
             continue;
         }
-        
+
         // Get the first and second alleles for comparison
         char lastAllele1 = (lastGT.size() >= 1) ? lastGT[lastGT.size() - 3] : '.';
         char lastAllele2 = (lastGT.size() >= 1) ? lastGT[lastGT.size() - 1] : '.';
         char newAllele1 = newGenotypes[s][0];
         char newAllele2 = newGenotypes[s][2];
-        
+
         if (debugMode) {
-            std::cerr << "Comparing alleles: " << lastAllele1 << "|" << lastAllele2
-                      << " vs " << newAllele1 << "|" << newAllele2 << "\n";
+            std::cerr << "Comparing alleles: " << lastAllele1 << "|" << lastAllele2 << " vs " << newAllele1 << "|"
+                      << newAllele2 << "\n";
         }
-        
+
         // If e.g. lastGT=="0|1", newGenotypes=="1|0" => inconsistent
         // Check for phase flips - when both alleles flip positions
-        if (lastAllele1 != newAllele1 && lastAllele2 != newAllele2 && 
-            lastAllele1 == newAllele2 && lastAllele2 == newAllele1) {
+        if (lastAllele1 != newAllele1 && lastAllele2 != newAllele2 && lastAllele1 == newAllele2 &&
+            lastAllele2 == newAllele1) {
             if (debugMode) {
                 std::cerr << "Phase flip detected in sample " << s << "\n";
             }
@@ -160,16 +158,14 @@ bool HaplotypeExtractor::phaseIsConsistent(const HaplotypeBlock& block,
 // updateBlocks: merges new variant into last block or starts new block
 //   we rely on the blockDistanceThreshold and (optionally) checkPhaseConsistency
 // ---------------------------------------------------------------------
-void HaplotypeExtractor::updateBlocks(std::vector<HaplotypeBlock>& haplotypeBlocks,
-                                      const std::string& chrom, int pos,
-                                      const std::vector<std::string>& genotypes)
-{
+void HaplotypeExtractor::updateBlocks(std::vector<HaplotypeBlock> &haplotypeBlocks, const std::string &chrom, int pos,
+                                      const std::vector<std::string> &genotypes) {
     if (haplotypeBlocks.empty()) {
         // start first block
         HaplotypeBlock b;
         b.chrom = chrom;
         b.start = pos;
-        b.end   = pos;
+        b.end = pos;
         // haplotypes => each sample's genotype
         b.haplotypes = genotypes;
         haplotypeBlocks.push_back(std::move(b));
@@ -180,8 +176,7 @@ void HaplotypeExtractor::updateBlocks(std::vector<HaplotypeBlock>& haplotypeBloc
     HaplotypeBlock &lastB = haplotypeBlocks.back();
     // if same chrom, and pos-lastB.end <= blockDistanceThreshold
     // and if checkPhaseConsistency => phaseIsConsistent
-    bool canExtend = (chrom == lastB.chrom) &&
-                     (pos - lastB.end <= blockDistanceThreshold);
+    bool canExtend = (chrom == lastB.chrom) && (pos - lastB.end <= blockDistanceThreshold);
 
     if (canExtend && checkPhaseConsistency) {
         canExtend = phaseIsConsistent(lastB, genotypes);
@@ -192,7 +187,7 @@ void HaplotypeExtractor::updateBlocks(std::vector<HaplotypeBlock>& haplotypeBloc
         lastB.end = pos;
         // for each sample, append "|" + new genotype
         // if they are guaranteed phased, we can do that
-        for (size_t s=0; s<lastB.haplotypes.size(); s++) {
+        for (size_t s = 0; s < lastB.haplotypes.size(); s++) {
             lastB.haplotypes[s] += "|" + genotypes[s];
         }
     } else {
@@ -200,7 +195,7 @@ void HaplotypeExtractor::updateBlocks(std::vector<HaplotypeBlock>& haplotypeBloc
         HaplotypeBlock nb;
         nb.chrom = chrom;
         nb.start = pos;
-        nb.end   = pos;
+        nb.end = pos;
         nb.haplotypes = genotypes;
         haplotypeBlocks.push_back(std::move(nb));
     }
@@ -209,18 +204,17 @@ void HaplotypeExtractor::updateBlocks(std::vector<HaplotypeBlock>& haplotypeBloc
 // ---------------------------------------------------------------------
 // processVariant: parse data line, check phased, update blocks
 // ---------------------------------------------------------------------
-bool HaplotypeExtractor::processVariant(const std::vector<std::string>& fields,
-                                        std::vector<HaplotypeBlock>& haplotypeBlocks)
-{
-    if (fields.size()<9) {
+bool HaplotypeExtractor::processVariant(const std::vector<std::string> &fields,
+                                        std::vector<HaplotypeBlock> &haplotypeBlocks) {
+    if (fields.size() < 9) {
         std::cerr << "Warning: skipping invalid VCF line (<9 fields)\n";
         return false;
     }
     const std::string &chrom = fields[0];
-    int pos=0;
+    int pos = 0;
     try {
         pos = std::stoi(fields[1]);
-    } catch(...) {
+    } catch (...) {
         std::cerr << "Warning: invalid POS => skip variant\n";
         return false;
     }
@@ -228,13 +222,13 @@ bool HaplotypeExtractor::processVariant(const std::vector<std::string>& fields,
     const std::string &formatStr = fields[8];
     auto formatToks = splitString(formatStr, ':');
     int gtIndex = -1;
-    for (int i=0; i<(int)formatToks.size(); i++) {
-        if (formatToks[i]=="GT") {
+    for (int i = 0; i < (int)formatToks.size(); i++) {
+        if (formatToks[i] == "GT") {
             gtIndex = i;
             break;
         }
     }
-    if (gtIndex<0) {
+    if (gtIndex < 0) {
         // no GT => skip
         return false;
     }
@@ -242,14 +236,14 @@ bool HaplotypeExtractor::processVariant(const std::vector<std::string>& fields,
     // from col=9 onward => sample columns
     std::vector<std::string> genotypeFields(numSamples);
     bool allPhased = true;
-    for (size_t s=0; s<numSamples; s++) {
-        if (9+s >= fields.size()) {
+    for (size_t s = 0; s < numSamples; s++) {
+        if (9 + s >= fields.size()) {
             // missing sample => set .|.
             genotypeFields[s] = ".|.";
             allPhased = false;
             continue;
         }
-        auto sampleToks = splitString(fields[9+s], ':');
+        auto sampleToks = splitString(fields[9 + s], ':');
         if (gtIndex >= (int)sampleToks.size()) {
             genotypeFields[s] = ".|.";
             allPhased = false;
@@ -257,7 +251,7 @@ bool HaplotypeExtractor::processVariant(const std::vector<std::string>& fields,
         }
         // e.g. "0|1"
         std::string gt = sampleToks[gtIndex];
-        if (gt.find('|')==std::string::npos) {
+        if (gt.find('|') == std::string::npos) {
             allPhased = false;
         }
         genotypeFields[s] = gt;
@@ -278,16 +272,17 @@ bool HaplotypeExtractor::processVariant(const std::vector<std::string>& fields,
 // ---------------------------------------------------------------------
 // extractHaplotypes: main function to read from 'in', produce blocks => 'out'
 // ---------------------------------------------------------------------
-bool HaplotypeExtractor::extractHaplotypes(std::istream& in, std::ostream& out) {
+bool HaplotypeExtractor::extractHaplotypes(std::istream &in, std::ostream &out) {
     bool foundHeader = false;
     std::vector<HaplotypeBlock> haplotypeBlocks;
 
     std::string line;
     while (std::getline(in, line)) {
-        if (line.empty()) continue;
-        if (line[0]=='#') {
+        if (line.empty())
+            continue;
+        if (line[0] == '#') {
             // if #CHROM => parse
-            if (!foundHeader && line.rfind("#CHROM",0)==0) {
+            if (!foundHeader && line.rfind("#CHROM", 0) == 0) {
                 foundHeader = true;
                 if (!parseHeader(line)) {
                     return false;
@@ -329,23 +324,24 @@ bool HaplotypeExtractor::extractHaplotypes(std::istream& in, std::ostream& out) 
 // ---------------------------------------------------------------------
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_haplotype_extractor", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_haplotype_extractor", show_help))
+        return 0;
     int blockSize = 100000;
     bool doCheck = false;
     bool debug = false;
 
     // simple arg parse
-    for (int i=1; i<argc; i++) {
+    for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
-        if (a=="--help" || a=="-h") {
+        if (a == "--help" || a == "-h") {
             printHelp();
             return 0;
-        } else if (a=="--block-size" && i+1<argc) {
+        } else if (a == "--block-size" && i + 1 < argc) {
             blockSize = std::stoi(argv[++i]);
-        } else if (a=="--check-phase-consistency") {
+        } else if (a == "--check-phase-consistency") {
             doCheck = true;
-        } else if (a=="--debug") {
+        } else if (a == "--debug") {
             debug = true;
         }
     }

--- a/src/VCFX_haplotype_extractor/VCFX_haplotype_extractor.h
+++ b/src/VCFX_haplotype_extractor/VCFX_haplotype_extractor.h
@@ -18,12 +18,12 @@ struct HaplotypeBlock {
 
 // Class to handle haplotype extraction
 class HaplotypeExtractor {
-public:
+  public:
     HaplotypeExtractor() = default;
     ~HaplotypeExtractor() = default;
 
     // Runs the core logic to parse the VCF and write haplotype blocks
-    bool extractHaplotypes(std::istream& in, std::ostream& out);
+    bool extractHaplotypes(std::istream &in, std::ostream &out);
 
     // Set the maximum distance for grouping consecutive variants in a block
     void setBlockDistanceThreshold(int dist) { blockDistanceThreshold = dist; }
@@ -34,7 +34,7 @@ public:
     // Enable or disable debug messages
     void setDebug(bool b) { debugMode = b; }
 
-private:
+  private:
     std::vector<std::string> sampleNames;
     size_t numSamples = 0;
 
@@ -48,27 +48,24 @@ private:
     bool debugMode = false;
 
     // Parses the #CHROM line to extract sample names
-    bool parseHeader(const std::string& headerLine);
+    bool parseHeader(const std::string &headerLine);
 
     // Splits a string by a delimiter
-    std::vector<std::string> splitString(const std::string& str, char delimiter);
+    std::vector<std::string> splitString(const std::string &str, char delimiter);
 
     // Processes one VCF data line => update or start a haplotype block
     // Returns false if variant not fully processed
-    bool processVariant(const std::vector<std::string>& fields,
-                        std::vector<HaplotypeBlock>& haplotypeBlocks);
+    bool processVariant(const std::vector<std::string> &fields, std::vector<HaplotypeBlock> &haplotypeBlocks);
 
     // For each sample's genotype, ensures it is phased. If any unphased => return false
-    bool areAllSamplesPhased(const std::vector<std::string>& genotypes);
+    bool areAllSamplesPhased(const std::vector<std::string> &genotypes);
 
     // Minimal check that new variant's genotypes are "consistent" with the existing block
-    bool phaseIsConsistent(const HaplotypeBlock& block,
-                           const std::vector<std::string>& newGenotypes);
+    bool phaseIsConsistent(const HaplotypeBlock &block, const std::vector<std::string> &newGenotypes);
 
     // Actually merges the new variant's genotypes into the last block or starts a new one
-    void updateBlocks(std::vector<HaplotypeBlock>& haplotypeBlocks,
-                      const std::string& chrom, int pos,
-                      const std::vector<std::string>& genotypes);
+    void updateBlocks(std::vector<HaplotypeBlock> &haplotypeBlocks, const std::string &chrom, int pos,
+                      const std::vector<std::string> &genotypes);
 };
 
 #endif // VCFX_HAPLOTYPE_EXTRACTOR_H

--- a/src/VCFX_haplotype_phaser/VCFX_haplotype_phaser.cpp
+++ b/src/VCFX_haplotype_phaser/VCFX_haplotype_phaser.cpp
@@ -1,40 +1,37 @@
-#include "vcfx_core.h"
 #include "VCFX_haplotype_phaser.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cmath>
+#include <getopt.h>
 #include <numeric>
+#include <sstream>
 #include <vector>
 
-int VCFXHaplotypePhaser::run(int argc, char* argv[]) {
+int VCFXHaplotypePhaser::run(int argc, char *argv[]) {
     // parse arguments
     int opt;
     bool showHelp = false;
     double ldThreshold = 0.8;
 
     static struct option long_options[] = {
-        {"help",        no_argument,       0, 'h'},
-        {"ld-threshold", required_argument, 0, 'l'},
-        {0,             0,                 0,  0 }
-    };
+        {"help", no_argument, 0, 'h'}, {"ld-threshold", required_argument, 0, 'l'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "hl:", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'l':
-                try {
-                    ldThreshold = std::stod(optarg);
-                } catch(...) {
-                    std::cerr << "Error: invalid LD threshold.\n";
-                    displayHelp();
-                    return 1;
-                }
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'l':
+            try {
+                ldThreshold = std::stod(optarg);
+            } catch (...) {
+                std::cerr << "Error: invalid LD threshold.\n";
+                displayHelp();
+                return 1;
+            }
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -43,7 +40,7 @@ int VCFXHaplotypePhaser::run(int argc, char* argv[]) {
         displayHelp();
         return 0;
     }
-    
+
     // If LD threshold is invalid, show help and return error (1)
     if (ldThreshold < 0.0 || ldThreshold > 1.0) {
         std::cerr << "Error: invalid LD threshold\n";
@@ -66,25 +63,25 @@ void VCFXHaplotypePhaser::displayHelp() {
               << "  VCFX_haplotype_phaser --ld-threshold 0.9 < input.vcf > blocks.txt\n";
 }
 
-void VCFXHaplotypePhaser::phaseHaplotypes(std::istream& in, std::ostream& out, double ldThreshold) {
+void VCFXHaplotypePhaser::phaseHaplotypes(std::istream &in, std::ostream &out, double ldThreshold) {
     std::string line;
     bool foundHeader = false;
 
     // We'll store the final list of variants
     std::vector<VariantData> variantList;
     std::vector<std::string> sampleNames;
-    
+
     // Read header lines until first non-# line
     bool foundFirstVariant = false;
     std::string firstVariantLine;
-    
+
     while (!foundFirstVariant && std::getline(in, line)) {
         if (line.empty()) {
             continue;
         }
         if (line[0] == '#') {
             // if it's #CHROM, parse sample columns
-            if (!foundHeader && line.rfind("#CHROM",0)==0) {
+            if (!foundHeader && line.rfind("#CHROM", 0) == 0) {
                 // parse
                 std::stringstream ss(line);
                 std::string f;
@@ -93,7 +90,7 @@ void VCFXHaplotypePhaser::phaseHaplotypes(std::istream& in, std::ostream& out, d
                     tokens.push_back(f);
                 }
                 // from col=9 onward => samples
-                for (size_t c=9; c<tokens.size(); c++) {
+                for (size_t c = 9; c < tokens.size(); c++) {
                     sampleNames.push_back(tokens[c]);
                 }
                 foundHeader = true;
@@ -111,13 +108,13 @@ void VCFXHaplotypePhaser::phaseHaplotypes(std::istream& in, std::ostream& out, d
         std::cerr << "Error: no #CHROM line found.\n";
         return;
     }
-    
+
     // Process variants
-    auto processVariantLine = [&](const std::string& varLine) {
-        if (varLine.empty() || varLine[0]=='#') {
+    auto processVariantLine = [&](const std::string &varLine) {
+        if (varLine.empty() || varLine[0] == '#') {
             return;
         }
-        
+
         std::stringstream ss(varLine);
         std::vector<std::string> fields;
         {
@@ -126,8 +123,8 @@ void VCFXHaplotypePhaser::phaseHaplotypes(std::istream& in, std::ostream& out, d
                 fields.push_back(t);
             }
         }
-        
-        if (fields.size()<10) {
+
+        if (fields.size() < 10) {
             std::cerr << "Warning: skipping line with <10 fields: " << varLine << "\n";
             return;
         }
@@ -137,56 +134,56 @@ void VCFXHaplotypePhaser::phaseHaplotypes(std::istream& in, std::ostream& out, d
         std::string id = fields[2];
         std::string ref = fields[3];
         std::string alt = fields[4];
-        
-        int posVal=0;
+
+        int posVal = 0;
         try {
             posVal = std::stoi(posStr);
-        } catch(...) {
+        } catch (...) {
             std::cerr << "Warning: invalid pos => skip " << varLine << "\n";
             return;
         }
 
         // Build the genotype vector for this variant
         std::vector<int> genotypeVec;
-        genotypeVec.reserve(fields.size()-9);
-        for (size_t s=9; s<fields.size(); s++) {
+        genotypeVec.reserve(fields.size() - 9);
+        for (size_t s = 9; s < fields.size(); s++) {
             // e.g. "0/1"
             std::string gt = fields[s];
             // find slash or pipe
             size_t delim = gt.find_first_of("/|");
-            if (delim==std::string::npos) {
+            if (delim == std::string::npos) {
                 genotypeVec.push_back(-1);
                 continue;
             }
             std::string a1 = gt.substr(0, delim);
-            std::string a2 = gt.substr(delim+1);
-            if (a1.empty() || a2.empty() || a1=="." || a2==".") {
+            std::string a2 = gt.substr(delim + 1);
+            if (a1.empty() || a2.empty() || a1 == "." || a2 == ".") {
                 genotypeVec.push_back(-1);
                 continue;
             }
-            int i1=0, i2=0;
+            int i1 = 0, i2 = 0;
             try {
-                i1= std::stoi(a1);
-                i2= std::stoi(a2);
-            } catch(...) {
+                i1 = std::stoi(a1);
+                i2 = std::stoi(a2);
+            } catch (...) {
                 genotypeVec.push_back(-1);
                 continue;
             }
             genotypeVec.push_back(i1 + i2); // naive approach
         }
-        
+
         VariantData v;
         v.chrom = chrom;
         v.pos = posVal;
         v.genotype = genotypeVec;
         variantList.push_back(v);
     };
-    
+
     // Process the first variant line if found during header processing
     if (foundFirstVariant) {
         processVariantLine(firstVariantLine);
     }
-    
+
     // Process remaining variant lines
     while (std::getline(in, line)) {
         processVariantLine(line);
@@ -196,77 +193,77 @@ void VCFXHaplotypePhaser::phaseHaplotypes(std::istream& in, std::ostream& out, d
         std::cerr << "Error: no variant data found.\n";
         return;
     }
-    
+
     // group variants
     auto blocks = groupVariants(variantList, ldThreshold);
-    
+
     // we also output # the line "#HAPLOTYPE_BLOCKS" or something
     out << "#HAPLOTYPE_BLOCKS_START\n";
-    for (size_t b=0; b<blocks.size(); b++) {
-        out << "Block " << (b+1) << ": ";
+    for (size_t b = 0; b < blocks.size(); b++) {
+        out << "Block " << (b + 1) << ": ";
         // We'll list the variants with index, chrom, pos
         // e.g. "0:(chr1:1000), 1:(chr1:1050)"
-        for (size_t i=0; i<blocks[b].size(); i++) {
+        for (size_t i = 0; i < blocks[b].size(); i++) {
             int idx = blocks[b][i];
             out << idx << ":(" << variantList[idx].chrom << ":" << variantList[idx].pos << ")";
-            if (i+1<blocks[b].size()) out << ", ";
+            if (i + 1 < blocks[b].size())
+                out << ", ";
         }
         out << "\n";
     }
     out << "#HAPLOTYPE_BLOCKS_END\n";
 }
 
-LDResult VCFXHaplotypePhaser::calculateLD(const VariantData& v1, const VariantData& v2) {
+LDResult VCFXHaplotypePhaser::calculateLD(const VariantData &v1, const VariantData &v2) {
     // We compute r^2
     // ignoring missing (-1)
-    int n=0;
-    long sumX=0, sumY=0, sumXY=0, sumX2=0, sumY2=0;
-    const auto &g1= v1.genotype;
-    const auto &g2= v2.genotype;
-    
+    int n = 0;
+    long sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+    const auto &g1 = v1.genotype;
+    const auto &g2 = v2.genotype;
+
     LDResult result = {0.0, 0.0};
-    
-    if (g1.size()!=g2.size()) {
+
+    if (g1.size() != g2.size()) {
         return result;
     }
-    for (size_t s=0; s<g1.size(); s++) {
+    for (size_t s = 0; s < g1.size(); s++) {
         int x = g1[s];
         int y = g2[s];
-        if (x<0 || y<0) {
+        if (x < 0 || y < 0) {
             continue; // missing
         }
         n++;
-        sumX+= x;
-        sumY+= y;
-        sumXY += x*y;
-        sumX2 += x*x;
-        sumY2 += y*y;
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+        sumY2 += y * y;
     }
-    if (n==0) {
+    if (n == 0) {
         return result;
     }
-    double meanX= (double)sumX/n;
-    double meanY= (double)sumY/n;
-    double cov  = ((double)sumXY/n) - (meanX*meanY);
-    double varX = ((double)sumX2/n) - (meanX*meanX);
-    double varY = ((double)sumY2/n) - (meanY*meanY);
-    
-    if (varX<=0.0 || varY<=0.0) {
+    double meanX = (double)sumX / n;
+    double meanY = (double)sumY / n;
+    double cov = ((double)sumXY / n) - (meanX * meanY);
+    double varX = ((double)sumX2 / n) - (meanX * meanX);
+    double varY = ((double)sumY2 / n) - (meanY * meanY);
+
+    if (varX <= 0.0 || varY <= 0.0) {
         return result;
     }
-    result.r = cov/(std::sqrt(varX)*std::sqrt(varY));
+    result.r = cov / (std::sqrt(varX) * std::sqrt(varY));
     result.r2 = result.r * result.r;
     return result;
 }
 
-std::vector<std::vector<int>> VCFXHaplotypePhaser::groupVariants(const std::vector<VariantData>& variants,
-                                                                 double ldThreshold)
-{
+std::vector<std::vector<int>> VCFXHaplotypePhaser::groupVariants(const std::vector<VariantData> &variants,
+                                                                 double ldThreshold) {
     std::vector<std::vector<int>> blocks;
     std::vector<int> currentBlock;
     std::string currentChrom = "";
-    
-    for (size_t i=0; i<variants.size(); i++) {
+
+    for (size_t i = 0; i < variants.size(); i++) {
         if (currentBlock.empty()) {
             // Start a new block with the current variant
             currentBlock.push_back(i);
@@ -280,11 +277,11 @@ std::vector<std::vector<int>> VCFXHaplotypePhaser::groupVariants(const std::vect
                 currentChrom = variants[i].chrom;
                 continue;
             }
-            
+
             // Check LD with last variant in current block
             int lastIdx = currentBlock.back();
             LDResult ldResult = calculateLD(variants[lastIdx], variants[i]);
-            
+
             // For all chromosomes:
             // - For chromosome 1: Use both r² and sign of r (r > 0)
             // - For chromosomes 2+: Use only r² value regardless of sign
@@ -296,7 +293,7 @@ std::vector<std::vector<int>> VCFXHaplotypePhaser::groupVariants(const std::vect
                 // For all other chromosomes, only check the r² value
                 shouldAddToBlock = (ldResult.r2 >= ldThreshold);
             }
-            
+
             if (shouldAddToBlock) {
                 // Add to current block if meets LD criteria
                 currentBlock.push_back(i);
@@ -309,19 +306,26 @@ std::vector<std::vector<int>> VCFXHaplotypePhaser::groupVariants(const std::vect
             }
         }
     }
-    
+
     // Add the final block if it's not empty
     if (!currentBlock.empty()) {
         blocks.push_back(currentBlock);
     }
-    
+
     return blocks;
 }
 
-static void show_help() { VCFXHaplotypePhaser obj; char arg0[] = "VCFX_haplotype_phaser"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXHaplotypePhaser obj;
+    char arg0[] = "VCFX_haplotype_phaser";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_haplotype_phaser", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_haplotype_phaser", show_help))
+        return 0;
     VCFXHaplotypePhaser hp;
     return hp.run(argc, argv);
 }

--- a/src/VCFX_haplotype_phaser/VCFX_haplotype_phaser.h
+++ b/src/VCFX_haplotype_phaser/VCFX_haplotype_phaser.h
@@ -14,27 +14,27 @@ struct VariantData {
 
 // Stores the result of LD calculation
 struct LDResult {
-    double r;    // Correlation coefficient
-    double r2;   // Squared correlation coefficient
+    double r;  // Correlation coefficient
+    double r2; // Squared correlation coefficient
 };
 
 class VCFXHaplotypePhaser {
-public:
+  public:
     // main runner
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // prints usage
     void displayHelp();
 
     // Main function that does phasing
-    void phaseHaplotypes(std::istream& in, std::ostream& out, double ldThreshold);
+    void phaseHaplotypes(std::istream &in, std::ostream &out, double ldThreshold);
 
     // Groups variants into haplotype blocks by naive r^2 threshold
-    std::vector<std::vector<int>> groupVariants(const std::vector<VariantData>& variants, double ldThreshold);
+    std::vector<std::vector<int>> groupVariants(const std::vector<VariantData> &variants, double ldThreshold);
 
     // calculates r^2 between two variants
-    LDResult calculateLD(const VariantData& v1, const VariantData& v2);
+    LDResult calculateLD(const VariantData &v1, const VariantData &v2);
 };
 
 #endif // VCFX_HAPLOTYPE_PHASER_H

--- a/src/VCFX_header_parser/VCFX_header_parser.cpp
+++ b/src/VCFX_header_parser/VCFX_header_parser.cpp
@@ -1,5 +1,5 @@
-#include "vcfx_core.h"
 #include "VCFX_header_parser.h"
+#include "vcfx_core.h"
 #include <iostream>
 #include <sstream>
 
@@ -15,7 +15,7 @@ void printHelp() {
               << "  ./VCFX_header_parser < input.vcf > header.txt\n";
 }
 
-void processHeader(std::istream& in, std::ostream& out) {
+void processHeader(std::istream &in, std::ostream &out) {
     std::string line;
     while (std::getline(in, line)) {
         if (!line.empty() && line[0] == '#') {
@@ -28,8 +28,9 @@ void processHeader(std::istream& in, std::ostream& out) {
 
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_header_parser", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_header_parser", show_help))
+        return 0;
     // Simple argument parsing
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];

--- a/src/VCFX_header_parser/VCFX_header_parser.h
+++ b/src/VCFX_header_parser/VCFX_header_parser.h
@@ -5,6 +5,6 @@
 #include <string>
 
 // Function to process and extract header lines from VCF
-void processHeader(std::istream& in, std::ostream& out);
+void processHeader(std::istream &in, std::ostream &out);
 
 #endif // VCFX_HEADER_PARSER_H

--- a/src/VCFX_hwe_tester/VCFX_hwe_tester.cpp
+++ b/src/VCFX_hwe_tester/VCFX_hwe_tester.cpp
@@ -1,27 +1,24 @@
-#include "vcfx_core.h"
 #include "VCFX_hwe_tester.h"
-#include <getopt.h>
-#include <sstream>
-#include <cmath>
-#include <iomanip>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <vector>
-#include <iostream>
+#include <cmath>
 #include <cstdlib>
+#include <getopt.h>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <vector>
 
 // Constructor-like run method
-int VCFXHWETester::run(int argc, char* argv[]) {
+int VCFXHWETester::run(int argc, char *argv[]) {
     int opt;
     bool showHelp = false;
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},
-        {0,0,0,0}
-    };
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
     while ((opt = getopt_long(argc, argv, "h", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-            default:
-                showHelp = true;
+        case 'h':
+        default:
+            showHelp = true;
         }
     }
     if (showHelp) {
@@ -35,16 +32,15 @@ int VCFXHWETester::run(int argc, char* argv[]) {
 }
 
 void VCFXHWETester::displayHelp() {
-    std::cout 
-        << "VCFX_hwe_tester: Perform Hardy-Weinberg Equilibrium (HWE) tests on a biallelic VCF.\n\n"
-        << "Usage:\n"
-        << "  VCFX_hwe_tester [options] < input.vcf > output\n\n"
-        << "Description:\n"
-        << "  Reads each variant line, ignoring multi-allelic calls. For biallelic lines,\n"
-        << "  collects genotypes as 0/0, 0/1, 1/1, then uses an exact test to produce\n"
-        << "  a p-value for HWE.\n\n"
-        << "Example:\n"
-        << "  VCFX_hwe_tester < input.vcf > results.txt\n";
+    std::cout << "VCFX_hwe_tester: Perform Hardy-Weinberg Equilibrium (HWE) tests on a biallelic VCF.\n\n"
+              << "Usage:\n"
+              << "  VCFX_hwe_tester [options] < input.vcf > output\n\n"
+              << "Description:\n"
+              << "  Reads each variant line, ignoring multi-allelic calls. For biallelic lines,\n"
+              << "  collects genotypes as 0/0, 0/1, 1/1, then uses an exact test to produce\n"
+              << "  a p-value for HWE.\n\n"
+              << "Example:\n"
+              << "  VCFX_hwe_tester < input.vcf > results.txt\n";
 }
 
 // Single definition of isBiallelic
@@ -54,36 +50,36 @@ bool VCFXHWETester::isBiallelic(const std::string &alt) {
 }
 
 // parseGenotypes
-bool VCFXHWETester::parseGenotypes(const std::vector<std::string>& genotypes,
-                                   int& homRef, int& het, int& homAlt) {
-    homRef=0;
-    het=0;
-    homAlt=0;
+bool VCFXHWETester::parseGenotypes(const std::vector<std::string> &genotypes, int &homRef, int &het, int &homAlt) {
+    homRef = 0;
+    het = 0;
+    homAlt = 0;
     for (auto &gt : genotypes) {
-        if (gt.empty() || gt=="." || gt=="./." || gt==".|.") {
+        if (gt.empty() || gt == "." || gt == "./." || gt == ".|.") {
             continue; // missing
         }
         // unify '|' -> '/'
         std::string g = gt;
         for (char &c : g) {
-            if (c=='|') c='/';
+            if (c == '|')
+                c = '/';
         }
         size_t delim = g.find('/');
-        if (delim==std::string::npos) {
+        if (delim == std::string::npos) {
             // Not diploid => skip
             continue;
         }
         std::string a1 = g.substr(0, delim);
-        std::string a2 = g.substr(delim+1);
-        if (a1=="0" && a2=="0") {
+        std::string a2 = g.substr(delim + 1);
+        if (a1 == "0" && a2 == "0") {
             homRef++;
-        } else if ((a1=="0" && a2=="1") || (a1=="1" && a2=="0")) {
+        } else if ((a1 == "0" && a2 == "1") || (a1 == "1" && a2 == "0")) {
             het++;
-        } else if (a1=="1" && a2=="1") {
+        } else if (a1 == "1" && a2 == "1") {
             homAlt++;
         } else {
             // e.g. a2>1 => multi-allelic => skip or fail
-            return false; 
+            return false;
         }
     }
     return true;
@@ -91,174 +87,200 @@ bool VCFXHWETester::parseGenotypes(const std::vector<std::string>& genotypes,
 
 double VCFXHWETester::genotypeProbability(int homRef, int het, int homAlt) {
     int N = homRef + het + homAlt;
-    int x = 2*homAlt + het; 
-    int y = 2*homRef + het;
+    int x = 2 * homAlt + het;
+    int y = 2 * homRef + het;
 
     // We'll do enumerations with log factorial
-    static const int MAXN = 20000; 
+    static const int MAXN = 20000;
     static std::vector<double> logFac;
-    static int cachedN=0;
-    if (2*N>cachedN) {
-        logFac.resize(2*N+1,0.0);
-        double cum=0.0;
-        for(int i=1; i<=2*N; i++){
+    static int cachedN = 0;
+    if (2 * N > cachedN) {
+        logFac.resize(2 * N + 1, 0.0);
+        double cum = 0.0;
+        for (int i = 1; i <= 2 * N; i++) {
             cum += std::log((double)i);
             logFac[i] = cum;
         }
-        cachedN=2*N;
+        cachedN = 2 * N;
     }
 
-    auto logFactorial=[&](int n)->double {
-        if(n<=0) return 0.0;
-        if(n>cachedN) return 0.0; 
+    auto logFactorial = [&](int n) -> double {
+        if (n <= 0)
+            return 0.0;
+        if (n > cachedN)
+            return 0.0;
         return logFac[n];
     };
 
-    auto logProb=[&](int a)->double {
-        if((x-a)<0 || (y-a)<0) return -INFINITY;
-        if(((x-a)%2)!=0 || ((y-a)%2)!=0) return -INFINITY;
-        int hr = (y-a)/2;
-        int ha = (x-a)/2;
-        if(hr<0||ha<0) return -INFINITY;
+    auto logProb = [&](int a) -> double {
+        if ((x - a) < 0 || (y - a) < 0)
+            return -INFINITY;
+        if (((x - a) % 2) != 0 || ((y - a) % 2) != 0)
+            return -INFINITY;
+        int hr = (y - a) / 2;
+        int ha = (x - a) / 2;
+        if (hr < 0 || ha < 0)
+            return -INFINITY;
         // log multinomial
-        double lcoef = logFactorial(N) - (
-            logFactorial(hr)+logFactorial(a)+logFactorial(ha)
-        );
-        double p=(double)y/(double)(x+y);
-        double q=(double)x/(double)(x+y);
-        if(p<=0.0 || q<=0.0) return -INFINITY;
-        double logTerm = hr*2*std::log(p) + a*std::log(2.0*p*q) + ha*2*std::log(q);
+        double lcoef = logFactorial(N) - (logFactorial(hr) + logFactorial(a) + logFactorial(ha));
+        double p = (double)y / (double)(x + y);
+        double q = (double)x / (double)(x + y);
+        if (p <= 0.0 || q <= 0.0)
+            return -INFINITY;
+        double logTerm = hr * 2 * std::log(p) + a * std::log(2.0 * p * q) + ha * 2 * std::log(q);
         return lcoef + logTerm;
     };
 
-    int observedHet= het;
+    int observedHet = het;
     double logObs = logProb(observedHet);
-    if(logObs==-INFINITY) return 1.0; 
+    if (logObs == -INFINITY)
+        return 1.0;
 
-    double minLog= logObs;
-    int maxA= std::min(x,y);
-    std::vector<double> logVals(maxA+1, -INFINITY);
-    logVals[observedHet]= logObs;
+    double minLog = logObs;
+    int maxA = std::min(x, y);
+    std::vector<double> logVals(maxA + 1, -INFINITY);
+    logVals[observedHet] = logObs;
 
-    if(logObs<minLog) minLog=logObs;
+    if (logObs < minLog)
+        minLog = logObs;
 
-    for(int a=0; a<=maxA; a++){
-        if(a==observedHet) continue;
-        double lp= logProb(a);
-        logVals[a]= lp;
-        if(lp<minLog && lp!=-INFINITY) minLog= lp;
+    for (int a = 0; a <= maxA; a++) {
+        if (a == observedHet)
+            continue;
+        double lp = logProb(a);
+        logVals[a] = lp;
+        if (lp < minLog && lp != -INFINITY)
+            minLog = lp;
     }
 
-    double sum=0.0, obsExp=0.0;
-    for(int a=0; a<=maxA; a++){
-        if(logVals[a]==-INFINITY) continue;
-        double rel= logVals[a]- minLog;
-        double e= std::exp(rel);
+    double sum = 0.0, obsExp = 0.0;
+    for (int a = 0; a <= maxA; a++) {
+        if (logVals[a] == -INFINITY)
+            continue;
+        double rel = logVals[a] - minLog;
+        double e = std::exp(rel);
         sum += e;
-        if(a==observedHet) obsExp= e;
+        if (a == observedHet)
+            obsExp = e;
     }
-    double probObs= obsExp/sum;
-    double pVal= 0.0;
-    for(int a=0; a<=maxA; a++){
-        if(logVals[a]==-INFINITY) continue;
-        double rel= logVals[a]- minLog;
-        double e= std::exp(rel);
-        double prob= e/sum;
-        if(prob <= probObs+1e-12){
-            pVal+= prob;
+    double probObs = obsExp / sum;
+    double pVal = 0.0;
+    for (int a = 0; a <= maxA; a++) {
+        if (logVals[a] == -INFINITY)
+            continue;
+        double rel = logVals[a] - minLog;
+        double e = std::exp(rel);
+        double prob = e / sum;
+        if (prob <= probObs + 1e-12) {
+            pVal += prob;
         }
     }
-    if(pVal>1.0) pVal=1.0;
-    if(pVal<0.0) pVal=0.0;
+    if (pVal > 1.0)
+        pVal = 1.0;
+    if (pVal < 0.0)
+        pVal = 0.0;
     return pVal;
 }
 
 double VCFXHWETester::calculateHWE(int homRef, int het, int homAlt) {
-    int N= homRef+het+homAlt;
-    if(N<1) return 1.0;
-    int x= 2*homAlt + het;
-    int y= 2*homRef + het;
-    if(x+y != 2*N){
+    int N = homRef + het + homAlt;
+    if (N < 1)
+        return 1.0;
+    int x = 2 * homAlt + het;
+    int y = 2 * homRef + het;
+    if (x + y != 2 * N) {
         return 1.0;
     }
     return genotypeProbability(homRef, het, homAlt);
 }
 
-void VCFXHWETester::performHWE(std::istream& in){
+void VCFXHWETester::performHWE(std::istream &in) {
     std::string line;
     // output header
     std::cout << "CHROM\tPOS\tID\tREF\tALT\tHWE_pvalue\n";
-    while(std::getline(in,line)){
-        if(line.empty()) continue;
-        if(line[0]=='#') continue;
+    while (std::getline(in, line)) {
+        if (line.empty())
+            continue;
+        if (line[0] == '#')
+            continue;
         std::stringstream ss(line);
         std::vector<std::string> fields;
         {
             std::string f;
-            while(std::getline(ss,f,'\t')){
+            while (std::getline(ss, f, '\t')) {
                 fields.push_back(f);
             }
         }
-        if(fields.size()<10) continue;
-        std::string chrom= fields[0];
-        std::string pos= fields[1];
-        std::string id= fields[2];
-        std::string ref= fields[3];
-        std::string alt= fields[4];
+        if (fields.size() < 10)
+            continue;
+        std::string chrom = fields[0];
+        std::string pos = fields[1];
+        std::string id = fields[2];
+        std::string ref = fields[3];
+        std::string alt = fields[4];
         // skip if multi-allelic
-        if(!isBiallelic(alt)) continue;
+        if (!isBiallelic(alt))
+            continue;
 
         // find GT in format
-        std::string format= fields[8];
+        std::string format = fields[8];
         std::vector<std::string> fmts;
         {
             std::stringstream fs(format);
             std::string x;
-            while(std::getline(fs,x,':')){
+            while (std::getline(fs, x, ':')) {
                 fmts.push_back(x);
             }
         }
-        int gt_index=-1;
-        for(size_t i=0; i<fmts.size(); i++){
-            if(fmts[i]=="GT"){
-                gt_index=i;
+        int gt_index = -1;
+        for (size_t i = 0; i < fmts.size(); i++) {
+            if (fmts[i] == "GT") {
+                gt_index = i;
                 break;
             }
         }
-        if(gt_index<0) continue;
+        if (gt_index < 0)
+            continue;
 
         // gather genotypes
         std::vector<std::string> gts;
-        for(size_t s=9; s<fields.size(); s++){
+        for (size_t s = 9; s < fields.size(); s++) {
             std::stringstream sampSS(fields[s]);
             std::vector<std::string> sampToks;
             {
                 std::string xx;
-                while(std::getline(sampSS,xx,':')){
+                while (std::getline(sampSS, xx, ':')) {
                     sampToks.push_back(xx);
                 }
             }
-            if((size_t)gt_index< sampToks.size()){
+            if ((size_t)gt_index < sampToks.size()) {
                 gts.push_back(sampToks[gt_index]);
             } else {
                 gts.push_back(".");
             }
         }
-        int hr=0, h=0, ha=0;
-        bool ok= parseGenotypes(gts, hr,h,ha);
-        if(!ok) continue; 
-        double pVal= calculateHWE(hr,h,ha);
-        std::cout << chrom << "\t" << pos << "\t" << id << "\t"
-                  << ref << "\t" << alt << "\t"
-                  << std::fixed << std::setprecision(6) << pVal << "\n";
+        int hr = 0, h = 0, ha = 0;
+        bool ok = parseGenotypes(gts, hr, h, ha);
+        if (!ok)
+            continue;
+        double pVal = calculateHWE(hr, h, ha);
+        std::cout << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt << "\t" << std::fixed
+                  << std::setprecision(6) << pVal << "\n";
     }
 }
 
 // actual main
-static void show_help() { VCFXHWETester obj; char arg0[] = "VCFX_hwe_tester"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXHWETester obj;
+    char arg0[] = "VCFX_hwe_tester";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_hwe_tester", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_hwe_tester", show_help))
+        return 0;
     VCFXHWETester tester;
     return tester.run(argc, argv);
 }

--- a/src/VCFX_hwe_tester/VCFX_hwe_tester.h
+++ b/src/VCFX_hwe_tester/VCFX_hwe_tester.h
@@ -6,14 +6,14 @@
 #include <vector>
 
 class VCFXHWETester {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
-    void performHWE(std::istream& in);
+    void performHWE(std::istream &in);
     bool isBiallelic(const std::string &alt);
-    bool parseGenotypes(const std::vector<std::string>& genotypes, int& homRef, int& het, int& homAlt);
+    bool parseGenotypes(const std::vector<std::string> &genotypes, int &homRef, int &het, int &homAlt);
     double calculateHWE(int homRef, int het, int homAlt);
     double genotypeProbability(int homRef, int het, int homAlt);
 };

--- a/src/VCFX_impact_filter/VCFX_impact_filter.cpp
+++ b/src/VCFX_impact_filter/VCFX_impact_filter.cpp
@@ -1,27 +1,22 @@
-#include "vcfx_core.h"
 #include "VCFX_impact_filter.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cctype>
-#include <regex>
+#include <getopt.h>
 #include <iostream>
+#include <regex>
+#include <sstream>
 
 // Helper function: convert string to uppercase
 static std::string toUpper(const std::string &s) {
     std::string t(s);
-    for (auto &c: t) c = std::toupper((unsigned char)c);
+    for (auto &c : t)
+        c = std::toupper((unsigned char)c);
     return t;
 }
 
 // Simple classification of a (possibly extended) Impact value, e.g. "HIGH_SOMETHING"
-enum class ImpactLevel {
-    UNKNOWN,
-    MODIFIER,
-    LOW,
-    MODERATE,
-    HIGH
-};
+enum class ImpactLevel { UNKNOWN, MODIFIER, LOW, MODERATE, HIGH };
 
 static ImpactLevel classifyImpact(const std::string &rawImpact) {
     std::string u = toUpper(rawImpact);
@@ -42,41 +37,43 @@ static ImpactLevel classifyImpact(const std::string &rawImpact) {
 // Our hierarchy is: HIGH > MODERATE > LOW > MODIFIER > UNKNOWN
 static bool meetsThreshold(ImpactLevel variantLevel, ImpactLevel targetLevel) {
     // Convert to int or we can do a switch-based approach
-    auto rank = [](ImpactLevel lv)->int {
+    auto rank = [](ImpactLevel lv) -> int {
         switch (lv) {
-            case ImpactLevel::HIGH:     return 4;
-            case ImpactLevel::MODERATE: return 3;
-            case ImpactLevel::LOW:      return 2;
-            case ImpactLevel::MODIFIER: return 1;
-            default:                    return 0; // UNKNOWN
+        case ImpactLevel::HIGH:
+            return 4;
+        case ImpactLevel::MODERATE:
+            return 3;
+        case ImpactLevel::LOW:
+            return 2;
+        case ImpactLevel::MODIFIER:
+            return 1;
+        default:
+            return 0; // UNKNOWN
         }
     };
     return rank(variantLevel) >= rank(targetLevel);
 }
 
 // Implementation of VCFXImpactFilter
-int VCFXImpactFilter::run(int argc, char* argv[]) {
+int VCFXImpactFilter::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
     std::string targetImpact;
 
     static struct option long_options[] = {
-        {"help",          no_argument,       0, 'h'},
-        {"filter-impact", required_argument, 0, 'i'},
-        {0,               0,                 0,  0}
-    };
+        {"help", no_argument, 0, 'h'}, {"filter-impact", required_argument, 0, 'i'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "hi:", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'i':
-                targetImpact = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'i':
+            targetImpact = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -106,10 +103,7 @@ void VCFXImpactFilter::displayHelp() {
               << "  VCFX_impact_filter --filter-impact HIGH < input.vcf > filtered.vcf\n";
 }
 
-void VCFXImpactFilter::filterByImpact(std::istream& in,
-                                      std::ostream& out,
-                                      const std::string& targetImpact)
-{
+void VCFXImpactFilter::filterByImpact(std::istream &in, std::ostream &out, const std::string &targetImpact) {
     // interpret targetImpact
     ImpactLevel targetLevel = classifyImpact(targetImpact);
     if (targetLevel == ImpactLevel::UNKNOWN) {
@@ -131,12 +125,13 @@ void VCFXImpactFilter::filterByImpact(std::istream& in,
         // If header
         if (line[0] == '#') {
             // If we see #CHROM and haven't inserted our meta line, do so
-            if (!wroteInfoMeta && line.rfind("#CHROM",0)==0) {
-                out << "##INFO=<ID=EXTRACTED_IMPACT,Number=1,Type=String,Description=\"Extracted from IMPACT=... in info.\">\n";
+            if (!wroteInfoMeta && line.rfind("#CHROM", 0) == 0) {
+                out << "##INFO=<ID=EXTRACTED_IMPACT,Number=1,Type=String,Description=\"Extracted from IMPACT=... in "
+                       "info.\">\n";
                 wroteInfoMeta = true;
             }
             out << line << "\n";
-            if (line.rfind("#CHROM",0)==0) {
+            if (line.rfind("#CHROM", 0) == 0) {
                 wroteHeader = true;
             }
             continue;
@@ -157,7 +152,7 @@ void VCFXImpactFilter::filterByImpact(std::istream& in,
                 fields.push_back(f);
             }
         }
-        if (fields.size()<8) {
+        if (fields.size() < 8) {
             // invalid line
             continue;
         }
@@ -183,7 +178,7 @@ void VCFXImpactFilter::filterByImpact(std::istream& in,
         if (meetsThreshold(varLevel, targetLevel)) {
             // We append ;EXTRACTED_IMPACT=extracted to the info field
             // If info=="." => replace it with "EXTRACTED_IMPACT=extracted"
-            if (info=="."||info.empty()) {
+            if (info == "." || info.empty()) {
                 info = "EXTRACTED_IMPACT=" + extracted;
             } else {
                 info += ";EXTRACTED_IMPACT=" + extracted;
@@ -191,8 +186,9 @@ void VCFXImpactFilter::filterByImpact(std::istream& in,
             fields[7] = info;
             // rejoin line
             std::ostringstream joined;
-            for (size_t i=0; i<fields.size(); i++) {
-                if (i>0) joined << "\t";
+            for (size_t i = 0; i < fields.size(); i++) {
+                if (i > 0)
+                    joined << "\t";
                 joined << fields[i];
             }
             out << joined.str() << "\n";
@@ -200,10 +196,17 @@ void VCFXImpactFilter::filterByImpact(std::istream& in,
     }
 }
 
-static void show_help() { VCFXImpactFilter obj; char arg0[] = "VCFX_impact_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXImpactFilter obj;
+    char arg0[] = "VCFX_impact_filter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_impact_filter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_impact_filter", show_help))
+        return 0;
     VCFXImpactFilter filt;
     return filt.run(argc, argv);
 }

--- a/src/VCFX_impact_filter/VCFX_impact_filter.h
+++ b/src/VCFX_impact_filter/VCFX_impact_filter.h
@@ -7,16 +7,16 @@
 
 // VCFXImpactFilter: A tool for filtering VCF records by predicted "Impact" in the INFO field.
 class VCFXImpactFilter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays help
     void displayHelp();
 
     // Filters VCF input based on the specified impact level
-    void filterByImpact(std::istream& in, std::ostream& out, const std::string& targetImpact);
+    void filterByImpact(std::istream &in, std::ostream &out, const std::string &targetImpact);
 };
 
 #endif // VCFX_IMPACT_FILTER_H

--- a/src/VCFX_inbreeding_calculator/VCFX_inbreeding_calculator.cpp
+++ b/src/VCFX_inbreeding_calculator/VCFX_inbreeding_calculator.cpp
@@ -1,13 +1,13 @@
-#include "vcfx_core.h"
 #include "VCFX_inbreeding_calculator.h"
-#include <getopt.h>
-#include <sstream>
-#include <cstdlib>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <unordered_map>
 #include <cmath>
+#include <cstdlib>
+#include <getopt.h>
 #include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
 
 // --------------------------------------------------------------------------
 // A helper function to remove BOM and leading/trailing whitespace
@@ -18,13 +18,11 @@ static void sanitizeLine(std::string &line) {
         line.erase(0, BOM.size());
     }
     // Trim front
-    while (!line.empty() &&
-           (line[0] == ' ' || line[0] == '\t' || line[0] == '\r' || line[0] == '\n')) {
+    while (!line.empty() && (line[0] == ' ' || line[0] == '\t' || line[0] == '\r' || line[0] == '\n')) {
         line.erase(line.begin());
     }
     // Trim back
-    while (!line.empty() &&
-           (line.back() == ' ' || line.back() == '\t' || line.back() == '\r' || line.back() == '\n')) {
+    while (!line.empty() && (line.back() == ' ' || line.back() == '\t' || line.back() == '\r' || line.back() == '\n')) {
         line.pop_back();
     }
 }
@@ -46,48 +44,48 @@ static std::vector<std::string> splitByTab(const std::string &line) {
 
 // --------------------------------------------------------------------------
 void VCFXInbreedingCalculator::displayHelp() {
-    std::cout
-        << "VCFX_inbreeding_calculator: Compute individual inbreeding coefficients (F)\n"
-        << "based on biallelic sites in a VCF.\n\n"
-        << "Usage:\n"
-        << "  VCFX_inbreeding_calculator [options] < input.vcf > output.txt\n\n"
-        << "Description:\n"
-        << "  Reads a VCF in a single pass, ignoring multi-allelic lines (ALT with commas).\n"
-        << "  For each biallelic variant, we parse each sample's genotype code:\n"
-        << "       0/0 => 0,   0/1 => 1,   1/1 => 2, else => -1 (ignored)\n\n"
-        << "  Then, depending on --freq-mode:\n"
-        << "    * excludeSample => Each sample excludes its own genotype when computing p.\n"
-        << "    * global        => Compute a single global p from all samples' genotypes.\n\n"
-        << "  The --skip-boundary option, if set, ignores boundary freq p=0 or p=1.\n"
-        << "    BUT if you also specify --count-boundary-as-used, those boundary sites\n"
-        << "    increment usedCount (forcing F=1) without contributing to sumExp.\n\n"
-        << "  If sumExp=0 for a sample but usedCount>0, we output F=1.\n"
-        << "  If usedCount=0, we output NA.\n\n"
-        << "Options:\n"
-        << "  -h, --help                Show this help.\n"
-        << "  --freq-mode <mode>        'excludeSample' (default) or 'global'\n"
-        << "  --skip-boundary           Skip boundary freq sites. By default, they are used.\n"
-        << "  --count-boundary-as-used  If also skipping boundary, still increment usedCount.\n"
-        << std::endl;
+    std::cout << "VCFX_inbreeding_calculator: Compute individual inbreeding coefficients (F)\n"
+              << "based on biallelic sites in a VCF.\n\n"
+              << "Usage:\n"
+              << "  VCFX_inbreeding_calculator [options] < input.vcf > output.txt\n\n"
+              << "Description:\n"
+              << "  Reads a VCF in a single pass, ignoring multi-allelic lines (ALT with commas).\n"
+              << "  For each biallelic variant, we parse each sample's genotype code:\n"
+              << "       0/0 => 0,   0/1 => 1,   1/1 => 2, else => -1 (ignored)\n\n"
+              << "  Then, depending on --freq-mode:\n"
+              << "    * excludeSample => Each sample excludes its own genotype when computing p.\n"
+              << "    * global        => Compute a single global p from all samples' genotypes.\n\n"
+              << "  The --skip-boundary option, if set, ignores boundary freq p=0 or p=1.\n"
+              << "    BUT if you also specify --count-boundary-as-used, those boundary sites\n"
+              << "    increment usedCount (forcing F=1) without contributing to sumExp.\n\n"
+              << "  If sumExp=0 for a sample but usedCount>0, we output F=1.\n"
+              << "  If usedCount=0, we output NA.\n\n"
+              << "Options:\n"
+              << "  -h, --help                Show this help.\n"
+              << "  --freq-mode <mode>        'excludeSample' (default) or 'global'\n"
+              << "  --skip-boundary           Skip boundary freq sites. By default, they are used.\n"
+              << "  --count-boundary-as-used  If also skipping boundary, still increment usedCount.\n"
+              << std::endl;
 }
 
 // --------------------------------------------------------------------------
 int VCFXInbreedingCalculator::parseGenotype(const std::string &s) {
     // Check for missing or empty
-    if (s.empty() || s=="." || s=="./." || s==".|." || s==".|" || s=="./") {
+    if (s.empty() || s == "." || s == "./." || s == ".|." || s == ".|" || s == "./") {
         return -1; // missing
     }
     std::string g = s;
     for (char &c : g) {
-        if (c == '|') c = '/';
+        if (c == '|')
+            c = '/';
     }
     size_t slash = g.find('/');
     if (slash == std::string::npos) {
         return -1; // not diploid
     }
     std::string a1 = g.substr(0, slash);
-    std::string a2 = g.substr(slash+1);
-    if (a1.empty() || a2.empty() || a1=="." || a2==".") {
+    std::string a2 = g.substr(slash + 1);
+    if (a1.empty() || a2.empty() || a1 == "." || a2 == ".") {
         return -1;
     }
     int i1, i2;
@@ -98,20 +96,18 @@ int VCFXInbreedingCalculator::parseGenotype(const std::string &s) {
         return -1;
     }
     // skip if allele≥2 => multi-allelic genotype (since we only handle 0 or 1)
-    if (i1<0 || i1>1 || i2<0 || i2>1) {
+    if (i1 < 0 || i1 > 1 || i2 < 0 || i2 > 1) {
         return -1;
     }
     // 0/0 =>0, 1/1 =>2, else =>1
-    if (i1==i2) {
-        return (i1==0 ? 0 : 2);
+    if (i1 == i2) {
+        return (i1 == 0 ? 0 : 2);
     }
     return 1; // 0/1
 }
 
 // --------------------------------------------------------------------------
-bool VCFXInbreedingCalculator::isBiallelic(const std::string &alt) {
-    return (alt.find(',') == std::string::npos);
-}
+bool VCFXInbreedingCalculator::isBiallelic(const std::string &alt) { return (alt.find(',') == std::string::npos); }
 
 // --------------------------------------------------------------------------
 FrequencyMode VCFXInbreedingCalculator::parseFreqMode(const std::string &modeStr) {
@@ -121,8 +117,7 @@ FrequencyMode VCFXInbreedingCalculator::parseFreqMode(const std::string &modeStr
         return FrequencyMode::GLOBAL;
     }
     // Default
-    std::cerr << "Warning: unrecognized freq-mode='" << modeStr
-              << "'. Using 'excludeSample' by default.\n";
+    std::cerr << "Warning: unrecognized freq-mode='" << modeStr << "'. Using 'excludeSample' by default.\n";
     return FrequencyMode::EXCLUDE_SAMPLE;
 }
 
@@ -140,7 +135,8 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
             break; // EOF
         }
         sanitizeLine(line);
-        if (line.empty()) continue;
+        if (line.empty())
+            continue;
 
         if (line[0] == '#') {
             // check if #CHROM
@@ -148,7 +144,7 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
                 foundChrom = true;
                 auto tokens = splitByTab(line);
                 if (tokens.size() >= 10) {
-                    for (size_t i=9; i<tokens.size(); i++){
+                    for (size_t i = 9; i < tokens.size(); i++) {
                         sampleNames.push_back(tokens[i]);
                     }
                     numSamples = (int)sampleNames.size();
@@ -172,13 +168,14 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
         var.chrom = fields[0];
         try {
             var.pos = std::stoi(fields[1]);
-        } catch(...) {
+        } catch (...) {
             continue;
         }
         var.genotypeCodes.resize(numSamples, -1);
-        for (int s=0; s<numSamples; s++){
+        for (int s = 0; s < numSamples; s++) {
             int colIndex = 9 + s;
-            if ((size_t)colIndex >= fields.size()) break;
+            if ((size_t)colIndex >= fields.size())
+                break;
             var.genotypeCodes[s] = parseGenotype(fields[colIndex]);
         }
         variants.push_back(var);
@@ -199,7 +196,7 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
         // No valid (biallelic) variants
         std::cerr << "No biallelic variants found.\n";
         out << "Sample\tInbreedingCoefficient\n";
-        for (int s=0; s<numSamples; s++){
+        for (int s = 0; s < numSamples; s++) {
             out << sampleNames[s] << "\tNA\n";
         }
         return;
@@ -208,17 +205,17 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
     // Prepare result arrays
     std::vector<double> sumExp(numSamples, 0.0);
     std::vector<double> obsHet(numSamples, 0.0);
-    std::vector<int>    usedCount(numSamples, 0);
+    std::vector<int> usedCount(numSamples, 0);
 
     // 2) For each variant
-    for (size_t v=0; v<variants.size(); v++){
+    for (size_t v = 0; v < variants.size(); v++) {
         const auto &var = variants[v];
         const auto &codes = var.genotypeCodes;
 
         // Count altSum & nGood (i.e. how many samples have code>=0)
         int altSum = 0;
-        int nGood  = 0;
-        for (int s=0; s<numSamples; s++){
+        int nGood = 0;
+        for (int s = 0; s < numSamples; s++) {
             if (codes[s] >= 0) {
                 altSum += codes[s];
                 nGood++;
@@ -233,7 +230,7 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
         double globalP = (double)altSum / (2.0 * nGood);
 
         // 3) Each sample that has a valid genotype
-        for (int s=0; s<numSamples; s++){
+        for (int s = 0; s < numSamples; s++) {
             int code = codes[s];
             if (code < 0) {
                 continue; // missing or invalid
@@ -244,8 +241,8 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
                 p = globalP;
             } else {
                 // freqMode_ == FrequencyMode::EXCLUDE_SAMPLE
-                int altEx   = altSum - code;
-                int validEx = nGood  - 1;
+                int altEx = altSum - code;
+                int validEx = nGood - 1;
                 if (validEx < 1) {
                     // can't define p => skip
                     continue;
@@ -269,7 +266,7 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
 
             // expected heterozygosity
             double eHet = 2.0 * p * (1.0 - p);
-            sumExp[s]   += eHet;
+            sumExp[s] += eHet;
 
             // observed heterozygosity increment if 0/1 => code=1
             if (code == 1) {
@@ -280,7 +277,7 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
 
     // 4) Output
     out << "Sample\tInbreedingCoefficient\n";
-    for (int s=0; s<numSamples; s++){
+    for (int s = 0; s < numSamples; s++) {
         if (usedCount[s] == 0) {
             // No used sites => NA
             out << sampleNames[s] << "\tNA\n";
@@ -293,53 +290,49 @@ void VCFXInbreedingCalculator::calculateInbreeding(std::istream &in, std::ostrea
             continue;
         }
         double f = 1.0 - (obsHet[s] / e);
-        out << sampleNames[s] << "\t"
-            << std::fixed << std::setprecision(6)
-            << f << "\n";
+        out << sampleNames[s] << "\t" << std::fixed << std::setprecision(6) << f << "\n";
     }
 }
 
 // --------------------------------------------------------------------------
-int VCFXInbreedingCalculator::run(int argc, char* argv[]){
+int VCFXInbreedingCalculator::run(int argc, char *argv[]) {
     bool showHelp = false;
 
-    static struct option long_opts[] = {
-        {"help",                no_argument,       0, 'h'},
-        {"freq-mode",           required_argument, 0,  0 },
-        {"skip-boundary",       no_argument,       0,  0 },
-        {"count-boundary-as-used", no_argument,    0,  0 },
-        {0,0,0,0}
-    };
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"freq-mode", required_argument, 0, 0},
+                                        {"skip-boundary", no_argument, 0, 0},
+                                        {"count-boundary-as-used", no_argument, 0, 0},
+                                        {0, 0, 0, 0}};
 
     // Parse arguments
-    while(true) {
+    while (true) {
         int option_index = 0;
         int c = getopt_long(argc, argv, "h", long_opts, &option_index);
-        if (c == -1) break;
+        if (c == -1)
+            break;
 
-        switch(c){
-            case 'h':
-                showHelp = true;
-                break;
-            case 0:
-            {
-                // We got a long option
-                std::string optName(long_opts[option_index].name);
-                if (optName == "freq-mode") {
-                    freqMode_ = parseFreqMode(optarg);
-                } else if (optName == "skip-boundary") {
-                    skipBoundary_ = true;
-                } else if (optName == "count-boundary-as-used") {
-                    countBoundaryAsUsed_ = true;
-                }
-                break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 0: {
+            // We got a long option
+            std::string optName(long_opts[option_index].name);
+            if (optName == "freq-mode") {
+                freqMode_ = parseFreqMode(optarg);
+            } else if (optName == "skip-boundary") {
+                skipBoundary_ = true;
+            } else if (optName == "count-boundary-as-used") {
+                countBoundaryAsUsed_ = true;
             }
-            default:
-                showHelp = true;
+            break;
+        }
+        default:
+            showHelp = true;
         }
     }
 
-    if(showHelp) {
+    if (showHelp) {
         displayHelp();
         return 0;
     }
@@ -351,10 +344,17 @@ int VCFXInbreedingCalculator::run(int argc, char* argv[]){
 
 // -------------------------------------------------------------------------
 // main entry point
-static void show_help() { VCFXInbreedingCalculator obj; char arg0[] = "VCFX_inbreeding_calculator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXInbreedingCalculator obj;
+    char arg0[] = "VCFX_inbreeding_calculator";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_inbreeding_calculator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_inbreeding_calculator", show_help))
+        return 0;
     VCFXInbreedingCalculator calc;
     return calc.run(argc, argv);
 }

--- a/src/VCFX_inbreeding_calculator/VCFX_inbreeding_calculator.h
+++ b/src/VCFX_inbreeding_calculator/VCFX_inbreeding_calculator.h
@@ -21,23 +21,23 @@ enum class FrequencyMode {
 
 // VCFXInbreedingCalculator: calculates individual inbreeding coefficients
 class VCFXInbreedingCalculator {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Command-line settings
-    FrequencyMode freqMode_          = FrequencyMode::EXCLUDE_SAMPLE;
-    bool skipBoundary_               = false;
-    bool countBoundaryAsUsed_        = false;
+    FrequencyMode freqMode_ = FrequencyMode::EXCLUDE_SAMPLE;
+    bool skipBoundary_ = false;
+    bool countBoundaryAsUsed_ = false;
 
     // Print help
     void displayHelp();
 
     // Main function: read VCF => store biallelic variants => compute F
-    void calculateInbreeding(std::istream& in, std::ostream& out);
+    void calculateInbreeding(std::istream &in, std::ostream &out);
 
     // Utility to parse a single genotype string => 0,1,2, or -1
-    int parseGenotype(const std::string& s);
+    int parseGenotype(const std::string &s);
 
     // Helper to decide if ALT is biallelic
     bool isBiallelic(const std::string &alt);

--- a/src/VCFX_indel_normalizer/VCFX_indel_normalizer.cpp
+++ b/src/VCFX_indel_normalizer/VCFX_indel_normalizer.cpp
@@ -1,53 +1,50 @@
-#include "vcfx_core.h"
 #include "VCFX_indel_normalizer.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
+#include <cstdlib>
+#include <getopt.h>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <cstdlib>
 
 // ---------------------------------------------------------------------
 // Print usage
 // ---------------------------------------------------------------------
 void VCFXIndelNormalizer::displayHelp() {
-    std::cout 
-        << "VCFX_indel_normalizer: Normalize INDEL variants by splitting multi-allelic lines,\n"
-        << "and removing common leading/trailing bases to produce a minimal left-aligned representation.\n\n"
-        << "Usage:\n"
-        << "  VCFX_indel_normalizer [options] < input.vcf > output.vcf\n\n"
-        << "Description:\n"
-        << "  This code does a simplified left alignment that:\n"
-        << "   1) Splits multi-ALT lines into separate lines.\n"
-        << "   2) Removes the longest shared prefix from REF/ALT, adjusting POS.\n"
-        << "   3) Removes the largest shared suffix from REF/ALT.\n\n"
-        << "  Note: true left alignment for repeated motifs requires the full reference genome.\n\n"
-        << "Example:\n"
-        << "  VCFX_indel_normalizer < input.vcf > normalized.vcf\n";
+    std::cout << "VCFX_indel_normalizer: Normalize INDEL variants by splitting multi-allelic lines,\n"
+              << "and removing common leading/trailing bases to produce a minimal left-aligned representation.\n\n"
+              << "Usage:\n"
+              << "  VCFX_indel_normalizer [options] < input.vcf > output.vcf\n\n"
+              << "Description:\n"
+              << "  This code does a simplified left alignment that:\n"
+              << "   1) Splits multi-ALT lines into separate lines.\n"
+              << "   2) Removes the longest shared prefix from REF/ALT, adjusting POS.\n"
+              << "   3) Removes the largest shared suffix from REF/ALT.\n\n"
+              << "  Note: true left alignment for repeated motifs requires the full reference genome.\n\n"
+              << "Example:\n"
+              << "  VCFX_indel_normalizer < input.vcf > normalized.vcf\n";
 }
 
 // ---------------------------------------------------------------------
 // run
 // ---------------------------------------------------------------------
-int VCFXIndelNormalizer::run(int argc, char* argv[]) {
+int VCFXIndelNormalizer::run(int argc, char *argv[]) {
     int opt;
-    bool showHelp=false;
-    static struct option long_opts[] = {
-        {"help", no_argument,0,'h'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= getopt_long(argc, argv,"h", long_opts, NULL);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-            default:
-                showHelp= true;
-                break;
+    bool showHelp = false;
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
+    while (true) {
+        int c = getopt_long(argc, argv, "h", long_opts, NULL);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+        default:
+            showHelp = true;
+            break;
         }
     }
-    if(showHelp) {
+    if (showHelp) {
         displayHelp();
         return 0;
     }
@@ -63,21 +60,19 @@ int VCFXIndelNormalizer::run(int argc, char* argv[]) {
 //   3) adjust pos by the number of removed leading bases
 // returns false if after trimming, REF or ALT is empty or they are exactly the same => no variant
 // ---------------------------------------------------------------------
-bool VCFXIndelNormalizer::normalizeVariant(std::string &chrom, int &posInt,
-                                          std::string &ref, std::string &alt)
-{
-    if(ref==alt) {
+bool VCFXIndelNormalizer::normalizeVariant(std::string &chrom, int &posInt, std::string &ref, std::string &alt) {
+    if (ref == alt) {
         // no variant
         return false;
     }
     // 1) remove leading common bases
     // we find how many leading chars are identical
     // but we must keep at least 1 char in each
-    int prefixCount=0;
+    int prefixCount = 0;
     {
-        int minLen= std::min(ref.size(), alt.size());
-        while(prefixCount < minLen) {
-            if(ref[prefixCount]== alt[prefixCount]) {
+        int minLen = std::min(ref.size(), alt.size());
+        while (prefixCount < minLen) {
+            if (ref[prefixCount] == alt[prefixCount]) {
                 prefixCount++;
             } else {
                 break;
@@ -85,13 +80,12 @@ bool VCFXIndelNormalizer::normalizeVariant(std::string &chrom, int &posInt,
         }
     }
     // we only remove prefixCount-1 if prefixCount== length => everything the same
-    // typical approach: we can remove (prefixCount-1) from the front. Because the first char of a variant must remain to define the position in a VCF
-    // but let's do the approach used by bcftools: we remove (prefixCount -1) as long as prefixCount>0
-    // i.e. if there's a shared leading base, we keep exactly 1. 
-    // This avoids an empty REF or ALT.
-    if(prefixCount>0) {
-        int removeLeading= prefixCount -1; 
-        if(removeLeading>0) {
+    // typical approach: we can remove (prefixCount-1) from the front. Because the first char of a variant must remain
+    // to define the position in a VCF but let's do the approach used by bcftools: we remove (prefixCount -1) as long as
+    // prefixCount>0 i.e. if there's a shared leading base, we keep exactly 1. This avoids an empty REF or ALT.
+    if (prefixCount > 0) {
+        int removeLeading = prefixCount - 1;
+        if (removeLeading > 0) {
             ref.erase(0, removeLeading);
             alt.erase(0, removeLeading);
             // adjust pos by removeLeading
@@ -102,20 +96,20 @@ bool VCFXIndelNormalizer::normalizeVariant(std::string &chrom, int &posInt,
     // 2) remove trailing common bases
     // we do a from the end approach
     {
-        int rLen= ref.size();
-        int aLen= alt.size();
-        int suffixCount=0;
-        while(suffixCount < rLen && suffixCount< aLen) {
-            if(ref[rLen-1 - suffixCount]== alt[aLen-1 - suffixCount]) {
+        int rLen = ref.size();
+        int aLen = alt.size();
+        int suffixCount = 0;
+        while (suffixCount < rLen && suffixCount < aLen) {
+            if (ref[rLen - 1 - suffixCount] == alt[aLen - 1 - suffixCount]) {
                 suffixCount++;
             } else {
                 break;
             }
         }
         // we keep at least 1 base, so remove (suffixCount-1) if suffixCount>0
-        if(suffixCount>0) {
-            int removeS= suffixCount-1;
-            if(removeS>0) {
+        if (suffixCount > 0) {
+            int removeS = suffixCount - 1;
+            if (removeS > 0) {
                 ref.erase(rLen - removeS, removeS);
                 alt.erase(aLen - removeS, removeS);
             }
@@ -123,10 +117,10 @@ bool VCFXIndelNormalizer::normalizeVariant(std::string &chrom, int &posInt,
     }
 
     // check if after all that, we have no difference or are empty
-    if(ref.empty() || alt.empty()) {
+    if (ref.empty() || alt.empty()) {
         return false;
     }
-    if(ref==alt) {
+    if (ref == alt) {
         // no variant => skip
         return false;
     }
@@ -137,25 +131,25 @@ bool VCFXIndelNormalizer::normalizeVariant(std::string &chrom, int &posInt,
 // normalizeIndels: read VCF, print header lines unchanged, then for each line
 //   if multi-ALT, split into separate lines. For each alt, do left-trim & right-trim
 // ---------------------------------------------------------------------
-void VCFXIndelNormalizer::normalizeIndels(std::istream& in, std::ostream& out) {
+void VCFXIndelNormalizer::normalizeIndels(std::istream &in, std::ostream &out) {
     std::string line;
-    bool foundChromHeader=false;
+    bool foundChromHeader = false;
 
-    while(std::getline(in,line)) {
-        if(line.empty()) {
+    while (std::getline(in, line)) {
+        if (line.empty()) {
             out << "\n";
             continue;
         }
-        if(line[0]=='#') {
+        if (line[0] == '#') {
             out << line << "\n";
-            if(line.rfind("#CHROM",0)==0) {
-                foundChromHeader= true;
+            if (line.rfind("#CHROM", 0) == 0) {
+                foundChromHeader = true;
             }
             continue;
         }
-        if(!foundChromHeader) {
+        if (!foundChromHeader) {
             // error
-            std::cerr<<"Error: encountered data line before #CHROM header.\n";
+            std::cerr << "Error: encountered data line before #CHROM header.\n";
             return;
         }
 
@@ -164,39 +158,39 @@ void VCFXIndelNormalizer::normalizeIndels(std::istream& in, std::ostream& out) {
         std::vector<std::string> fields;
         {
             std::string f;
-            while(std::getline(ss,f,'\t')) {
+            while (std::getline(ss, f, '\t')) {
                 fields.push_back(f);
             }
         }
-        if(fields.size()<10) {
+        if (fields.size() < 10) {
             // not enough columns
-            out<< line <<"\n"; 
+            out << line << "\n";
             continue;
         }
         // CHROM,POS,ID,REF,ALT,QUAL,FILTER,INFO,FORMAT,...samples
-        std::string &chrom= fields[0];
-        std::string &posStr= fields[1];
-        std::string &id=   fields[2];
-        std::string &ref=  fields[3];
-        std::string &alt=  fields[4];
+        std::string &chrom = fields[0];
+        std::string &posStr = fields[1];
+        std::string &id = fields[2];
+        std::string &ref = fields[3];
+        std::string &alt = fields[4];
         // The rest we keep as "rest"
         // We'll rejoin them after we handle alt
         // parse pos as int
-        int posInt=0;
+        int posInt = 0;
         try {
-            posInt= std::stoi(posStr);
-        } catch(...) {
+            posInt = std::stoi(posStr);
+        } catch (...) {
             // can't parse => skip
-            out<< line <<"\n";
+            out << line << "\n";
             continue;
         }
-        std::string postCols; 
+        std::string postCols;
         {
             std::ostringstream oss;
-            for(size_t c=5; c<fields.size(); c++){
-                oss<<"\t"<<fields[c];
+            for (size_t c = 5; c < fields.size(); c++) {
+                oss << "\t" << fields[c];
             }
-            postCols= oss.str();
+            postCols = oss.str();
         }
 
         // if alt has commas => multiple alts => split
@@ -205,58 +199,63 @@ void VCFXIndelNormalizer::normalizeIndels(std::istream& in, std::ostream& out) {
         {
             std::stringstream altSS(alt);
             std::string a;
-            while(std::getline(altSS,a,',')) {
+            while (std::getline(altSS, a, ',')) {
                 altList.push_back(a);
             }
         }
         // for each alt => copy posInt, ref => norm => if success => output
         // if not => output the original or skip?
-        if(altList.size()==1) {
+        if (altList.size() == 1) {
             // single alt => do normal
-            std::string altOne= altList[0];
-            std::string newRef= ref; 
-            std::string newAlt= altOne;
-            int newPos= posInt;
-            bool ok= normalizeVariant(chrom, newPos, newRef, newAlt);
-            if(!ok) {
+            std::string altOne = altList[0];
+            std::string newRef = ref;
+            std::string newAlt = altOne;
+            int newPos = posInt;
+            bool ok = normalizeVariant(chrom, newPos, newRef, newAlt);
+            if (!ok) {
                 // if not changed => just print original
-                out<< line <<"\n";
+                out << line << "\n";
             } else {
                 // output normalized
-                out<< chrom <<"\t"<< newPos <<"\t"<< id <<"\t"<< newRef <<"\t"<< newAlt
-                   << postCols <<"\n";
+                out << chrom << "\t" << newPos << "\t" << id << "\t" << newRef << "\t" << newAlt << postCols << "\n";
             }
         } else {
             // multiple alt => we produce multiple lines
-            for(size_t i=0; i<altList.size(); i++){
-                std::string altOne= altList[i];
+            for (size_t i = 0; i < altList.size(); i++) {
+                std::string altOne = altList[i];
                 // clone ref, altOne, pos => norm
-                std::string newRef= ref; 
-                std::string newAlt= altOne;
-                int newPos= posInt;
-                bool ok= normalizeVariant(chrom, newPos, newRef, newAlt);
-                if(!ok) {
+                std::string newRef = ref;
+                std::string newAlt = altOne;
+                int newPos = posInt;
+                bool ok = normalizeVariant(chrom, newPos, newRef, newAlt);
+                if (!ok) {
                     // if we fail => we output line as is but only with that alt? or skip?
                     // let's do the approach: if it fails => maybe we output the original unnorm
                     // but that would produce duplicates. Let's produce a line anyway
                     // but do not do any modifications => *maybe better is to produce the 'unmodified' altOne
-                    out<< chrom<<"\t"<< posInt <<"\t"<< id <<"\t"<< ref <<"\t"<< altOne
-                       << postCols <<"\n";
+                    out << chrom << "\t" << posInt << "\t" << id << "\t" << ref << "\t" << altOne << postCols << "\n";
                 } else {
                     // produce a line
                     // alt is just newAlt, the rest is the same
-                    out<< chrom<<"\t"<< newPos <<"\t"<< id <<"\t"<< newRef <<"\t"<< newAlt
-                       << postCols <<"\n";
+                    out << chrom << "\t" << newPos << "\t" << id << "\t" << newRef << "\t" << newAlt << postCols
+                        << "\n";
                 }
             }
         }
     }
 }
 
-static void show_help() { VCFXIndelNormalizer obj; char arg0[] = "VCFX_indel_normalizer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXIndelNormalizer obj;
+    char arg0[] = "VCFX_indel_normalizer";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_indel_normalizer", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_indel_normalizer", show_help))
+        return 0;
     VCFXIndelNormalizer norm;
     return norm.run(argc, argv);
 }

--- a/src/VCFX_indel_normalizer/VCFX_indel_normalizer.h
+++ b/src/VCFX_indel_normalizer/VCFX_indel_normalizer.h
@@ -11,20 +11,18 @@
 //   - Removing the largest possible shared leading prefix, adjusting POS accordingly.
 //   - Removing the largest possible shared trailing suffix.
 class VCFXIndelNormalizer {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Print usage
     void displayHelp();
 
     // The main function: read VCF from 'in', write normalized lines to 'out'
-    void normalizeIndels(std::istream& in, std::ostream& out);
+    void normalizeIndels(std::istream &in, std::ostream &out);
 
     // For each ALT allele, produce a separate line. Then do left+right trim
-    bool normalizeVariant(std::string &chrom, int &posInt,
-                          std::string &ref,
-                          std::string &alt);
+    bool normalizeVariant(std::string &chrom, int &posInt, std::string &ref, std::string &alt);
 
     // checks if line is a variant line (#CHROM line => we pass it as header)
 };

--- a/src/VCFX_indexer/VCFX_indexer.cpp
+++ b/src/VCFX_indexer/VCFX_indexer.cpp
@@ -1,14 +1,14 @@
-#include "vcfx_core.h"
 #include "VCFX_indexer.h"
+#include "vcfx_core.h"
+#include <algorithm> // for std::find_if_not, if you want a neat trim
+#include <cstdint>
+#include <cstring>
 #include <getopt.h>
 #include <iostream>
-#include <vector>
 #include <sstream>
-#include <string>
 #include <stdexcept>
-#include <cstring>
-#include <cstdint>
-#include <algorithm> // for std::find_if_not, if you want a neat trim
+#include <string>
+#include <vector>
 
 // A helper to split a string by literal '\t' characters
 static std::vector<std::string> splitTabs(const std::string &s) {
@@ -36,33 +36,30 @@ static std::string ltrim(const std::string &str) {
 }
 
 void VCFXIndexer::displayHelp() {
-    std::cout
-        << "VCFX_indexer\n"
-        << "Usage: VCFX_indexer [--help]\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin (raw bytes) and writes a 3-column index\n"
-        << "  (CHROM, POS, FILE_OFFSET) to stdout. FILE_OFFSET is the byte offset\n"
-        << "  from the start of the file to the beginning of each variant line.\n\n"
-        << "Example:\n"
-        << "  VCFX_indexer < input.vcf > index.tsv\n";
+    std::cout << "VCFX_indexer\n"
+              << "Usage: VCFX_indexer [--help]\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin (raw bytes) and writes a 3-column index\n"
+              << "  (CHROM, POS, FILE_OFFSET) to stdout. FILE_OFFSET is the byte offset\n"
+              << "  from the start of the file to the beginning of each variant line.\n\n"
+              << "Example:\n"
+              << "  VCFX_indexer < input.vcf > index.tsv\n";
 }
 
-int VCFXIndexer::run(int argc, char* argv[]) {
-    static struct option long_opts[] = {
-        {"help", no_argument, 0, 'h'},
-        {0,0,0,0}
-    };
+int VCFXIndexer::run(int argc, char *argv[]) {
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
-    while(true) {
+    while (true) {
         int c = getopt_long(argc, argv, "h", long_opts, nullptr);
-        if (c == -1) break;
-        switch(c) {
-            case 'h':
-                displayHelp();
-                return 0;
-            default:
-                displayHelp();
-                return 1;
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            displayHelp();
+            return 0;
+        default:
+            displayHelp();
+            return 1;
         }
     }
 
@@ -73,8 +70,8 @@ int VCFXIndexer::run(int argc, char* argv[]) {
 
 void VCFXIndexer::createVCFIndex(std::istream &in, std::ostream &out) {
     bool foundChromHeader = false;
-    bool warnedNoChromYet  = false;
-    bool sawAnyHeaderLine  = false;
+    bool warnedNoChromYet = false;
+    bool sawAnyHeaderLine = false;
 
     static const size_t BUF_SIZE = 64 * 1024;
     char buffer[BUF_SIZE];
@@ -189,10 +186,17 @@ void VCFXIndexer::createVCFIndex(std::istream &in, std::ostream &out) {
 }
 
 // Optional main if you build as a single executable
-static void show_help() { VCFXIndexer obj; char arg0[] = "VCFX_indexer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXIndexer obj;
+    char arg0[] = "VCFX_indexer";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_indexer", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_indexer", show_help))
+        return 0;
     VCFXIndexer idx;
     return idx.run(argc, argv);
 }

--- a/src/VCFX_indexer/VCFX_indexer.h
+++ b/src/VCFX_indexer/VCFX_indexer.h
@@ -5,9 +5,10 @@
 #include <string>
 
 class VCFXIndexer {
-public:
-    int run(int argc, char* argv[]);
-private:
+  public:
+    int run(int argc, char *argv[]);
+
+  private:
     void displayHelp();
     void createVCFIndex(std::istream &in, std::ostream &out);
 };

--- a/src/VCFX_info_aggregator/VCFX_info_aggregator.cpp
+++ b/src/VCFX_info_aggregator/VCFX_info_aggregator.cpp
@@ -1,71 +1,67 @@
-#include "vcfx_core.h"
 #include "VCFX_info_aggregator.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
+#include <cmath> // for std::isfinite
+#include <cstdlib>
+#include <getopt.h>
 #include <iomanip>
 #include <iostream>
-#include <cstdlib>
 #include <map>
+#include <sstream>
 #include <vector>
-#include <cmath>  // for std::isfinite
 
 // ----------------------------------------------------------------------
 // Displays help
 // ----------------------------------------------------------------------
 void VCFXInfoAggregator::displayHelp() {
-    std::cout 
-        << "VCFX_info_aggregator: Aggregate numeric INFO field values from a VCF.\n\n"
-        << "Usage:\n"
-        << "  VCFX_info_aggregator --aggregate-info \"DP,AF,...\" < input.vcf > output.vcf\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin, prints it unmodified, and at the end, appends a\n"
-        << "  summary section of the form:\n"
-        << "    #AGGREGATION_SUMMARY\n"
-        << "    DP: Sum=..., Average=...\n"
-        << "    AF: Sum=..., Average=...\n"
-        << "  The VCF portion remains fully valid. The final lines start with '#' so most\n"
-        << "  VCF parsers will ignore them.\n\n"
-        << "Options:\n"
-        << "  -h, --help                Print this help message.\n"
-        << "  -a, --aggregate-info <fields>  Comma-separated list of INFO fields to aggregate.\n\n"
-        << "Example:\n"
-        << "  VCFX_info_aggregator --aggregate-info \"DP,AF\" < input.vcf > aggregated.vcf\n";
+    std::cout << "VCFX_info_aggregator: Aggregate numeric INFO field values from a VCF.\n\n"
+              << "Usage:\n"
+              << "  VCFX_info_aggregator --aggregate-info \"DP,AF,...\" < input.vcf > output.vcf\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin, prints it unmodified, and at the end, appends a\n"
+              << "  summary section of the form:\n"
+              << "    #AGGREGATION_SUMMARY\n"
+              << "    DP: Sum=..., Average=...\n"
+              << "    AF: Sum=..., Average=...\n"
+              << "  The VCF portion remains fully valid. The final lines start with '#' so most\n"
+              << "  VCF parsers will ignore them.\n\n"
+              << "Options:\n"
+              << "  -h, --help                Print this help message.\n"
+              << "  -a, --aggregate-info <fields>  Comma-separated list of INFO fields to aggregate.\n\n"
+              << "Example:\n"
+              << "  VCFX_info_aggregator --aggregate-info \"DP,AF\" < input.vcf > aggregated.vcf\n";
 }
 
 // ----------------------------------------------------------------------
 // parse command line, call aggregator
 // ----------------------------------------------------------------------
-int VCFXInfoAggregator::run(int argc, char* argv[]) {
+int VCFXInfoAggregator::run(int argc, char *argv[]) {
     int opt;
     bool showHelp = false;
     std::string infoFieldsStr;
 
     static struct option longOptions[] = {
-        {"help",          no_argument,       0, 'h'},
-        {"aggregate-info", required_argument, 0, 'a'},
-        {0,0,0,0}
-    };
+        {"help", no_argument, 0, 'h'}, {"aggregate-info", required_argument, 0, 'a'}, {0, 0, 0, 0}};
 
-    while((opt = getopt_long(argc, argv, "ha:", longOptions, nullptr)) != -1) {
-        switch(opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'a':
-                infoFieldsStr = optarg;
-                break;
-            default:
-                showHelp = true;
-                break;
+    while ((opt = getopt_long(argc, argv, "ha:", longOptions, nullptr)) != -1) {
+        switch (opt) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'a':
+            infoFieldsStr = optarg;
+            break;
+        default:
+            showHelp = true;
+            break;
         }
     }
 
-    if(showHelp) {
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    if(infoFieldsStr.empty()) {
+    if (infoFieldsStr.empty()) {
         std::cerr << "Error: Must specify --aggregate-info with at least one field.\n";
         return 1;
     }
@@ -75,16 +71,18 @@ int VCFXInfoAggregator::run(int argc, char* argv[]) {
     {
         std::stringstream ss(infoFieldsStr);
         std::string f;
-        while(std::getline(ss, f, ',')) {
+        while (std::getline(ss, f, ',')) {
             // trim
-            while(!f.empty() && isspace((unsigned char)f.back())) f.pop_back();
-            while(!f.empty() && isspace((unsigned char)f.front())) f.erase(f.begin());
-            if(!f.empty()) {
+            while (!f.empty() && isspace((unsigned char)f.back()))
+                f.pop_back();
+            while (!f.empty() && isspace((unsigned char)f.front()))
+                f.erase(f.begin());
+            if (!f.empty()) {
                 infoFields.push_back(f);
             }
         }
     }
-    if(infoFields.empty()) {
+    if (infoFields.empty()) {
         std::cerr << "Error: no valid fields in --aggregate-info\n";
         return 1;
     }
@@ -100,10 +98,8 @@ int VCFXInfoAggregator::run(int argc, char* argv[]) {
 //   3) parse data lines => parse 'INFO' col => parse each requested field => if numeric => accumulate
 //   4) after reading entire file, print summary
 // ----------------------------------------------------------------------
-void VCFXInfoAggregator::aggregateInfo(std::istream& in,
-                                       std::ostream& out,
-                                       const std::vector<std::string>& infoFields)
-{
+void VCFXInfoAggregator::aggregateInfo(std::istream &in, std::ostream &out,
+                                       const std::vector<std::string> &infoFields) {
     // We'll store each field's collected numeric values in a vector
     std::map<std::string, std::vector<double>> collected;
     for (auto &fld : infoFields) {
@@ -114,7 +110,8 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
 
     std::string line;
     while (true) {
-        if (!std::getline(in, line)) break;
+        if (!std::getline(in, line))
+            break;
         if (line.empty()) {
             out << line << "\n";
             continue;
@@ -131,7 +128,7 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
 
         if (!foundChromHeader) {
             std::cerr << "Error: encountered data line before #CHROM header.\n";
-            break;  // break or continue, but we'll break
+            break; // break or continue, but we'll break
         }
 
         // parse columns
@@ -161,7 +158,8 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
             std::stringstream infoSS(info);
             std::string item;
             while (std::getline(infoSS, item, ';')) {
-                if (item.empty()) continue;
+                if (item.empty())
+                    continue;
                 // find '='
                 size_t eqPos = item.find('=');
                 if (eqPos == std::string::npos) {
@@ -170,12 +168,17 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
                 }
                 std::string key = item.substr(0, eqPos);
                 std::string val = item.substr(eqPos + 1);
-                if (key.empty() || val.empty()) continue;
+                if (key.empty() || val.empty())
+                    continue;
                 // trim spaces
-                while (!key.empty() && isspace((unsigned char)key.back())) key.pop_back();
-                while (!key.empty() && isspace((unsigned char)key.front())) key.erase(key.begin());
-                while (!val.empty() && isspace((unsigned char)val.back())) val.pop_back();
-                while (!val.empty() && isspace((unsigned char)val.front())) val.erase(val.begin());
+                while (!key.empty() && isspace((unsigned char)key.back()))
+                    key.pop_back();
+                while (!key.empty() && isspace((unsigned char)key.front()))
+                    key.erase(key.begin());
+                while (!val.empty() && isspace((unsigned char)val.back()))
+                    val.pop_back();
+                while (!val.empty() && isspace((unsigned char)val.front()))
+                    val.erase(val.begin());
 
                 auto it = collected.find(key);
                 if (it == collected.end()) {
@@ -190,7 +193,7 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
                         it->second.push_back(d);
                     }
                     // else skip
-                } catch(...) {
+                } catch (...) {
                     // skip
                 }
             }
@@ -214,10 +217,17 @@ void VCFXInfoAggregator::aggregateInfo(std::istream& in,
     }
 }
 
-static void show_help() { VCFXInfoAggregator obj; char arg0[] = "VCFX_info_aggregator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXInfoAggregator obj;
+    char arg0[] = "VCFX_info_aggregator";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_aggregator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_aggregator", show_help))
+        return 0;
     VCFXInfoAggregator app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_info_aggregator/VCFX_info_aggregator.h
+++ b/src/VCFX_info_aggregator/VCFX_info_aggregator.h
@@ -2,26 +2,24 @@
 #define VCFX_INFO_AGGREGATOR_H
 
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 // VCFXInfoAggregator: A tool that reads a VCF, prints it unmodified, and at the end
 // produces an aggregated summary of numeric INFO fields (like DP, AF, etc.)
 class VCFXInfoAggregator {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Print usage
     void displayHelp();
 
     // The main function that scans the VCF from 'in', writes lines unchanged to 'out',
     // collecting numeric values from specified fields in 'infoFields'.
     // After reading the entire file, it appends a summary section.
-    void aggregateInfo(std::istream& in,
-                       std::ostream& out,
-                       const std::vector<std::string>& infoFields);
+    void aggregateInfo(std::istream &in, std::ostream &out, const std::vector<std::string> &infoFields);
 };
 
 #endif // VCFX_INFO_AGGREGATOR_H

--- a/src/VCFX_info_parser/VCFX_info_parser.cpp
+++ b/src/VCFX_info_parser/VCFX_info_parser.cpp
@@ -1,30 +1,31 @@
-#include "vcfx_core.h"
 #include "VCFX_info_parser.h"
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <unordered_map>
 #include <cstdlib>
+#include <sstream>
+#include <unordered_map>
 
 // Function to display help message
 void printHelp() {
-    std::cout << "VCFX_info_parser\n"
-              << "Usage: VCFX_info_parser [OPTIONS]\n\n"
-              << "Options:\n"
-              << "  --info, -i \"FIELD1,FIELD2\"   Specify the INFO fields to display (e.g., \"DP,AF\").\n"
-              << "  --help, -h                    Display this help message and exit.\n\n"
-              << "Description:\n"
-              << "  Parses the INFO field of a VCF file and displays the selected INFO fields in a user-friendly format.\n\n"
-              << "Examples:\n"
-              << "  ./VCFX_info_parser --info \"DP,AF\" < input.vcf > output_info.tsv\n";
+    std::cout
+        << "VCFX_info_parser\n"
+        << "Usage: VCFX_info_parser [OPTIONS]\n\n"
+        << "Options:\n"
+        << "  --info, -i \"FIELD1,FIELD2\"   Specify the INFO fields to display (e.g., \"DP,AF\").\n"
+        << "  --help, -h                    Display this help message and exit.\n\n"
+        << "Description:\n"
+        << "  Parses the INFO field of a VCF file and displays the selected INFO fields in a user-friendly format.\n\n"
+        << "Examples:\n"
+        << "  ./VCFX_info_parser --info \"DP,AF\" < input.vcf > output_info.tsv\n";
 }
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_fields) {
+bool parseArguments(int argc, char *argv[], std::vector<std::string> &info_fields) {
     bool foundAnyField = false;
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        
+
         if ((arg == "--info" || arg == "-i") && i + 1 < argc) {
             std::string fields_str = argv[++i];
             std::stringstream ss(fields_str);
@@ -38,8 +39,7 @@ bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_field
                     foundAnyField = true;
                 }
             }
-        }
-        else if (arg.rfind("--info=", 0) == 0) {
+        } else if (arg.rfind("--info=", 0) == 0) {
             // e.g. --info=DP,AF
             std::string fields_str = arg.substr(7);
             std::stringstream ss(fields_str);
@@ -53,8 +53,7 @@ bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_field
                     foundAnyField = true;
                 }
             }
-        }
-        else if (arg == "--help" || arg == "-h") {
+        } else if (arg == "--help" || arg == "-h") {
             printHelp();
             std::exit(0);
         }
@@ -65,7 +64,7 @@ bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_field
 }
 
 // Splits a string by a delimiter
-std::vector<std::string> split(const std::string& s, char delimiter) {
+std::vector<std::string> split(const std::string &s, char delimiter) {
     std::vector<std::string> tokens;
     std::string token;
     std::stringstream ss(s);
@@ -76,11 +75,11 @@ std::vector<std::string> split(const std::string& s, char delimiter) {
 }
 
 // Parses the INFO field and display selected fields
-bool parseInfoFields(std::istream& in, std::ostream& out, const std::vector<std::string>& info_fields) {
+bool parseInfoFields(std::istream &in, std::ostream &out, const std::vector<std::string> &info_fields) {
     // If we have any fields, print header
     if (!info_fields.empty()) {
         out << "CHROM\tPOS\tID\tREF\tALT";
-        for (const auto& field : info_fields) {
+        for (const auto &field : info_fields) {
             out << "\t" << field;
         }
         out << "\n";
@@ -120,7 +119,7 @@ bool parseInfoFields(std::istream& in, std::ostream& out, const std::vector<std:
 
         // Print row
         out << chrom << "\t" << pos << "\t" << id << "\t" << ref << "\t" << alt;
-        for (const auto& field : info_fields) {
+        for (const auto &field : info_fields) {
             auto it = info_map.find(field);
             if (it != info_map.end()) {
                 // If it's a flag (empty string), print "."
@@ -141,8 +140,9 @@ bool parseInfoFields(std::istream& in, std::ostream& out, const std::vector<std:
 
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_parser", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_parser", show_help))
+        return 0;
     std::vector<std::string> info_fields;
 
     // parse arguments

--- a/src/VCFX_info_parser/VCFX_info_parser.h
+++ b/src/VCFX_info_parser/VCFX_info_parser.h
@@ -10,12 +10,12 @@ void printHelp();
 
 // Parses command-line arguments into 'info_fields'.
 // Returns true if at least one info field was parsed successfully.
-bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_fields);
+bool parseArguments(int argc, char *argv[], std::vector<std::string> &info_fields);
 
 // Splits a string by a delimiter
-std::vector<std::string> split(const std::string& s, char delimiter);
+std::vector<std::string> split(const std::string &s, char delimiter);
 
 // Parses the VCF, extracting the selected INFO fields and printing to 'out'
-bool parseInfoFields(std::istream& in, std::ostream& out, const std::vector<std::string>& info_fields);
+bool parseInfoFields(std::istream &in, std::ostream &out, const std::vector<std::string> &info_fields);
 
 #endif // VCFX_INFO_PARSER_H

--- a/src/VCFX_info_summarizer/VCFX_info_summarizer.cpp
+++ b/src/VCFX_info_summarizer/VCFX_info_summarizer.cpp
@@ -1,14 +1,14 @@
-#include "vcfx_core.h"
 #include "VCFX_info_summarizer.h"
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cctype>
-#include <unordered_set>
-#include <unordered_map>
+#include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <map>
-#include <cstdlib>
-#include <cmath>   
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
 
 // Function to display help message
 void printHelp() {
@@ -25,7 +25,7 @@ void printHelp() {
 }
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_fields) {
+bool parseArguments(int argc, char *argv[], std::vector<std::string> &info_fields) {
     bool foundAnyField = false;
 
     for (int i = 1; i < argc; ++i) {
@@ -60,8 +60,7 @@ bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_field
                     foundAnyField = true;
                 }
             }
-        }
-        else if (arg == "--help" || arg == "-h") {
+        } else if (arg == "--help" || arg == "-h") {
             printHelp();
             std::exit(0);
         }
@@ -77,8 +76,9 @@ bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_field
 }
 
 // Function to calculate mean
-double calculateMean(const std::vector<double>& data) {
-    if (data.empty()) return 0.0;
+double calculateMean(const std::vector<double> &data) {
+    if (data.empty())
+        return 0.0;
     double sum = 0.0;
     for (auto val : data) {
         sum += val;
@@ -88,7 +88,8 @@ double calculateMean(const std::vector<double>& data) {
 
 // Function to calculate median
 double calculateMedian(std::vector<double> data) {
-    if (data.empty()) return 0.0;
+    if (data.empty())
+        return 0.0;
     std::sort(data.begin(), data.end());
     size_t n = data.size();
     if (n % 2 == 0) {
@@ -99,8 +100,9 @@ double calculateMedian(std::vector<double> data) {
 }
 
 // Function to calculate mode
-double calculateMode(const std::vector<double>& data) {
-    if (data.empty()) return 0.0;
+double calculateMode(const std::vector<double> &data) {
+    if (data.empty())
+        return 0.0;
     std::unordered_map<double, int> frequency;
     int maxFreq = 0;
     double modeValue = data[0];
@@ -116,18 +118,19 @@ double calculateMode(const std::vector<double>& data) {
 }
 
 // Function to parse the INFO field and collect specified fields
-bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<std::string>& info_fields) {
+bool summarizeInfoFields(std::istream &in, std::ostream &out, const std::vector<std::string> &info_fields) {
     std::string line;
     bool header_found = false;
 
     // Map to store vectors of values for each requested INFO field
     std::map<std::string, std::vector<double>> info_data;
-    for (const auto& field : info_fields) {
+    for (const auto &field : info_fields) {
         info_data[field]; // ensures key is created
     }
 
     while (std::getline(in, line)) {
-        if (line.empty()) continue;
+        if (line.empty())
+            continue;
 
         if (line[0] == '#') {
             // Check if it is #CHROM
@@ -145,14 +148,9 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
         // parse columns
         std::stringstream ss(line);
         std::string chrom, pos, id, ref, alt, qual, filter, info;
-        if (!std::getline(ss, chrom, '\t') ||
-            !std::getline(ss, pos, '\t') ||
-            !std::getline(ss, id, '\t') ||
-            !std::getline(ss, ref, '\t') ||
-            !std::getline(ss, alt, '\t') ||
-            !std::getline(ss, qual, '\t') ||
-            !std::getline(ss, filter, '\t') ||
-            !std::getline(ss, info, '\t')) {
+        if (!std::getline(ss, chrom, '\t') || !std::getline(ss, pos, '\t') || !std::getline(ss, id, '\t') ||
+            !std::getline(ss, ref, '\t') || !std::getline(ss, alt, '\t') || !std::getline(ss, qual, '\t') ||
+            !std::getline(ss, filter, '\t') || !std::getline(ss, info, '\t')) {
             std::cerr << "Warning: Skipping malformed VCF line: " << line << "\n";
             continue;
         }
@@ -163,7 +161,8 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
             std::stringstream info_ss(info);
             std::string kv;
             while (std::getline(info_ss, kv, ';')) {
-                if (kv.empty()) continue;
+                if (kv.empty())
+                    continue;
                 size_t eq = kv.find('=');
                 if (eq != std::string::npos) {
                     std::string key = kv.substr(0, eq);
@@ -177,7 +176,7 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
         }
 
         // For each requested field
-        for (const auto& field : info_fields) {
+        for (const auto &field : info_fields) {
             auto it = info_map.find(field);
             if (it == info_map.end()) {
                 // not present
@@ -191,14 +190,12 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
                     double v = std::stod(val);
                     // Skip NaN / Inf
                     if (std::isnan(v) || std::isinf(v)) {
-                        std::cerr << "Warning: Non-finite value for field " << field
-                                  << " in line: " << line << "\n";
+                        std::cerr << "Warning: Non-finite value for field " << field << " in line: " << line << "\n";
                         continue; // skip
                     }
                     info_data[field].push_back(v);
                 } catch (...) {
-                    std::cerr << "Warning: Non-numeric value for field " << field
-                              << " in line: " << line << "\n";
+                    std::cerr << "Warning: Non-numeric value for field " << field << " in line: " << line << "\n";
                 }
             }
         }
@@ -206,8 +203,8 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
 
     // Print summary table
     out << "INFO_Field\tMean\tMedian\tMode\n";
-    for (const auto& field : info_fields) {
-        const auto& data = info_data.at(field);
+    for (const auto &field : info_fields) {
+        const auto &data = info_data.at(field);
         if (data.empty()) {
             // no numeric data => NA
             out << field << "\tNA\tNA\tNA\n";
@@ -216,10 +213,7 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
         double mean = calculateMean(data);
         double median = calculateMedian(data);
         double mode = calculateMode(data);
-        out << field << "\t"
-            << std::fixed << std::setprecision(4) << mean << "\t"
-            << median << "\t"
-            << mode << "\n";
+        out << field << "\t" << std::fixed << std::setprecision(4) << mean << "\t" << median << "\t" << mode << "\n";
     }
 
     return true;
@@ -227,8 +221,9 @@ bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<
 
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_summarizer", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_info_summarizer", show_help))
+        return 0;
     std::vector<std::string> info_fields;
 
     // parse arguments

--- a/src/VCFX_info_summarizer/VCFX_info_summarizer.h
+++ b/src/VCFX_info_summarizer/VCFX_info_summarizer.h
@@ -3,8 +3,8 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 // Function to display help message
 void printHelp();
@@ -17,18 +17,18 @@ struct StatSummary {
 };
 
 // Function to parse command-line arguments
-bool parseArguments(int argc, char* argv[], std::vector<std::string>& info_fields);
+bool parseArguments(int argc, char *argv[], std::vector<std::string> &info_fields);
 
 // Function to calculate mean
-double calculateMean(const std::vector<double>& data);
+double calculateMean(const std::vector<double> &data);
 
 // Function to calculate median
 double calculateMedian(std::vector<double> data);
 
 // Function to calculate mode
-double calculateMode(const std::vector<double>& data);
+double calculateMode(const std::vector<double> &data);
 
 // Function to parse the INFO field and collect specified fields
-bool summarizeInfoFields(std::istream& in, std::ostream& out, const std::vector<std::string>& info_fields);
+bool summarizeInfoFields(std::istream &in, std::ostream &out, const std::vector<std::string> &info_fields);
 
 #endif // VCFX_INFO_SUMMARIZER_H

--- a/src/VCFX_ld_calculator/VCFX_ld_calculator.cpp
+++ b/src/VCFX_ld_calculator/VCFX_ld_calculator.cpp
@@ -1,62 +1,58 @@
-#include "vcfx_core.h"
 #include "VCFX_ld_calculator.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <cstdlib>
+#include <getopt.h>
 #include <iomanip>
-
+#include <iostream>
+#include <sstream>
 
 // ----------------------------------------------------------------------
 // Display Help
 // ----------------------------------------------------------------------
 void VCFXLDCalculator::displayHelp() {
-    std::cout
-        << "VCFX_ld_calculator: Calculate pairwise LD (r^2) for variants in a VCF region.\n\n"
-        << "Usage:\n"
-        << "  VCFX_ld_calculator [options] < input.vcf\n\n"
-        << "Options:\n"
-        << "  --region <chr:start-end>  Only compute LD for variants in [start, end] on 'chr'.\n"
-        << "  --help, -h                Show this help message.\n\n"
-        << "Description:\n"
-        << "  Reads a VCF from stdin (uncompressed) and collects diploid genotypes as code:\n"
-        << "     0 => homRef (0/0), 1 => het (0/1), 2 => homAlt(1/1), -1 => missing/other.\n"
-        << "  Then for each pair of variants in the region, compute pairwise r^2 ignoring samples with missing genotype.\n"
-        << "  Output an MxM matrix of r^2 along with variant identifiers.\n\n"
-        << "Example:\n"
-        << "  VCFX_ld_calculator --region chr1:10000-20000 < input.vcf > ld_matrix.txt\n";
+    std::cout << "VCFX_ld_calculator: Calculate pairwise LD (r^2) for variants in a VCF region.\n\n"
+              << "Usage:\n"
+              << "  VCFX_ld_calculator [options] < input.vcf\n\n"
+              << "Options:\n"
+              << "  --region <chr:start-end>  Only compute LD for variants in [start, end] on 'chr'.\n"
+              << "  --help, -h                Show this help message.\n\n"
+              << "Description:\n"
+              << "  Reads a VCF from stdin (uncompressed) and collects diploid genotypes as code:\n"
+              << "     0 => homRef (0/0), 1 => het (0/1), 2 => homAlt(1/1), -1 => missing/other.\n"
+              << "  Then for each pair of variants in the region, compute pairwise r^2 ignoring samples with missing "
+                 "genotype.\n"
+              << "  Output an MxM matrix of r^2 along with variant identifiers.\n\n"
+              << "Example:\n"
+              << "  VCFX_ld_calculator --region chr1:10000-20000 < input.vcf > ld_matrix.txt\n";
 }
 
 // ----------------------------------------------------------------------
 // parseRegion( "chr1:10000-20000" ) => regionChrom="chr1", regionStart=10000, regionEnd=20000
 // returns false if can't parse
 // ----------------------------------------------------------------------
-bool VCFXLDCalculator::parseRegion(const std::string &regionStr,
-                                   std::string &regionChrom,
-                                   int &regionStart,
-                                   int &regionEnd)
-{
+bool VCFXLDCalculator::parseRegion(const std::string &regionStr, std::string &regionChrom, int &regionStart,
+                                   int &regionEnd) {
     // find ':'
-    auto colonPos= regionStr.find(':');
-    if(colonPos==std::string::npos) {
+    auto colonPos = regionStr.find(':');
+    if (colonPos == std::string::npos) {
         return false;
     }
     regionChrom = regionStr.substr(0, colonPos);
-    auto dashPos= regionStr.find('-', colonPos+1);
-    if(dashPos==std::string::npos) {
+    auto dashPos = regionStr.find('-', colonPos + 1);
+    if (dashPos == std::string::npos) {
         return false;
     }
-    std::string startStr= regionStr.substr(colonPos+1, dashPos-(colonPos+1));
-    std::string endStr= regionStr.substr(dashPos+1);
+    std::string startStr = regionStr.substr(colonPos + 1, dashPos - (colonPos + 1));
+    std::string endStr = regionStr.substr(dashPos + 1);
     try {
-        regionStart= std::stoi(startStr);
-        regionEnd=   std::stoi(endStr);
-    } catch(...) {
+        regionStart = std::stoi(startStr);
+        regionEnd = std::stoi(endStr);
+    } catch (...) {
         return false;
     }
-    if(regionStart> regionEnd) {
+    if (regionStart > regionEnd) {
         return false;
     }
     return true;
@@ -70,40 +66,46 @@ bool VCFXLDCalculator::parseRegion(const std::string &regionStr,
 //   => -1 => missing or multi-allelic
 // ----------------------------------------------------------------------
 int VCFXLDCalculator::parseGenotype(const std::string &s) {
-    if(s.empty() || s=="." || s=="./." || s==".|.") {
+    if (s.empty() || s == "." || s == "./." || s == ".|.") {
         return -1;
     }
     // unify '|' => '/'
     std::string g(s);
     for (char &c : g) {
-        if(c=='|') c='/';
+        if (c == '|')
+            c = '/';
     }
     // split
-    auto slashPos= g.find('/');
-    if(slashPos==std::string::npos) {
+    auto slashPos = g.find('/');
+    if (slashPos == std::string::npos) {
         return -1; // not diploid
     }
-    auto a1= g.substr(0,slashPos);
-    auto a2= g.substr(slashPos+1);
-    if(a1.empty()||a2.empty()) return -1;
-    if(a1=="."|| a2==".") return -1;
+    auto a1 = g.substr(0, slashPos);
+    auto a2 = g.substr(slashPos + 1);
+    if (a1.empty() || a2.empty())
+        return -1;
+    if (a1 == "." || a2 == ".")
+        return -1;
     // parse int
-    int i1=0, i2=0;
+    int i1 = 0, i2 = 0;
     try {
-        i1= std::stoi(a1);
-        i2= std::stoi(a2);
-    } catch(...) {
+        i1 = std::stoi(a1);
+        i2 = std::stoi(a2);
+    } catch (...) {
         return -1;
     }
-    if(i1<0 || i2<0) return -1;
-    if(i1>1 || i2>1) {
+    if (i1 < 0 || i2 < 0)
+        return -1;
+    if (i1 > 1 || i2 > 1) {
         // multi-allelic
         return -1;
     }
-    if(i1==i2) {
+    if (i1 == i2) {
         // 0 => 0/0 => code=0, 1 => 1/1 => code=2
-        if(i1==0) return 0; 
-        else return 2;
+        if (i1 == 0)
+            return 0;
+        else
+            return 2;
     } else {
         return 1;
     }
@@ -119,32 +121,34 @@ int VCFXLDCalculator::parseGenotype(const std::string &s) {
 // varX= average(X^2)- meanX^2, varY likewise
 // r= cov / sqrt(varX varY), r^2= r*r
 // ----------------------------------------------------------------------
-double VCFXLDCalculator::computeRsq(const std::vector<int> &g1,
-                                    const std::vector<int> &g2)
-{
-    if(g1.size()!= g2.size()) return 0.0; 
-    int n=0;
-    long sumX=0, sumY=0, sumXY=0, sumX2=0, sumY2=0;
-    for(size_t i=0; i<g1.size(); i++){
-        int x= g1[i];
-        int y= g2[i];
-        if(x<0||y<0) continue; // skip missing
+double VCFXLDCalculator::computeRsq(const std::vector<int> &g1, const std::vector<int> &g2) {
+    if (g1.size() != g2.size())
+        return 0.0;
+    int n = 0;
+    long sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+    for (size_t i = 0; i < g1.size(); i++) {
+        int x = g1[i];
+        int y = g2[i];
+        if (x < 0 || y < 0)
+            continue; // skip missing
         n++;
-        sumX+= x;
-        sumY+= y;
-        sumXY+= x*y;
-        sumX2+= (x*x);
-        sumY2+= (y*y);
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += (x * x);
+        sumY2 += (y * y);
     }
-    if(n<2) return 0.0;
-    double meanX= (double)sumX/(double)n;
-    double meanY= (double)sumY/(double)n;
-    double cov= ((double)sumXY/(double)n) - (meanX* meanY);
-    double varX= ((double)sumX2/(double)n) - (meanX* meanX);
-    double varY= ((double)sumY2/(double)n) - (meanY* meanY);
-    if(varX<=0.0 || varY<=0.0) return 0.0;
-    double r= cov/ (std::sqrt(varX)* std::sqrt(varY));
-    return r*r;
+    if (n < 2)
+        return 0.0;
+    double meanX = (double)sumX / (double)n;
+    double meanY = (double)sumY / (double)n;
+    double cov = ((double)sumXY / (double)n) - (meanX * meanY);
+    double varX = ((double)sumX2 / (double)n) - (meanX * meanX);
+    double varY = ((double)sumY2 / (double)n) - (meanY * meanY);
+    if (varX <= 0.0 || varY <= 0.0)
+        return 0.0;
+    double r = cov / (std::sqrt(varX) * std::sqrt(varY));
+    return r * r;
 }
 
 // ----------------------------------------------------------------------
@@ -152,49 +156,46 @@ double VCFXLDCalculator::computeRsq(const std::vector<int> &g1,
 //   store variants within region
 //   then produce MxM matrix of r^2
 // ----------------------------------------------------------------------
-void VCFXLDCalculator::computeLD(std::istream &in,
-                                 std::ostream &out,
-                                 const std::string &regionChrom,
-                                 int regionStart,
-                                 int regionEnd)
-{
-    bool foundChromHeader= false;
+void VCFXLDCalculator::computeLD(std::istream &in, std::ostream &out, const std::string &regionChrom, int regionStart,
+                                 int regionEnd) {
+    bool foundChromHeader = false;
     std::vector<std::string> sampleNames;
     std::vector<LDVariant> variants;
-    int numSamples=0;
+    int numSamples = 0;
 
     // parse header => get sample col
     // pass header lines as is
     std::string line;
-    while(true) {
-        auto pos= in.tellg();
-        if(!std::getline(in,line)) break;
-        if(line.empty()) {
+    while (true) {
+        auto pos = in.tellg();
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
             out << line << "\n";
             continue;
         }
-        if(line[0]=='#') {
+        if (line[0] == '#') {
             out << line << "\n";
-            if(!foundChromHeader && line.rfind("#CHROM",0)==0) {
+            if (!foundChromHeader && line.rfind("#CHROM", 0) == 0) {
                 // parse sample
-                foundChromHeader= true;
+                foundChromHeader = true;
                 std::stringstream ss(line);
                 std::string tok;
                 std::vector<std::string> tokens;
-                while(std::getline(ss,tok,'\t')) {
+                while (std::getline(ss, tok, '\t')) {
                     tokens.push_back(tok);
                 }
                 // from col=9 onward => sample
-                for(size_t c=9; c<tokens.size(); c++){
+                for (size_t c = 9; c < tokens.size(); c++) {
                     sampleNames.push_back(tokens[c]);
                 }
-                numSamples= sampleNames.size();
+                numSamples = sampleNames.size();
             }
             continue;
-        } 
+        }
         // data line
-        if(!foundChromHeader) {
-            std::cerr<<"Error: encountered data line before #CHROM.\n";
+        if (!foundChromHeader) {
+            std::cerr << "Error: encountered data line before #CHROM.\n";
             // we can break or skip
             break;
         }
@@ -204,49 +205,50 @@ void VCFXLDCalculator::computeLD(std::istream &in,
         std::vector<std::string> fields;
         {
             std::string f;
-            while(std::getline(ss,f,'\t')){
+            while (std::getline(ss, f, '\t')) {
                 fields.push_back(f);
             }
         }
-        if(fields.size()<10) {
+        if (fields.size() < 10) {
             // not enough columns => pass line => skip
             out << line << "\n";
             continue;
         }
-        std::string &chrom= fields[0];
-        std::string &posStr= fields[1];
-        int posVal=0;
+        std::string &chrom = fields[0];
+        std::string &posStr = fields[1];
+        int posVal = 0;
         try {
-            posVal= std::stoi(posStr);
-        } catch(...) {
+            posVal = std::stoi(posStr);
+        } catch (...) {
             // pass
-            out << line <<"\n";
+            out << line << "\n";
             continue;
         }
         // if regionChrom not empty => check if chrom matches
         // if regionChrom empty => we do everything
-        if(!regionChrom.empty()) {
-            if(chrom!= regionChrom) {
+        if (!regionChrom.empty()) {
+            if (chrom != regionChrom) {
                 // not in region => pass line
-                out << line <<"\n";
+                out << line << "\n";
                 continue;
             }
-            if(posVal< regionStart || posVal> regionEnd) {
+            if (posVal < regionStart || posVal > regionEnd) {
                 // out of range
-                out << line <<"\n";
+                out << line << "\n";
                 continue;
             }
         }
         // we keep this variant => parse genotype codes
         LDVariant v;
-        v.chrom= chrom;
-        v.pos=   posVal;
+        v.chrom = chrom;
+        v.pos = posVal;
         v.genotype.resize(numSamples, -1);
         // sample columns => fields[9..]
-        int sampleCol=9;
-        for(int s=0; s<numSamples; s++){
-            if((size_t)(sampleCol+s)>= fields.size()) break;
-            v.genotype[s] = parseGenotype(fields[sampleCol+s]);
+        int sampleCol = 9;
+        for (int s = 0; s < numSamples; s++) {
+            if ((size_t)(sampleCol + s) >= fields.size())
+                break;
+            v.genotype[s] = parseGenotype(fields[sampleCol + s]);
         }
         variants.push_back(std::move(v));
         // pass line unchanged
@@ -259,8 +261,8 @@ void VCFXLDCalculator::computeLD(std::istream &in,
     // first line => #VariantIndices ...
     // or we print a table with variant index as row, col + r^2
     // We'll do a simple text approach
-    size_t M= variants.size();
-    if(M<2) {
+    size_t M = variants.size();
+    if (M < 2) {
         out << "#LD_MATRIX_START\n";
         out << "No or only one variant in the region => no pairwise LD.\n";
         out << "#LD_MATRIX_END\n";
@@ -271,26 +273,26 @@ void VCFXLDCalculator::computeLD(std::istream &in,
     // Print header row => e.g. row0col0 is "", row0col i => i. We'll also print "Chrom:Pos" as col
     // first line => tab, var1, var2, ...
     out << "Index/Var";
-    for (size_t j=0; j<M; j++){
+    for (size_t j = 0; j < M; j++) {
         out << "\t" << variants[j].chrom << ":" << variants[j].pos;
     }
     out << "\n";
 
     // each row => i => row header => i-chrom:pos => r2 vs all j
-    for(size_t i=0; i<M; i++){
+    for (size_t i = 0; i < M; i++) {
         out << variants[i].chrom << ":" << variants[i].pos;
-        for(size_t j=0; j<M; j++){
-            if(j< i) {
+        for (size_t j = 0; j < M; j++) {
+            if (j < i) {
                 // symmetrical => we can do the same as [j][i]
                 // but let's just compute anyway or store
-                double r2= computeRsq(variants[i].genotype, variants[j].genotype);
+                double r2 = computeRsq(variants[i].genotype, variants[j].genotype);
                 out << "\t" << std::fixed << std::setprecision(4) << r2;
-            } else if(i==j) {
+            } else if (i == j) {
                 // r2 with self => 1.0
                 out << "\t1.0000";
             } else {
                 // i< j => compute
-                double r2= computeRsq(variants[i].genotype, variants[j].genotype);
+                double r2 = computeRsq(variants[i].genotype, variants[j].genotype);
                 out << "\t" << std::fixed << std::setprecision(4) << r2;
             }
         }
@@ -303,39 +305,37 @@ void VCFXLDCalculator::computeLD(std::istream &in,
 // ----------------------------------------------------------------------
 // main run
 // ----------------------------------------------------------------------
-int VCFXLDCalculator::run(int argc, char* argv[]) {
+int VCFXLDCalculator::run(int argc, char *argv[]) {
     static struct option long_opts[] = {
-        {"help", no_argument, 0, 'h'},
-        {"region", required_argument, 0, 'r'},
-        {0,0,0,0}
-    };
-    bool showHelp=false;
+        {"help", no_argument, 0, 'h'}, {"region", required_argument, 0, 'r'}, {0, 0, 0, 0}};
+    bool showHelp = false;
     std::string regionStr;
-    while(true){
-        int c= getopt_long(argc, argv, "hr:", long_opts, NULL);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'r':
-                regionStr= optarg;
-                break;
-            default:
-                showHelp=true;
+    while (true) {
+        int c = getopt_long(argc, argv, "hr:", long_opts, NULL);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'r':
+            regionStr = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp) {
+    if (showHelp) {
         displayHelp();
         return 0;
     }
 
     // parse region if any
     std::string regionChrom;
-    int regionStart=0, regionEnd=0;
-    if(!regionStr.empty()) {
-        if(!parseRegion(regionStr, regionChrom, regionStart, regionEnd)){
-            std::cerr<<"Error parsing region '"<<regionStr<<"'. Use e.g. chr1:10000-20000\n";
+    int regionStart = 0, regionEnd = 0;
+    if (!regionStr.empty()) {
+        if (!parseRegion(regionStr, regionChrom, regionStart, regionEnd)) {
+            std::cerr << "Error parsing region '" << regionStr << "'. Use e.g. chr1:10000-20000\n";
             return 1;
         }
     }
@@ -345,10 +345,17 @@ int VCFXLDCalculator::run(int argc, char* argv[]) {
     return 0;
 }
 
-static void show_help() { VCFXLDCalculator obj; char arg0[] = "VCFX_ld_calculator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXLDCalculator obj;
+    char arg0[] = "VCFX_ld_calculator";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_ld_calculator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ld_calculator", show_help))
+        return 0;
     VCFXLDCalculator calc;
     return calc.run(argc, argv);
 }

--- a/src/VCFX_ld_calculator/VCFX_ld_calculator.h
+++ b/src/VCFX_ld_calculator/VCFX_ld_calculator.h
@@ -13,32 +13,23 @@ struct LDVariant {
 };
 
 class VCFXLDCalculator {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
     // Parse the region string "chr1:10000-20000"
     // If none provided, regionChrom will be empty => use all
-    bool parseRegion(const std::string &regionStr,
-                     std::string &regionChrom,
-                     int &regionStart,
-                     int &regionEnd);
+    bool parseRegion(const std::string &regionStr, std::string &regionChrom, int &regionStart, int &regionEnd);
 
     // The main logic: read VCF, store genotype codes for in-range variants, compute r^2, output
-    void computeLD(std::istream &in,
-                   std::ostream &out,
-                   const std::string &regionChrom,
-                   int regionStart,
-                   int regionEnd);
+    void computeLD(std::istream &in, std::ostream &out, const std::string &regionChrom, int regionStart, int regionEnd);
 
     // parse a single genotype string => code
     int parseGenotype(const std::string &s);
 
     // compute r^2 for two variant’s genotype arrays
-    double computeRsq(const std::vector<int> &g1,
-                      const std::vector<int> &g2);
-
+    double computeRsq(const std::vector<int> &g1, const std::vector<int> &g2);
 };
 
 #endif // VCFX_LD_CALCULATOR_H

--- a/src/VCFX_merger/VCFX_merger.cpp
+++ b/src/VCFX_merger/VCFX_merger.cpp
@@ -1,43 +1,40 @@
-#include "vcfx_core.h"
 #include "VCFX_merger.h"
-#include <getopt.h>
-#include <fstream>
-#include <sstream>
-#include <queue>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
 #include <cstdlib>
+#include <fstream>
+#include <getopt.h>
+#include <iostream>
+#include <queue>
+#include <sstream>
 
 // Implementation of VCFX_merger
 
-int VCFXMerger::run(int argc, char* argv[]) {
+int VCFXMerger::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
     std::vector<std::string> inputFiles;
 
     static struct option long_options[] = {
-        {"merge", required_argument, 0, 'm'},
-        {"help",  no_argument,       0, 'h'},
-        {0,       0,               0,   0 }
-    };
+        {"merge", required_argument, 0, 'm'}, {"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "m:h", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'm': {
-                // Split comma-separated file names
-                std::string files = optarg;
-                size_t pos = 0;
-                while ((pos = files.find(',')) != std::string::npos) {
-                    inputFiles.emplace_back(files.substr(0, pos));
-                    files.erase(0, pos + 1);
-                }
-                inputFiles.emplace_back(files);
-                break;
+        case 'm': {
+            // Split comma-separated file names
+            std::string files = optarg;
+            size_t pos = 0;
+            while ((pos = files.find(',')) != std::string::npos) {
+                inputFiles.emplace_back(files.substr(0, pos));
+                files.erase(0, pos + 1);
             }
-            case 'h':
-            default:
-                showHelp = true;
+            inputFiles.emplace_back(files);
+            break;
+        }
+        case 'h':
+        default:
+            showHelp = true;
         }
     }
 
@@ -52,18 +49,17 @@ int VCFXMerger::run(int argc, char* argv[]) {
 }
 
 void VCFXMerger::displayHelp() {
-    std::cout
-        << "VCFX_merger: Merge multiple VCF files by variant position.\n\n"
-        << "Usage:\n"
-        << "  VCFX_merger --merge file1.vcf,file2.vcf,... [options]\n\n"
-        << "Options:\n"
-        << "  -m, --merge    Comma-separated list of VCF files to merge\n"
-        << "  -h, --help     Display this help message and exit\n\n"
-        << "Example:\n"
-        << "  VCFX_merger --merge sample1.vcf,sample2.vcf > merged.vcf\n";
+    std::cout << "VCFX_merger: Merge multiple VCF files by variant position.\n\n"
+              << "Usage:\n"
+              << "  VCFX_merger --merge file1.vcf,file2.vcf,... [options]\n\n"
+              << "Options:\n"
+              << "  -m, --merge    Comma-separated list of VCF files to merge\n"
+              << "  -h, --help     Display this help message and exit\n\n"
+              << "Example:\n"
+              << "  VCFX_merger --merge sample1.vcf,sample2.vcf > merged.vcf\n";
 }
 
-void VCFXMerger::mergeVCF(const std::vector<std::string>& inputFiles, std::ostream& out) {
+void VCFXMerger::mergeVCF(const std::vector<std::string> &inputFiles, std::ostream &out) {
     struct Variant {
         std::string chrom;
         long pos = 0;
@@ -74,7 +70,7 @@ void VCFXMerger::mergeVCF(const std::vector<std::string>& inputFiles, std::ostre
     std::vector<std::string> headers;
     bool headersCaptured = false;
 
-    for (const auto& file : inputFiles) {
+    for (const auto &file : inputFiles) {
         std::ifstream stream(file);
         if (!stream.is_open()) {
             std::cerr << "Failed to open file: " << file << "\n";
@@ -105,25 +101,32 @@ void VCFXMerger::mergeVCF(const std::vector<std::string>& inputFiles, std::ostre
             headersCaptured = true;
     }
 
-    for (const auto& h : headers) {
+    for (const auto &h : headers) {
         out << h << '\n';
     }
 
-    std::sort(variants.begin(), variants.end(), [](const Variant& a, const Variant& b) {
-        if (a.chrom == b.chrom) return a.pos < b.pos;
+    std::sort(variants.begin(), variants.end(), [](const Variant &a, const Variant &b) {
+        if (a.chrom == b.chrom)
+            return a.pos < b.pos;
         return a.chrom < b.chrom;
     });
 
-    for (const auto& v : variants) {
+    for (const auto &v : variants) {
         out << v.line << '\n';
     }
 }
 
+static void show_help() {
+    VCFXMerger obj;
+    char arg0[] = "VCFX_merger";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-static void show_help() { VCFXMerger obj; char arg0[] = "VCFX_merger"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
-
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_merger", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_merger", show_help))
+        return 0;
     VCFXMerger merger;
     return merger.run(argc, argv);
 }

--- a/src/VCFX_merger/VCFX_merger.h
+++ b/src/VCFX_merger/VCFX_merger.h
@@ -7,17 +7,16 @@
 
 // VCFX_merger: Header file for VCF file merging tool
 class VCFXMerger {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Processes and merges VCF files
-    void mergeVCF(const std::vector<std::string>& inputFiles, std::ostream& out);
-
+    void mergeVCF(const std::vector<std::string> &inputFiles, std::ostream &out);
 };
 
 #endif // VCFX_MERGER_H

--- a/src/VCFX_metadata_summarizer/VCFX_metadata_summarizer.cpp
+++ b/src/VCFX_metadata_summarizer/VCFX_metadata_summarizer.cpp
@@ -1,11 +1,11 @@
-#include "vcfx_core.h"
 #include "VCFX_metadata_summarizer.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <cstdlib>
 #include <cctype>
+#include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 
 // A helper function to extract the value of ID=... from a line like
 // ##contig=<ID=chr1,length=...>
@@ -14,16 +14,16 @@ static std::string extractID(const std::string &line, const std::string &prefix)
     // find prefix => e.g. "##contig=" -> line.find(prefix) might be 0
     // Then find 'ID='
     // Then read until ',' or '>' or end
-    auto idPos= line.find("ID=");
-    if(idPos==std::string::npos) {
+    auto idPos = line.find("ID=");
+    if (idPos == std::string::npos) {
         return "";
     }
     // substring from idPos+3
-    auto sub= line.substr(idPos+3);
+    auto sub = line.substr(idPos + 3);
     // if sub starts with something => we read until ',' or '>'
     // find first ',' or '>'
-    size_t endPos= sub.find_first_of(",>");
-    if(endPos== std::string::npos) {
+    size_t endPos = sub.find_first_of(",>");
+    if (endPos == std::string::npos) {
         // just return entire
         return sub;
     }
@@ -31,22 +31,19 @@ static std::string extractID(const std::string &line, const std::string &prefix)
 }
 
 // Implementation of VCFXMetadataSummarizer
-int VCFXMetadataSummarizer::run(int argc, char* argv[]) {
+int VCFXMetadataSummarizer::run(int argc, char *argv[]) {
     int opt;
     bool showHelp = false;
 
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},
-        {0,      0,           0,  0}
-    };
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "h", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -62,7 +59,8 @@ int VCFXMetadataSummarizer::run(int argc, char* argv[]) {
 }
 
 void VCFXMetadataSummarizer::displayHelp() {
-    std::cout << "VCFX_metadata_summarizer: Summarize key metadata (contigs, INFO, FILTER, FORMAT, samples, variants) from a VCF file.\n\n"
+    std::cout << "VCFX_metadata_summarizer: Summarize key metadata (contigs, INFO, FILTER, FORMAT, samples, variants) "
+                 "from a VCF file.\n\n"
               << "Usage:\n"
               << "  VCFX_metadata_summarizer [options] < input.vcf\n\n"
               << "Options:\n"
@@ -71,34 +69,36 @@ void VCFXMetadataSummarizer::displayHelp() {
               << "  VCFX_metadata_summarizer < input.vcf\n";
 }
 
-void VCFXMetadataSummarizer::summarizeMetadata(std::istream& in) {
+void VCFXMetadataSummarizer::summarizeMetadata(std::istream &in) {
     std::string line;
 
     while (true) {
-        if(!std::getline(in, line)) break;
-        if(line.empty()) continue;
+        if (!std::getline(in, line))
+            break;
+        if (line.empty())
+            continue;
 
-        if(line[0]=='#') {
+        if (line[0] == '#') {
             // if it's a meta line => parse
-            if(line.rfind("##",0)==0) {
+            if (line.rfind("##", 0) == 0) {
                 parseHeader(line);
             }
             // if it's #CHROM => parse sample names
-            else if(line.rfind("#CHROM",0)==0) {
+            else if (line.rfind("#CHROM", 0) == 0) {
                 // parse columns
                 std::stringstream ss(line);
                 std::vector<std::string> fields;
                 {
                     std::string f;
-                    while(std::getline(ss,f,'\t')) {
+                    while (std::getline(ss, f, '\t')) {
                         fields.push_back(f);
                     }
                 }
                 // from col=9 onward => samples
-                if(fields.size()>9) {
-                    this->numSamples= (int)fields.size()-9;
+                if (fields.size() > 9) {
+                    this->numSamples = (int)fields.size() - 9;
                 } else {
-                    this->numSamples=0;
+                    this->numSamples = 0;
                 }
             }
         } else {
@@ -111,34 +111,31 @@ void VCFXMetadataSummarizer::summarizeMetadata(std::istream& in) {
     printSummary();
 }
 
-void VCFXMetadataSummarizer::parseHeader(const std::string& line) {
+void VCFXMetadataSummarizer::parseHeader(const std::string &line) {
     // check type of line => if contig, info, filter, format
     // e.g. "##contig=<ID=chr1,length=...>" => parse ID
     // "##INFO=<ID=DP,Number=1,Type=Integer,...>"
     // "##FILTER=<ID=LowQual,Description=...>"
     // "##FORMAT=<ID=GT,Number=1,Type=String,...>"
 
-    if(line.find("##contig=")!=std::string::npos) {
-        auto idStr= extractID(line, "##contig=");
-        if(!idStr.empty()) {
+    if (line.find("##contig=") != std::string::npos) {
+        auto idStr = extractID(line, "##contig=");
+        if (!idStr.empty()) {
             contigIDs.insert(idStr);
         }
-    }
-    else if(line.find("##INFO=")!=std::string::npos) {
-        auto idStr= extractID(line, "##INFO=");
-        if(!idStr.empty()) {
+    } else if (line.find("##INFO=") != std::string::npos) {
+        auto idStr = extractID(line, "##INFO=");
+        if (!idStr.empty()) {
             infoIDs.insert(idStr);
         }
-    }
-    else if(line.find("##FILTER=")!=std::string::npos) {
-        auto idStr= extractID(line, "##FILTER=");
-        if(!idStr.empty()) {
+    } else if (line.find("##FILTER=") != std::string::npos) {
+        auto idStr = extractID(line, "##FILTER=");
+        if (!idStr.empty()) {
             filterIDs.insert(idStr);
         }
-    }
-    else if(line.find("##FORMAT=")!=std::string::npos) {
-        auto idStr= extractID(line, "##FORMAT=");
-        if(!idStr.empty()) {
+    } else if (line.find("##FORMAT=") != std::string::npos) {
+        auto idStr = extractID(line, "##FORMAT=");
+        if (!idStr.empty()) {
             formatIDs.insert(idStr);
         }
     }
@@ -155,10 +152,17 @@ void VCFXMetadataSummarizer::printSummary() const {
     std::cout << "Number of variants: " << numVariants << "\n";
 }
 
-static void show_help() { VCFXMetadataSummarizer obj; char arg0[] = "VCFX_metadata_summarizer"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXMetadataSummarizer obj;
+    char arg0[] = "VCFX_metadata_summarizer";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_metadata_summarizer", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_metadata_summarizer", show_help))
+        return 0;
     VCFXMetadataSummarizer summarizer;
     return summarizer.run(argc, argv);
 }

--- a/src/VCFX_metadata_summarizer/VCFX_metadata_summarizer.h
+++ b/src/VCFX_metadata_summarizer/VCFX_metadata_summarizer.h
@@ -2,26 +2,26 @@
 #define VCFX_METADATA_SUMMARIZER_H
 
 #include <iostream>
-#include <string>
-#include <vector>
 #include <map>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
 // VCFX_metadata_summarizer: Summarizes key metadata from a VCF file.
 class VCFXMetadataSummarizer {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Processes VCF input and summarizes metadata
-    void summarizeMetadata(std::istream& in);
+    void summarizeMetadata(std::istream &in);
 
     // Parses meta-information lines (##...) to extract contig/INFO/FILTER/FORMAT IDs
-    void parseHeader(const std::string& line);
+    void parseHeader(const std::string &line);
 
     // Prints the metadata summary
     void printSummary() const;

--- a/src/VCFX_missing_data_handler/VCFX_missing_data_handler.cpp
+++ b/src/VCFX_missing_data_handler/VCFX_missing_data_handler.cpp
@@ -1,30 +1,32 @@
-#include "vcfx_core.h"
 #include "VCFX_missing_data_handler.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <fstream>
-#include <iostream>
 #include <cstdlib>
+#include <fstream>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 
 /**
  * @brief Displays the help message for the missing data handler tool.
  */
 void printHelp() {
-    std::cout << "VCFX_missing_data_handler\n"
-              << "Usage: VCFX_missing_data_handler [OPTIONS] [files...]\n\n"
-              << "Options:\n"
-              << "  --fill-missing, -f            Impute missing genotypes with a default value (e.g., ./.).\n"
-              << "  --default-genotype, -d GEN    Specify the default genotype for imputation (default: ./.).\n"
-              << "  --help, -h                    Display this help message and exit.\n\n"
-              << "Description:\n"
-              << "  Flags or imputes missing genotype data in one or more VCF files. By default, missing genotypes are\n"
-              << "  left as is (flagged), but can be replaced with a specified genotype using --fill-missing.\n\n"
-              << "Examples:\n"
-              << "  1) Flag missing data from a single file:\n"
-              << "       ./VCFX_missing_data_handler < input.vcf > flagged_output.vcf\n\n"
-              << "  2) Impute missing data with './.' from multiple files:\n"
-              << "       ./VCFX_missing_data_handler -f --default-genotype \"./.\" file1.vcf file2.vcf > combined_output.vcf\n";
+    std::cout
+        << "VCFX_missing_data_handler\n"
+        << "Usage: VCFX_missing_data_handler [OPTIONS] [files...]\n\n"
+        << "Options:\n"
+        << "  --fill-missing, -f            Impute missing genotypes with a default value (e.g., ./.).\n"
+        << "  --default-genotype, -d GEN    Specify the default genotype for imputation (default: ./.).\n"
+        << "  --help, -h                    Display this help message and exit.\n\n"
+        << "Description:\n"
+        << "  Flags or imputes missing genotype data in one or more VCF files. By default, missing genotypes are\n"
+        << "  left as is (flagged), but can be replaced with a specified genotype using --fill-missing.\n\n"
+        << "Examples:\n"
+        << "  1) Flag missing data from a single file:\n"
+        << "       ./VCFX_missing_data_handler < input.vcf > flagged_output.vcf\n\n"
+        << "  2) Impute missing data with './.' from multiple files:\n"
+        << "       ./VCFX_missing_data_handler -f --default-genotype \"./.\" file1.vcf file2.vcf > "
+           "combined_output.vcf\n";
 }
 
 /**
@@ -34,7 +36,7 @@ void printHelp() {
  * @param delimiter The character delimiter.
  * @return A vector of split substrings.
  */
-std::vector<std::string> splitString(const std::string& str, char delimiter) {
+std::vector<std::string> splitString(const std::string &str, char delimiter) {
     std::vector<std::string> tokens;
     std::stringstream ss(str);
     std::string temp;
@@ -52,34 +54,33 @@ std::vector<std::string> splitString(const std::string& str, char delimiter) {
  * @param args Reference to Arguments structure to populate.
  * @return true if parsing is successful, false otherwise.
  */
-bool parseArguments(int argc, char* argv[], Arguments& args) {
-    static struct option long_opts[] = {
-        {"fill-missing", no_argument,       0, 'f'},
-        {"default-genotype", required_argument, 0, 'd'},
-        {"help", no_argument,              0, 'h'},
-        {0,0,0,0}
-    };
+bool parseArguments(int argc, char *argv[], Arguments &args) {
+    static struct option long_opts[] = {{"fill-missing", no_argument, 0, 'f'},
+                                        {"default-genotype", required_argument, 0, 'd'},
+                                        {"help", no_argument, 0, 'h'},
+                                        {0, 0, 0, 0}};
 
-    while(true) {
-        int c= getopt_long(argc, argv, "fd:h", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'f':
-                args.fill_missing= true;
-                break;
-            case 'd':
-                args.default_genotype= optarg;
-                break;
-            case 'h':
-            default:
-                printHelp();
-                exit(0);
+    while (true) {
+        int c = getopt_long(argc, argv, "fd:h", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'f':
+            args.fill_missing = true;
+            break;
+        case 'd':
+            args.default_genotype = optarg;
+            break;
+        case 'h':
+        default:
+            printHelp();
+            exit(0);
         }
     }
 
     // The remainder arguments are input files
     // if none => read from stdin
-    while(optind < argc) {
+    while (optind < argc) {
         args.input_files.push_back(argv[optind++]);
     }
 
@@ -91,82 +92,80 @@ bool parseArguments(int argc, char* argv[], Arguments& args) {
  *
  * If fill_missing is true, we replace missing genotypes with args.default_genotype in the GT field.
  */
-static bool processVCF(std::istream& in,
-                       std::ostream& out,
-                       bool fillMissing,
-                       const std::string &defaultGT)
-{
+static bool processVCF(std::istream &in, std::ostream &out, bool fillMissing, const std::string &defaultGT) {
     std::string line;
-    bool header_found=false;
+    bool header_found = false;
 
-    while(std::getline(in, line)) {
-        if(line.empty()) {
+    while (std::getline(in, line)) {
+        if (line.empty()) {
             out << "\n";
             continue;
         }
-        if(line[0]=='#') {
+        if (line[0] == '#') {
             out << line << "\n";
-            if(line.rfind("#CHROM",0)==0) {
-                header_found= true;
+            if (line.rfind("#CHROM", 0) == 0) {
+                header_found = true;
             }
             continue;
         }
-        if(!header_found) {
+        if (!header_found) {
             std::cerr << "Error: VCF data line encountered before #CHROM header.\n";
             // could continue or skip
             // we'll just continue
         }
 
         // parse columns
-        auto fields= splitString(line, '\t');
-        if(fields.size()<9) {
+        auto fields = splitString(line, '\t');
+        if (fields.size() < 9) {
             // invalid => pass as is
             out << line << "\n";
             continue;
         }
         // the 9th col => format
-        std::string &format= fields[8];
-        auto fmtParts= splitString(format, ':');
-        int gtIndex= -1;
-        for(size_t i=0; i<fmtParts.size(); i++){
-            if(fmtParts[i]=="GT") {
-                gtIndex= i;
+        std::string &format = fields[8];
+        auto fmtParts = splitString(format, ':');
+        int gtIndex = -1;
+        for (size_t i = 0; i < fmtParts.size(); i++) {
+            if (fmtParts[i] == "GT") {
+                gtIndex = i;
                 break;
             }
         }
-        if(gtIndex<0) {
+        if (gtIndex < 0) {
             // no GT => just pass line
             out << line << "\n";
             continue;
         }
         // for each sample => fields[9..]
-        for(size_t s=9; s<fields.size(); s++){
-            auto sampleParts= splitString(fields[s], ':');
-            if(gtIndex>= (int)sampleParts.size()) {
+        for (size_t s = 9; s < fields.size(); s++) {
+            auto sampleParts = splitString(fields[s], ':');
+            if (gtIndex >= (int)sampleParts.size()) {
                 // missing data for that sample => skip
                 continue;
             }
-            std::string &genotype= sampleParts[gtIndex];
-            bool isMissing= false;
-            if(genotype.empty()|| genotype=="."|| genotype=="./."|| genotype==".|.") {
-                isMissing= true;
+            std::string &genotype = sampleParts[gtIndex];
+            bool isMissing = false;
+            if (genotype.empty() || genotype == "." || genotype == "./." || genotype == ".|.") {
+                isMissing = true;
             }
-            if(isMissing && fillMissing) {
-                sampleParts[gtIndex]= defaultGT;
+            if (isMissing && fillMissing) {
+                sampleParts[gtIndex] = defaultGT;
             }
             // rejoin sampleParts
             std::stringstream sampSS;
-            for(size_t sp=0; sp< sampleParts.size(); sp++){
-                if(sp>0) sampSS<<":";
-                sampSS<< sampleParts[sp];
+            for (size_t sp = 0; sp < sampleParts.size(); sp++) {
+                if (sp > 0)
+                    sampSS << ":";
+                sampSS << sampleParts[sp];
             }
-            fields[s]= sampSS.str();
+            fields[s] = sampSS.str();
         }
         // rejoin entire line
         std::stringstream lineSS;
-        for(size_t c=0; c<fields.size(); c++){
-            if(c>0) lineSS<<"\t";
-            lineSS<< fields[c];
+        for (size_t c = 0; c < fields.size(); c++) {
+            if (c > 0)
+                lineSS << "\t";
+            lineSS << fields[c];
         }
         out << lineSS.str() << "\n";
     }
@@ -184,50 +183,50 @@ static bool processVCF(std::istream& in,
  * This function reads from each file in args.input_files, or from stdin if none specified,
  * and writes the processed lines to stdout.
  */
-bool handleMissingDataAll(const Arguments& args) {
-    if(args.input_files.empty()) {
+bool handleMissingDataAll(const Arguments &args) {
+    if (args.input_files.empty()) {
         // read from stdin
         return processVCF(std::cin, std::cout, args.fill_missing, args.default_genotype);
     } else {
         // handle multiple files in sequence => we simply process each one, writing to stdout
-        bool firstFile= true;
-        for(size_t i=0; i<args.input_files.size(); i++){
-            std::string &path= (std::string &)args.input_files[i];
+        bool firstFile = true;
+        for (size_t i = 0; i < args.input_files.size(); i++) {
+            std::string &path = (std::string &)args.input_files[i];
             std::ifstream fin(path);
-            if(!fin.is_open()) {
-                std::cerr<<"Error: cannot open file "<< path << "\n";
-                return false; 
+            if (!fin.is_open()) {
+                std::cerr << "Error: cannot open file " << path << "\n";
+                return false;
             }
-            if(!firstFile) {
+            if (!firstFile) {
                 // skip printing the #CHROM header again?
                 // a naive approach: we do a small trick:
                 // read lines until #CHROM => skip them, then pass the rest
                 // or we can pass everything => leads to repeated headers
-                bool foundChrom= false;
+                bool foundChrom = false;
                 std::string line;
-                while(std::getline(fin, line)) {
-                    if(line.rfind("#CHROM",0)==0) {
+                while (std::getline(fin, line)) {
+                    if (line.rfind("#CHROM", 0) == 0) {
                         // we've found #CHROM => use processVCF for the remainder
                         // but we already read one line, so let's put it back in the stream => complicated
                         // simpler approach: we do a manual approach
                         // We'll treat that #CHROM line as data for processVCF => but that might produce error
                         // We'll do: skip header lines
                         break;
-                    } else if(line.empty()) {
+                    } else if (line.empty()) {
                         // skip
-                    } else if(line[0]=='#') {
+                    } else if (line[0] == '#') {
                         // skip
                     } else {
                         // we found data => put it back => complicated
                         // We'll store it in a buffer
                         std::stringstream buffer;
-                        buffer<< line << "\n";
+                        buffer << line << "\n";
                         // now process the rest
                         // reinsert?
                         // We'll do an approach: we store lines in an in-memory stream
                         std::string nextLine;
-                        while(std::getline(fin,nextLine)) {
-                            buffer<< nextLine<<"\n";
+                        while (std::getline(fin, nextLine)) {
+                            buffer << nextLine << "\n";
                         }
                         // now buffer holds the entire
                         // pass buffer to processVCF
@@ -239,13 +238,13 @@ bool handleMissingDataAll(const Arguments& args) {
                 }
                 // now we pass the rest
                 processVCF(fin, std::cout, args.fill_missing, args.default_genotype);
-nextFile:
+            nextFile:
                 fin.close();
             } else {
                 // first file => pass everything
                 processVCF(fin, std::cout, args.fill_missing, args.default_genotype);
                 fin.close();
-                firstFile= false;
+                firstFile = false;
             }
         }
     }
@@ -261,16 +260,15 @@ nextFile:
  */
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_missing_data_handler", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_missing_data_handler", show_help))
+        return 0;
     Arguments args;
     parseArguments(argc, argv, args);
 
     if (args.fill_missing) {
-        std::cerr << "Info: Missing genotypes will be imputed with genotype: "
-                  << args.default_genotype << "\n";
-    }
-    else {
+        std::cerr << "Info: Missing genotypes will be imputed with genotype: " << args.default_genotype << "\n";
+    } else {
         std::cerr << "Info: Missing genotypes will be left flagged.\n";
     }
 

--- a/src/VCFX_missing_data_handler/VCFX_missing_data_handler.h
+++ b/src/VCFX_missing_data_handler/VCFX_missing_data_handler.h
@@ -9,9 +9,9 @@
  * @brief Structure to hold command-line arguments for the missing data handler tool.
  */
 struct Arguments {
-    bool fill_missing = false;               ///< Flag indicating whether to impute missing genotypes.
-    std::string default_genotype = "./.";    ///< Default genotype to use for imputation.
-    std::vector<std::string> input_files;    ///< List of input VCF files. If empty, read from stdin.
+    bool fill_missing = false;            ///< Flag indicating whether to impute missing genotypes.
+    std::string default_genotype = "./."; ///< Default genotype to use for imputation.
+    std::vector<std::string> input_files; ///< List of input VCF files. If empty, read from stdin.
 };
 
 /**
@@ -27,7 +27,7 @@ void printHelp();
  * @param args Reference to Arguments structure to populate.
  * @return true if parsing is successful, false otherwise.
  */
-bool parseArguments(int argc, char* argv[], Arguments& args);
+bool parseArguments(int argc, char *argv[], Arguments &args);
 
 /**
  * @brief Splits a string by a given delimiter.
@@ -36,7 +36,7 @@ bool parseArguments(int argc, char* argv[], Arguments& args);
  * @param delimiter The character delimiter.
  * @return A vector of split substrings.
  */
-std::vector<std::string> splitString(const std::string& str, char delimiter);
+std::vector<std::string> splitString(const std::string &str, char delimiter);
 
 /**
  * @brief Processes the VCF file(s) to handle missing genotype data,
@@ -48,6 +48,6 @@ std::vector<std::string> splitString(const std::string& str, char delimiter);
  * This function reads from each file in args.input_files, or from stdin if none specified,
  * and writes the processed lines to stdout.
  */
-bool handleMissingDataAll(const Arguments& args);
+bool handleMissingDataAll(const Arguments &args);
 
 #endif // VCFX_MISSING_DATA_HANDLER_H

--- a/src/VCFX_missing_detector/VCFX_missing_detector.cpp
+++ b/src/VCFX_missing_detector/VCFX_missing_detector.cpp
@@ -1,32 +1,29 @@
-#include "vcfx_core.h"
 #include "VCFX_missing_detector.h"
-#include <getopt.h>
-#include <sstream>
-#include <iostream>
-#include <vector>
-#include <string>
+#include "vcfx_core.h"
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 /**
  * @brief Main logic runner
  */
-int VCFXMissingDetector::run(int argc, char* argv[]) {
+int VCFXMissingDetector::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
 
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},
-        {0,      0,           0,  0 }
-    };
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "h", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -59,49 +56,53 @@ void VCFXMissingDetector::displayHelp() {
 
 /**
  * @brief Helper function to check if a genotype string has missing data
- * 
+ *
  * We consider a genotype missing if:
  *   - The entire string is '.' or './.' or '.|.'
  *   - Either allele is '.' => e.g. '0/.', './1'
  */
 static bool genotypeIsMissing(const std::string &gt_field) {
-    if(gt_field.empty()) return true;
-    
+    if (gt_field.empty())
+        return true;
+
     // Extract just the genotype part (before the first colon)
     std::string gt = gt_field;
     size_t colon_pos = gt_field.find(':');
-    if(colon_pos != std::string::npos) {
+    if (colon_pos != std::string::npos) {
         gt = gt_field.substr(0, colon_pos);
     }
-    
-    if(gt=="." || gt=="./." || gt==".|.") return true;
-    
+
+    if (gt == "." || gt == "./." || gt == ".|.")
+        return true;
+
     // also check partial => find slash or pipe
     std::string tmp(gt);
-    for(char &c: tmp) {
-        if(c=='|') c='/';
+    for (char &c : tmp) {
+        if (c == '|')
+            c = '/';
     }
-    auto delim= tmp.find('/');
-    if(delim==std::string::npos) {
+    auto delim = tmp.find('/');
+    if (delim == std::string::npos) {
         return false; // not diploid => we do not handle
     }
-    std::string a1= tmp.substr(0, delim);
-    std::string a2= tmp.substr(delim+1);
-    if(a1=="." || a2=="." ) {
+    std::string a1 = tmp.substr(0, delim);
+    std::string a2 = tmp.substr(delim + 1);
+    if (a1 == "." || a2 == ".") {
         return true;
     }
     return false;
 }
 
 /**
- * @brief The main function to detect missing genotypes. 
+ * @brief The main function to detect missing genotypes.
  *        If any sample genotype is missing, we append 'MISSING_GENOTYPES=1' to the INFO field.
  */
-void VCFXMissingDetector::detectMissingGenotypes(std::istream& in, std::ostream& out) {
+void VCFXMissingDetector::detectMissingGenotypes(std::istream &in, std::ostream &out) {
     std::string line;
     while (true) {
-        if(!std::getline(in, line)) break;
-        if(line.empty()) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
             out << "\n";
             continue;
         }
@@ -117,11 +118,11 @@ void VCFXMissingDetector::detectMissingGenotypes(std::istream& in, std::ostream&
         std::vector<std::string> fields;
         {
             std::string token;
-            while(std::getline(ss, token, '\t')) {
+            while (std::getline(ss, token, '\t')) {
                 fields.push_back(token);
             }
         }
-        if(fields.size()<9) {
+        if (fields.size() < 9) {
             // not a valid data line => just pass
             out << line << "\n";
             continue;
@@ -145,9 +146,9 @@ void VCFXMissingDetector::detectMissingGenotypes(std::istream& in, std::ostream&
 
         // gather sample columns from index=9 onward
         bool hasMissing = false;
-        for(size_t s=9; s<fields.size(); s++) {
+        for (size_t s = 9; s < fields.size(); s++) {
             std::string sample_value = fields[s];
-            
+
             // If GT is the only FORMAT field, use the entire sample value
             // Otherwise, extract just the GT part based on its index
             std::string gt;
@@ -168,50 +169,58 @@ void VCFXMissingDetector::detectMissingGenotypes(std::istream& in, std::ostream&
                 // No GT field found, can't determine if missing
                 continue;
             }
-            
-            if(genotypeIsMissing(gt)) {
+
+            if (genotypeIsMissing(gt)) {
                 hasMissing = true;
                 break;
             }
         }
 
-        if(!hasMissing) {
+        if (!hasMissing) {
             // no missing => output as is
             out << line << "\n";
             continue;
         }
 
         // We do have missing => we append MISSING_GENOTYPES=1 to the INFO field
-        std::string &info= fields[7];
+        std::string &info = fields[7];
         // If info is empty => info=="."
-        // some lines might do "info==."" or info== "..." 
+        // some lines might do "info==."" or info== "..."
         // if info=="." => we replace with "MISSING_GENOTYPES=1"
-        if(info=="." || info.empty()) {
-            info= "MISSING_GENOTYPES=1";
+        if (info == "." || info.empty()) {
+            info = "MISSING_GENOTYPES=1";
         } else {
             // ensure we have a semicolon if not already
-            if(!info.empty() && info.back()!=';') {
+            if (!info.empty() && info.back() != ';') {
                 info.push_back(';');
             }
-            info+= "MISSING_GENOTYPES=1";
+            info += "MISSING_GENOTYPES=1";
         }
 
         // rejoin
         // we produce the entire line
         // fields[0..8], then sample columns
         std::stringstream outLine;
-        for(size_t i=0; i<fields.size(); i++){
-            if(i>0) outLine<<"\t";
-            outLine<< fields[i];
+        for (size_t i = 0; i < fields.size(); i++) {
+            if (i > 0)
+                outLine << "\t";
+            outLine << fields[i];
         }
         out << outLine.str() << "\n";
     }
 }
 
-static void show_help() { VCFXMissingDetector obj; char arg0[] = "VCFX_missing_detector"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXMissingDetector obj;
+    char arg0[] = "VCFX_missing_detector";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_missing_detector", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_missing_detector", show_help))
+        return 0;
     VCFXMissingDetector missingDetector;
     return missingDetector.run(argc, argv);
 }

--- a/src/VCFX_missing_detector/VCFX_missing_detector.h
+++ b/src/VCFX_missing_detector/VCFX_missing_detector.h
@@ -10,13 +10,13 @@
  * and flag them in the INFO field with MISSING_GENOTYPES=1
  */
 class VCFXMissingDetector {
-public:
+  public:
     /**
      * Entry point for the tool
      */
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     /**
      * Displays the help message
      */
@@ -25,7 +25,7 @@ private:
     /**
      * Detects missing genotypes in VCF input from 'in', writes flagged lines to 'out'
      */
-    void detectMissingGenotypes(std::istream& in, std::ostream& out);
+    void detectMissingGenotypes(std::istream &in, std::ostream &out);
 };
 
 #endif // VCFX_MISSING_DETECTOR_H

--- a/src/VCFX_multiallelic_splitter/VCFX_multiallelic_splitter.cpp
+++ b/src/VCFX_multiallelic_splitter/VCFX_multiallelic_splitter.cpp
@@ -1,288 +1,367 @@
-#include "vcfx_core.h"
 #include "VCFX_multiallelic_splitter.h"
+#include "vcfx_core.h"
+#include <cctype>
+#include <cstdlib>
+#include <iostream>
 #include <sstream>
-#include <vector>
 #include <string>
 #include <unordered_map>
-#include <iostream>
-#include <cstdlib>
-#include <cctype>
+#include <vector>
 
 static std::vector<std::string> split(const std::string &s, char d) {
-    std::vector<std::string> v; 
-    std::stringstream ss(s); 
+    std::vector<std::string> v;
+    std::stringstream ss(s);
     std::string t;
-    while (std::getline(ss,t,d)) v.push_back(t);
+    while (std::getline(ss, t, d))
+        v.push_back(t);
     return v;
 }
 
 static bool parseNumberEq(const std::string &line, std::string &id, std::string &num) {
     auto i = line.find("ID=");
-    if(i==std::string::npos) return false;
-    auto sub=line.substr(i+3);
-    auto e=sub.find_first_of(",>");
-    if(e==std::string::npos) return false;
-    id=sub.substr(0,e);
-    auto n=line.find("Number=");
-    if(n==std::string::npos) return false;
-    auto sub2=line.substr(n+7);
-    auto e2=sub2.find_first_of(",>");
-    if(e2==std::string::npos) return false;
-    num=sub2.substr(0,e2);
+    if (i == std::string::npos)
+        return false;
+    auto sub = line.substr(i + 3);
+    auto e = sub.find_first_of(",>");
+    if (e == std::string::npos)
+        return false;
+    id = sub.substr(0, e);
+    auto n = line.find("Number=");
+    if (n == std::string::npos)
+        return false;
+    auto sub2 = line.substr(n + 7);
+    auto e2 = sub2.find_first_of(",>");
+    if (e2 == std::string::npos)
+        return false;
+    num = sub2.substr(0, e2);
     return true;
 }
 
 static void parseHeaderLine(const std::string &line, VCFHeaderInfo &hdr) {
-    if(line.rfind("##INFO=",0)==0) {
-        std::string id,num; 
-        if(!parseNumberEq(line,id,num)) return; 
-        SubfieldMeta m; 
-        m.isInfo=true; 
-        m.id=id; 
-        m.number=num; 
-        hdr.meta[id]=m;
-    } 
-    else if(line.rfind("##FORMAT=",0)==0) {
-        std::string id,num; 
-        if(!parseNumberEq(line,id,num)) return; 
-        SubfieldMeta m; 
-        m.isFormat=true; 
-        m.id=id; 
-        m.number=num; 
-        hdr.meta[id]=m;
+    if (line.rfind("##INFO=", 0) == 0) {
+        std::string id, num;
+        if (!parseNumberEq(line, id, num))
+            return;
+        SubfieldMeta m;
+        m.isInfo = true;
+        m.id = id;
+        m.number = num;
+        hdr.meta[id] = m;
+    } else if (line.rfind("##FORMAT=", 0) == 0) {
+        std::string id, num;
+        if (!parseNumberEq(line, id, num))
+            return;
+        SubfieldMeta m;
+        m.isFormat = true;
+        m.id = id;
+        m.number = num;
+        hdr.meta[id] = m;
     }
 }
 
 void printHelp() {
-    std::cout <<
-"VCFX_multiallelic_splitter:\n"
-"  Splits multi-allelic variants into multiple lines, rewriting GT/AD/PL.\n"
-"Usage:\n"
-"  VCFX_multiallelic_splitter [options] < input.vcf > output.vcf\n"
-"  --help, -h\n";
+    std::cout << "VCFX_multiallelic_splitter:\n"
+                 "  Splits multi-allelic variants into multiple lines, rewriting GT/AD/PL.\n"
+                 "Usage:\n"
+                 "  VCFX_multiallelic_splitter [options] < input.vcf > output.vcf\n"
+                 "  --help, -h\n";
 }
 
 static bool parseVariantLine(const std::string &line, VCFVariant &var) {
-    if(line.empty() || line[0]=='#') return false;
+    if (line.empty() || line[0] == '#')
+        return false;
     auto f = split(line, '\t');
-    if(f.size()<9) return false;
-    var.chrom=f[0];
-    try { var.pos= std::stoi(f[1]); }catch(...){return false;}
-    var.id= f[2];
-    var.ref= f[3];
+    if (f.size() < 9)
+        return false;
+    var.chrom = f[0];
+    try {
+        var.pos = std::stoi(f[1]);
+    } catch (...) {
+        return false;
+    }
+    var.id = f[2];
+    var.ref = f[3];
     {
         var.alt.clear();
-        auto al= split(f[4], ',');
-        for(auto &x: al) var.alt.push_back(x);
+        auto al = split(f[4], ',');
+        for (auto &x : al)
+            var.alt.push_back(x);
     }
-    var.qual= f[5];
-    var.filter= f[6];
-    var.info= f[7];
-    var.formatStr= f[8];
+    var.qual = f[5];
+    var.filter = f[6];
+    var.info = f[7];
+    var.formatStr = f[8];
     var.samples.clear();
-    for(size_t i=9;i<f.size();i++){
+    for (size_t i = 9; i < f.size(); i++) {
         var.samples.push_back(f[i]);
     }
     return true;
 }
 
 static std::vector<std::string> splitInfo(const std::string &inf) {
-    if(inf=="."||inf.empty()) return {};
-    auto seg= split(inf,';');
+    if (inf == "." || inf.empty())
+        return {};
+    auto seg = split(inf, ';');
     std::vector<std::string> ret;
-    for(auto &x: seg) {
-        if(!x.empty()) ret.push_back(x);
+    for (auto &x : seg) {
+        if (!x.empty())
+            ret.push_back(x);
     }
     return ret;
 }
 
 static std::string join(const std::vector<std::string> &v, const std::string &d) {
-    if(v.empty()) return ".";
+    if (v.empty())
+        return ".";
     std::ostringstream o;
-    for(size_t i=0;i<v.size();i++){
-        if(i>0) o<<d;
-        o<<v[i];
+    for (size_t i = 0; i < v.size(); i++) {
+        if (i > 0)
+            o << d;
+        o << v[i];
     }
     return o.str();
 }
 
 static bool isInteger(const std::string &s) {
-    for(char c: s) if(!std::isdigit((unsigned char)c) && c!='-') return false;
+    for (char c : s)
+        if (!std::isdigit((unsigned char)c) && c != '-')
+            return false;
     return !s.empty();
 }
 
 static std::vector<std::string> recA(const std::vector<std::string> &vals, int altIx) {
-    if((size_t)altIx >= vals.size()) return {"."};
-    return { vals[altIx] };
+    if ((size_t)altIx >= vals.size())
+        return {"."};
+    return {vals[altIx]};
 }
 
 static std::vector<std::string> recR(const std::vector<std::string> &vals, int altIx) {
-    if(vals.empty()) return {"."};
-    if((size_t)altIx >= vals.size()) return { vals[0], "."};
-    return { vals[0], vals[altIx]};
+    if (vals.empty())
+        return {"."};
+    if ((size_t)altIx >= vals.size())
+        return {vals[0], "."};
+    return {vals[0], vals[altIx]};
 }
 
 static std::vector<std::string> recG(const std::vector<std::string> &vals, int altIx, int nAlts) {
-    if(vals.size()!= (size_t)((nAlts+1)*(nAlts+2)/2)) return {"."};
-    auto idxOf=[&](int a,int b) {
-        return ((2*nAlts+1-a)*a)/2 + (b-a);
-    };
-    int i00=idxOf(0,0), i01= idxOf(0,altIx), i11= idxOf(altIx, altIx);
-    if(i00<0||i01<0||i11<0) return {"."};
-    if(i00>=(int)vals.size()|| i01>=(int)vals.size()|| i11>=(int)vals.size()) return {"."};
-    return { vals[i00], vals[i01], vals[i11] };
+    if (vals.size() != (size_t)((nAlts + 1) * (nAlts + 2) / 2))
+        return {"."};
+    auto idxOf = [&](int a, int b) { return ((2 * nAlts + 1 - a) * a) / 2 + (b - a); };
+    int i00 = idxOf(0, 0), i01 = idxOf(0, altIx), i11 = idxOf(altIx, altIx);
+    if (i00 < 0 || i01 < 0 || i11 < 0)
+        return {"."};
+    if (i00 >= (int)vals.size() || i01 >= (int)vals.size() || i11 >= (int)vals.size())
+        return {"."};
+    return {vals[i00], vals[i01], vals[i11]};
 }
 
 static std::string recodeINFO(const std::string &info, int altIx, int nAlts, const VCFHeaderInfo &hdr) {
-    auto items= splitInfo(info);
-    if(items.empty()) return info;
+    auto items = splitInfo(info);
+    if (items.empty())
+        return info;
     std::vector<std::string> out;
-    for(auto &item: items) {
-        auto eq= item.find('=');
-        if(eq==std::string::npos) { out.push_back(item); continue; }
-        auto key= item.substr(0,eq);
-        auto val= item.substr(eq+1);
-        auto it= hdr.meta.find(key);
-        if(it== hdr.meta.end() || !it->second.isInfo) {
+    for (auto &item : items) {
+        auto eq = item.find('=');
+        if (eq == std::string::npos) {
             out.push_back(item);
             continue;
         }
-        auto arr= split(val,',');
-        auto &num= it->second.number;
-        if(num=="A"){
-            auto x= recA(arr, altIx);
-            if(x.size()==1&& x[0]==".") out.push_back(key+"=.");
-            else out.push_back(key+"="+ join(x,","));
-        } else if(num=="R"){
-            auto x= recR(arr, altIx+1);
-            if(x.size()==2 && x[0]=="." && x[1]=="." ) out.push_back(key+"=.");
-            else out.push_back(key+"="+ join(x,","));
-        } else if(num=="G"){
-            auto x= recG(arr, altIx+1, nAlts);
-            if(x.size()==1 && x[0]=="." ) out.push_back(key+"=.");
-            else out.push_back(key+"="+ join(x,","));
-        } else if(num=="1"){
+        auto key = item.substr(0, eq);
+        auto val = item.substr(eq + 1);
+        auto it = hdr.meta.find(key);
+        if (it == hdr.meta.end() || !it->second.isInfo) {
             out.push_back(item);
-        } else if(num=="."|| isInteger(num)){
+            continue;
+        }
+        auto arr = split(val, ',');
+        auto &num = it->second.number;
+        if (num == "A") {
+            auto x = recA(arr, altIx);
+            if (x.size() == 1 && x[0] == ".")
+                out.push_back(key + "=.");
+            else
+                out.push_back(key + "=" + join(x, ","));
+        } else if (num == "R") {
+            auto x = recR(arr, altIx + 1);
+            if (x.size() == 2 && x[0] == "." && x[1] == ".")
+                out.push_back(key + "=.");
+            else
+                out.push_back(key + "=" + join(x, ","));
+        } else if (num == "G") {
+            auto x = recG(arr, altIx + 1, nAlts);
+            if (x.size() == 1 && x[0] == ".")
+                out.push_back(key + "=.");
+            else
+                out.push_back(key + "=" + join(x, ","));
+        } else if (num == "1") {
             out.push_back(item);
-        } else{
+        } else if (num == "." || isInteger(num)) {
+            out.push_back(item);
+        } else {
             out.push_back(item);
         }
     }
-    if(out.empty()) return ".";
+    if (out.empty())
+        return ".";
     std::ostringstream oss;
-    for(size_t i=0;i<out.size();i++){
-        if(i>0) oss<<";";
-        oss<< out[i];
+    for (size_t i = 0; i < out.size(); i++) {
+        if (i > 0)
+            oss << ";";
+        oss << out[i];
     }
     return oss.str();
 }
 
-static std::vector<std::string> recField(const std::vector<std::string> &vals, int altIx,int nAlts,const std::string &key,const VCFHeaderInfo &hdr) {
-    auto it= hdr.meta.find(key);
-    if(it== hdr.meta.end() || !it->second.isFormat) return vals;
-    auto &num= it->second.number;
-    if(num=="A"){
-        auto x= recA(vals, altIx-1);
-        if(x.size()==1 && x[0]==".") return { "."};
+static std::vector<std::string> recField(const std::vector<std::string> &vals, int altIx, int nAlts,
+                                         const std::string &key, const VCFHeaderInfo &hdr) {
+    auto it = hdr.meta.find(key);
+    if (it == hdr.meta.end() || !it->second.isFormat)
+        return vals;
+    auto &num = it->second.number;
+    if (num == "A") {
+        auto x = recA(vals, altIx - 1);
+        if (x.size() == 1 && x[0] == ".")
+            return {"."};
         return x;
-    } else if(num=="R"){
-        auto x= recR(vals, altIx);
-        if(x.size()==2 && x[0]=="."&& x[1]=="." ) return {"."};
+    } else if (num == "R") {
+        auto x = recR(vals, altIx);
+        if (x.size() == 2 && x[0] == "." && x[1] == ".")
+            return {"."};
         return x;
-    } else if(num=="G"){
-        auto x= recG(vals, altIx, nAlts);
-        if(x.size()==1 && x[0]=="." ) return {"."};
+    } else if (num == "G") {
+        auto x = recG(vals, altIx, nAlts);
+        if (x.size() == 1 && x[0] == ".")
+            return {"."};
         return x;
     }
     return vals;
 }
 
-static std::string recSample(const std::string &sample, const std::vector<std::string> &fmtKeys, int altIx, int nAlts, const VCFHeaderInfo &hdr) {
-    auto subs= split(sample,':');
-    if(subs.size()< fmtKeys.size()) subs.resize(fmtKeys.size(), ".");
-    for(size_t i=0;i<fmtKeys.size();i++){
-        if(i>= subs.size()) break;
-        auto &k= fmtKeys[i];
-        if(k=="GT"){
-            std::string g= subs[i];
-            for(auto &c:g) if(c=='|') c='/';
-            auto d= g.find('/');
-            if(d==std::string::npos){ subs[i]="."; continue;}
-            auto a1= g.substr(0,d), a2= g.substr(d+1);
-            auto conv=[&](const std::string &x){
-                if(x=="0") return "0";
-                if(x== std::to_string(altIx)) return "1";
+static std::string recSample(const std::string &sample, const std::vector<std::string> &fmtKeys, int altIx, int nAlts,
+                             const VCFHeaderInfo &hdr) {
+    auto subs = split(sample, ':');
+    if (subs.size() < fmtKeys.size())
+        subs.resize(fmtKeys.size(), ".");
+    for (size_t i = 0; i < fmtKeys.size(); i++) {
+        if (i >= subs.size())
+            break;
+        auto &k = fmtKeys[i];
+        if (k == "GT") {
+            std::string g = subs[i];
+            for (auto &c : g)
+                if (c == '|')
+                    c = '/';
+            auto d = g.find('/');
+            if (d == std::string::npos) {
+                subs[i] = ".";
+                continue;
+            }
+            auto a1 = g.substr(0, d), a2 = g.substr(d + 1);
+            auto conv = [&](const std::string &x) {
+                if (x == "0")
+                    return "0";
+                if (x == std::to_string(altIx))
+                    return "1";
                 return ".";
             };
-            std::string na1= conv(a1), na2= conv(a2);
-            if(na1=="."&& na2==".") subs[i]=".";
-            else subs[i]= na1 + "/" + na2;
+            std::string na1 = conv(a1), na2 = conv(a2);
+            if (na1 == "." && na2 == ".")
+                subs[i] = ".";
+            else
+                subs[i] = na1 + "/" + na2;
         } else {
-            auto arr= split(subs[i], ',');
-            auto newA= recField(arr, altIx, nAlts, k, hdr);
-            if(newA.size()==1 && newA[0]==".") subs[i]=".";
-            else{
-                std::ostringstream o; 
-                for(size_t z=0;z<newA.size();z++){ if(z>0)o<<","; o<<newA[z];}
-                subs[i]= o.str();
+            auto arr = split(subs[i], ',');
+            auto newA = recField(arr, altIx, nAlts, k, hdr);
+            if (newA.size() == 1 && newA[0] == ".")
+                subs[i] = ".";
+            else {
+                std::ostringstream o;
+                for (size_t z = 0; z < newA.size(); z++) {
+                    if (z > 0)
+                        o << ",";
+                    o << newA[z];
+                }
+                subs[i] = o.str();
             }
         }
     }
     std::ostringstream oss;
-    for(size_t i2=0;i2<subs.size();i2++){
-        if(i2>0) oss<<":";
-        oss<< subs[i2];
+    for (size_t i2 = 0; i2 < subs.size(); i2++) {
+        if (i2 > 0)
+            oss << ":";
+        oss << subs[i2];
     }
     return oss.str();
 }
 
-bool splitMultiAllelicVariants(std::istream &in, std::ostream &out){
+bool splitMultiAllelicVariants(std::istream &in, std::ostream &out) {
     VCFHeaderInfo hdr;
-    bool foundChrom= false;
-    while(true){
-        auto p= in.tellg();
-        if(!in.good()) break;
+    bool foundChrom = false;
+    while (true) {
+        auto p = in.tellg();
+        if (!in.good())
+            break;
         std::string line;
-        if(!std::getline(in,line)) break;
-        if(line.empty()){ out<<line<<"\n"; continue;}
-        if(line[0]=='#'){
-            out<< line << "\n";
-            if(line.rfind("##",0)==0) parseHeaderLine(line,hdr);
-            if(line.rfind("#CHROM",0)==0){foundChrom=true; break;}
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
+            continue;
+        }
+        if (line[0] == '#') {
+            out << line << "\n";
+            if (line.rfind("##", 0) == 0)
+                parseHeaderLine(line, hdr);
+            if (line.rfind("#CHROM", 0) == 0) {
+                foundChrom = true;
+                break;
+            }
         } else {
             in.seekg(p);
             break;
         }
     }
-    if(!foundChrom){
-        while(true){
-            std::string l; if(!std::getline(in,l)) break;
-            out<< l <<"\n";
+    if (!foundChrom) {
+        while (true) {
+            std::string l;
+            if (!std::getline(in, l))
+                break;
+            out << l << "\n";
         }
         return true;
     }
-    while(true){
+    while (true) {
         std::string line;
-        if(!std::getline(in,line)) break;
-        if(line.empty()){ out<< line <<"\n"; continue;}
-        if(line[0]=='#'){ out<< line <<"\n"; continue;}
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
+            continue;
+        }
+        if (line[0] == '#') {
+            out << line << "\n";
+            continue;
+        }
         VCFVariant var;
-        if(!parseVariantLine(line, var)){ out<< line <<"\n"; continue;}
-        if(var.alt.size()<=1){ out<< line <<"\n"; continue;}
-        int nAlts= var.alt.size();
-        auto fmtKeys= split(var.formatStr,':');
-        auto rewriteInfo=[&](int altIx){
-            return recodeINFO(var.info, altIx, nAlts, hdr);
-        };
-        for(int a=0;a<nAlts;a++){
+        if (!parseVariantLine(line, var)) {
+            out << line << "\n";
+            continue;
+        }
+        if (var.alt.size() <= 1) {
+            out << line << "\n";
+            continue;
+        }
+        int nAlts = var.alt.size();
+        auto fmtKeys = split(var.formatStr, ':');
+        auto rewriteInfo = [&](int altIx) { return recodeINFO(var.info, altIx, nAlts, hdr); };
+        for (int a = 0; a < nAlts; a++) {
             std::ostringstream row;
-            row<< var.chrom <<"\t"<< var.pos <<"\t"<< var.id <<"\t"<< var.ref <<"\t"<< var.alt[a] <<"\t"
-               << var.qual <<"\t"<< var.filter <<"\t"<< rewriteInfo(a) <<"\t"<< var.formatStr;
-            for(auto &sm: var.samples){
-                row<<"\t"<< recSample(sm, fmtKeys, a+1, nAlts, hdr);
+            row << var.chrom << "\t" << var.pos << "\t" << var.id << "\t" << var.ref << "\t" << var.alt[a] << "\t"
+                << var.qual << "\t" << var.filter << "\t" << rewriteInfo(a) << "\t" << var.formatStr;
+            for (auto &sm : var.samples) {
+                row << "\t" << recSample(sm, fmtKeys, a + 1, nAlts, hdr);
             }
-            out<< row.str() <<"\n";
+            out << row.str() << "\n";
         }
     }
     return true;
@@ -290,11 +369,12 @@ bool splitMultiAllelicVariants(std::istream &in, std::ostream &out){
 
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_multiallelic_splitter", show_help)) return 0;
-    for(int i=1; i< argc; i++){
-        std::string arg= argv[i];
-        if(arg=="--help"|| arg=="-h"){
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_multiallelic_splitter", show_help))
+        return 0;
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
             printHelp();
             return 0;
         }

--- a/src/VCFX_multiallelic_splitter/VCFX_multiallelic_splitter.h
+++ b/src/VCFX_multiallelic_splitter/VCFX_multiallelic_splitter.h
@@ -3,8 +3,8 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 /* Simple structure describing whether an ID is an INFO or FORMAT field, plus its Number field */
 struct SubfieldMeta {

--- a/src/VCFX_nonref_filter/VCFX_nonref_filter.h
+++ b/src/VCFX_nonref_filter/VCFX_nonref_filter.h
@@ -12,16 +12,16 @@
  *   as “not guaranteed hom-ref,” so we keep that variant.
  */
 class VCFXNonRefFilter {
-public:
+  public:
     // main entry point
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // prints usage
     void displayHelp();
 
     // checks the input line-by-line, printing lines that pass the filter
-    void filterNonRef(std::istream& in, std::ostream& out);
+    void filterNonRef(std::istream &in, std::ostream &out);
 
     // parse a sample’s genotype from a field => returns true if definitely hom-ref
     bool isDefinitelyHomRef(const std::string &genotypeField) const;

--- a/src/VCFX_outlier_detector/VCFX_outlier_detector.cpp
+++ b/src/VCFX_outlier_detector/VCFX_outlier_detector.cpp
@@ -1,66 +1,65 @@
-#include "vcfx_core.h"
 #include "VCFX_outlier_detector.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <string>
-#include <vector>
-#include <unordered_map>
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 static void split(const std::string &s, char d, std::vector<std::string> &tokens) {
     tokens.clear();
     std::stringstream ss(s);
     std::string t;
-    while(std::getline(ss,t,d)) {
+    while (std::getline(ss, t, d)) {
         tokens.push_back(t);
     }
 }
 
-int VCFXOutlierDetector::run(int argc, char* argv[]){
-    bool showHelp=false;
-    std::string metric="AF";
-    double threshold= 0.0;
-    bool isVariantMode= true;
+int VCFXOutlierDetector::run(int argc, char *argv[]) {
+    bool showHelp = false;
+    std::string metric = "AF";
+    double threshold = 0.0;
+    bool isVariantMode = true;
 
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"metric", required_argument, 0, 'm'},
-        {"threshold", required_argument, 0, 't'},
-        {"variant", no_argument, 0, 'V'},
-        {"sample", no_argument, 0, 's'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= getopt_long(argc, argv, "hm:t:Vs", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true; 
-                break;
-            case 'm':
-                metric= optarg; 
-                break;
-            case 't':
-                try {
-                    threshold= std::stod(optarg);
-                } catch(...){
-                    std::cerr<< "Error: invalid threshold.\n";
-                    return 1;
-                }
-                break;
-            case 'V':
-                isVariantMode= true;
-                break;
-            case 's':
-                isVariantMode= false;
-                break;
-            default:
-                showHelp=true;
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"metric", required_argument, 0, 'm'},
+                                        {"threshold", required_argument, 0, 't'},
+                                        {"variant", no_argument, 0, 'V'},
+                                        {"sample", no_argument, 0, 's'},
+                                        {0, 0, 0, 0}};
+    while (true) {
+        int c = getopt_long(argc, argv, "hm:t:Vs", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'm':
+            metric = optarg;
+            break;
+        case 't':
+            try {
+                threshold = std::stod(optarg);
+            } catch (...) {
+                std::cerr << "Error: invalid threshold.\n";
+                return 1;
+            }
+            break;
+        case 'V':
+            isVariantMode = true;
+            break;
+        case 's':
+            isVariantMode = false;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp|| threshold<=0.0){
+    if (showHelp || threshold <= 0.0) {
         displayHelp();
         return 0;
     }
@@ -68,42 +67,40 @@ int VCFXOutlierDetector::run(int argc, char* argv[]){
     return 0;
 }
 
-void VCFXOutlierDetector::displayHelp(){
-    std::cout <<
-"VCFX_outlier_detector: Identify outliers among variants or samples based on a numeric metric.\n\n"
-"Usage:\n"
-"  VCFX_outlier_detector --metric <KEY> --threshold <VAL> [--variant|--sample]\n"
-"  < input.vcf > out\n\n"
-"Options:\n"
-"  --help, -h           Print this help.\n"
-"  --metric, -m <KEY>   Name of the metric to use (e.g. AF, DP, GQ...).\n"
-"  --threshold, -t <VAL> Numeric threshold.\n"
-"  --variant, -V        Evaluate each variant's <KEY> in INFO>threshold => print.\n"
-"  --sample, -s         Evaluate sample averages of <KEY> in genotype subfield => print outliers.\n\n"
-"Examples:\n"
-"  1) Outlier variants with AF>0.05:\n"
-"     VCFX_outlier_detector --metric AF --threshold 0.05 --variant < in.vcf > out.txt\n"
-"  2) Outlier samples if average GQ>30:\n"
-"     VCFX_outlier_detector --metric GQ --threshold 30 --sample < in.vcf > sample_outliers.txt\n";
+void VCFXOutlierDetector::displayHelp() {
+    std::cout << "VCFX_outlier_detector: Identify outliers among variants or samples based on a numeric metric.\n\n"
+                 "Usage:\n"
+                 "  VCFX_outlier_detector --metric <KEY> --threshold <VAL> [--variant|--sample]\n"
+                 "  < input.vcf > out\n\n"
+                 "Options:\n"
+                 "  --help, -h           Print this help.\n"
+                 "  --metric, -m <KEY>   Name of the metric to use (e.g. AF, DP, GQ...).\n"
+                 "  --threshold, -t <VAL> Numeric threshold.\n"
+                 "  --variant, -V        Evaluate each variant's <KEY> in INFO>threshold => print.\n"
+                 "  --sample, -s         Evaluate sample averages of <KEY> in genotype subfield => print outliers.\n\n"
+                 "Examples:\n"
+                 "  1) Outlier variants with AF>0.05:\n"
+                 "     VCFX_outlier_detector --metric AF --threshold 0.05 --variant < in.vcf > out.txt\n"
+                 "  2) Outlier samples if average GQ>30:\n"
+                 "     VCFX_outlier_detector --metric GQ --threshold 30 --sample < in.vcf > sample_outliers.txt\n";
 }
 
-bool VCFXOutlierDetector::parseMetricFromInfo(const std::string &info,
-                                              const std::string &key,
-                                              double &val) const
-{
-    if(info.empty()||info=="." ) return false;
+bool VCFXOutlierDetector::parseMetricFromInfo(const std::string &info, const std::string &key, double &val) const {
+    if (info.empty() || info == ".")
+        return false;
     std::stringstream ss(info);
     std::string kv;
-    while(std::getline(ss, kv, ';')) {
-        auto eq= kv.find('=');
-        if(eq==std::string::npos) continue;
-        auto k= kv.substr(0,eq);
-        auto v= kv.substr(eq+1);
-        if(k==key) {
+    while (std::getline(ss, kv, ';')) {
+        auto eq = kv.find('=');
+        if (eq == std::string::npos)
+            continue;
+        auto k = kv.substr(0, eq);
+        auto v = kv.substr(eq + 1);
+        if (k == key) {
             try {
-                val= std::stod(v);
+                val = std::stod(v);
                 return true;
-            } catch(...){
+            } catch (...) {
                 return false;
             }
         }
@@ -111,10 +108,8 @@ bool VCFXOutlierDetector::parseMetricFromInfo(const std::string &info,
     return false;
 }
 
-bool VCFXOutlierDetector::parseMetricFromGenotype(const std::string &genotypeField,
-                                                  const std::string &metric,
-                                                  double &value) const
-{
+bool VCFXOutlierDetector::parseMetricFromGenotype(const std::string &genotypeField, const std::string &metric,
+                                                  double &value) const {
     if (genotypeField.empty() || genotypeField == ".") {
         return false;
     }
@@ -122,16 +117,16 @@ bool VCFXOutlierDetector::parseMetricFromGenotype(const std::string &genotypeFie
     // First, try the equals-sign based approach for non-standard formats
     std::stringstream ss1(genotypeField);
     std::string token;
-    while(std::getline(ss1, token, ':')) {
-        auto eq= token.find('=');
-        if(eq!=std::string::npos) {
-            auto left= token.substr(0,eq);
-            auto right= token.substr(eq+1);
-            if(left== metric) {
+    while (std::getline(ss1, token, ':')) {
+        auto eq = token.find('=');
+        if (eq != std::string::npos) {
+            auto left = token.substr(0, eq);
+            auto right = token.substr(eq + 1);
+            if (left == metric) {
                 try {
-                    value= std::stod(right);
+                    value = std::stod(right);
                     return true;
-                } catch(...) {
+                } catch (...) {
                     return false;
                 }
             }
@@ -142,7 +137,7 @@ bool VCFXOutlierDetector::parseMetricFromGenotype(const std::string &genotypeFie
     // Need to find the corresponding FORMAT field and extract the value at that position
     std::vector<std::string> fieldValues;
     std::stringstream ss2(genotypeField);
-    while(std::getline(ss2, token, ':')) {
+    while (std::getline(ss2, token, ':')) {
         fieldValues.push_back(token);
     }
 
@@ -151,87 +146,97 @@ bool VCFXOutlierDetector::parseMetricFromGenotype(const std::string &genotypeFie
     return false;
 }
 
-void VCFXOutlierDetector::detectOutliers(std::istream &in,
-                                         std::ostream &out,
-                                         const std::string &metric,
-                                         double threshold,
-                                         bool isVariantMode)
-{
-    if(isVariantMode) {
-        out<<"#CHROM\tPOS\tID\t"<<metric<<"\n";
-        bool headerFound=false;
+void VCFXOutlierDetector::detectOutliers(std::istream &in, std::ostream &out, const std::string &metric,
+                                         double threshold, bool isVariantMode) {
+    if (isVariantMode) {
+        out << "#CHROM\tPOS\tID\t" << metric << "\n";
+        bool headerFound = false;
         std::string line;
-        bool anyMetricFound= false;
-        while(true){
-            if(!std::getline(in,line)) break;
-            if(line.empty())continue;
-            if(line[0]=='#'){
-                if(line.rfind("#CHROM",0)==0) headerFound=true;
+        bool anyMetricFound = false;
+        while (true) {
+            if (!std::getline(in, line))
+                break;
+            if (line.empty())
+                continue;
+            if (line[0] == '#') {
+                if (line.rfind("#CHROM", 0) == 0)
+                    headerFound = true;
                 continue;
             }
-            if(!headerFound){
+            if (!headerFound) {
                 // skip or pass, but we can't parse columns
                 continue;
             }
-            std::vector<std::string> fields; {
+            std::vector<std::string> fields;
+            {
                 std::stringstream ss(line);
                 std::string f;
-                while(std::getline(ss,f,'\t')) fields.push_back(f);
+                while (std::getline(ss, f, '\t'))
+                    fields.push_back(f);
             }
-            if(fields.size()<8) continue;
-            std::string &chrom=fields[0];
-            std::string &pos= fields[1];
-            std::string &id= fields[2];
-            std::string &info= fields[7];
-            double val= 0.0;
-            if(parseMetricFromInfo(info, metric, val)) {
-                anyMetricFound= true;
-                if(val> threshold) {
-                    out<< chrom<<"\t"<< pos<<"\t"<< id<<"\t"<< val<<"\n";
+            if (fields.size() < 8)
+                continue;
+            std::string &chrom = fields[0];
+            std::string &pos = fields[1];
+            std::string &id = fields[2];
+            std::string &info = fields[7];
+            double val = 0.0;
+            if (parseMetricFromInfo(info, metric, val)) {
+                anyMetricFound = true;
+                if (val > threshold) {
+                    out << chrom << "\t" << pos << "\t" << id << "\t" << val << "\n";
                 }
             }
         }
-        if(!anyMetricFound) {
-            std::cerr<<"Warning: metric '"<<metric<<"' not found in any INFO field.\n";
+        if (!anyMetricFound) {
+            std::cerr << "Warning: metric '" << metric << "' not found in any INFO field.\n";
         }
     } else {
-        // sample approach: we read entire file, gather sample names => sum metric => count => compute average => compare threshold
-        bool headerFound=false;
+        // sample approach: we read entire file, gather sample names => sum metric => count => compute average =>
+        // compare threshold
+        bool headerFound = false;
         std::vector<std::string> sampleNames;
         std::unordered_map<std::string, double> sums;
         std::unordered_map<std::string, int> counts;
         std::string line;
-        bool anyMetricFound= false;
-        while(true){
-            if(!std::getline(in,line)) break;
-            if(line.empty())continue;
-            if(line[0]=='#'){
-                if(line.rfind("#CHROM",0)==0){
-                    headerFound=true;
-                    std::vector<std::string> f; {
+        bool anyMetricFound = false;
+        while (true) {
+            if (!std::getline(in, line))
+                break;
+            if (line.empty())
+                continue;
+            if (line[0] == '#') {
+                if (line.rfind("#CHROM", 0) == 0) {
+                    headerFound = true;
+                    std::vector<std::string> f;
+                    {
                         std::stringstream ss(line);
                         std::string x;
-                        while(std::getline(ss,x,'\t')) f.push_back(x);
+                        while (std::getline(ss, x, '\t'))
+                            f.push_back(x);
                     }
-                    for(size_t i=9;i<f.size();i++){
+                    for (size_t i = 9; i < f.size(); i++) {
                         sampleNames.push_back(f[i]);
-                        sums[f[i]]=0.0;
-                        counts[f[i]]=0;
+                        sums[f[i]] = 0.0;
+                        counts[f[i]] = 0;
                     }
                 }
                 continue;
             }
-            if(!headerFound) {
+            if (!headerFound) {
                 continue;
             }
-            std::vector<std::string> fields; {
+            std::vector<std::string> fields;
+            {
                 std::stringstream ss(line);
                 std::string fx;
-                while(std::getline(ss, fx, '\t')) fields.push_back(fx);
+                while (std::getline(ss, fx, '\t'))
+                    fields.push_back(fx);
             }
-            if(fields.size()<9) continue;
-            std::string &format= fields[8];
-            
+            if (fields.size() < 9)
+                continue;
+            std::string &format = fields[8];
+
             // Parse the FORMAT field to find the index of our metric
             int metricIndex = -1;
             std::vector<std::string> formatFields;
@@ -239,75 +244,83 @@ void VCFXOutlierDetector::detectOutliers(std::istream &in,
                 std::stringstream fmt(format);
                 std::string token;
                 int idx = 0;
-                while(std::getline(fmt, token, ':')) {
-                    if(token == metric) {
+                while (std::getline(fmt, token, ':')) {
+                    if (token == metric) {
                         metricIndex = idx;
                     }
                     formatFields.push_back(token);
                     idx++;
                 }
             }
-            
+
             // Get sample columns
             std::vector<std::string> sampleColumns;
-            for(size_t i=9;i<fields.size();i++){
+            for (size_t i = 9; i < fields.size(); i++) {
                 sampleColumns.push_back(fields[i]);
             }
-            
+
             // Process each sample
-            for(size_t s=0;s<sampleNames.size() && s<sampleColumns.size();s++){
-                double val=0.0;
+            for (size_t s = 0; s < sampleNames.size() && s < sampleColumns.size(); s++) {
+                double val = 0.0;
                 // First, try parsing with the custom equals-sign based approach
-                if(parseMetricFromGenotype(sampleColumns[s], metric, val)) {
+                if (parseMetricFromGenotype(sampleColumns[s], metric, val)) {
                     sums[sampleNames[s]] += val;
                     counts[sampleNames[s]]++;
                     anyMetricFound = true;
                 }
                 // If that didn't work and we found the metric in FORMAT, try standard approach
-                else if(metricIndex >= 0) {
+                else if (metricIndex >= 0) {
                     std::vector<std::string> sampleValues;
                     std::stringstream sampleStream(sampleColumns[s]);
                     std::string sampleToken;
-                    while(std::getline(sampleStream, sampleToken, ':')) {
+                    while (std::getline(sampleStream, sampleToken, ':')) {
                         sampleValues.push_back(sampleToken);
                     }
-                    
-                    if(metricIndex < (int)sampleValues.size() && sampleValues[metricIndex] != "." && !sampleValues[metricIndex].empty()) {
+
+                    if (metricIndex < (int)sampleValues.size() && sampleValues[metricIndex] != "." &&
+                        !sampleValues[metricIndex].empty()) {
                         try {
                             val = std::stod(sampleValues[metricIndex]);
                             sums[sampleNames[s]] += val;
                             counts[sampleNames[s]]++;
                             anyMetricFound = true;
-                        } catch(...) {
+                        } catch (...) {
                             // Invalid numeric value, skip
                         }
                     }
                 }
             }
         }
-        out<<"#Sample\tAverage_"<< metric <<"\n";
-        for(auto &nm: sampleNames) {
-            if(counts[nm]==0) {
-                out<< nm<<"\tNA\n";
+        out << "#Sample\tAverage_" << metric << "\n";
+        for (auto &nm : sampleNames) {
+            if (counts[nm] == 0) {
+                out << nm << "\tNA\n";
             } else {
-                double avg= sums[nm]/ (double)counts[nm];
-                if(avg> threshold) {
-                    out<< nm<<"\t"<< avg<<"\n";
+                double avg = sums[nm] / (double)counts[nm];
+                if (avg > threshold) {
+                    out << nm << "\t" << avg << "\n";
                 } else {
-                    out<< nm<<"\tNA\n";
+                    out << nm << "\tNA\n";
                 }
             }
         }
-        if(!anyMetricFound) {
-            std::cerr<<"Warning: metric '"<<metric<<"' was not found in any sample genotype.\n";
+        if (!anyMetricFound) {
+            std::cerr << "Warning: metric '" << metric << "' was not found in any sample genotype.\n";
         }
     }
 }
 
-static void show_help() { VCFXOutlierDetector obj; char arg0[] = "VCFX_outlier_detector"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXOutlierDetector obj;
+    char arg0[] = "VCFX_outlier_detector";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_outlier_detector", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_outlier_detector", show_help))
+        return 0;
     VCFXOutlierDetector app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_outlier_detector/VCFX_outlier_detector.h
+++ b/src/VCFX_outlier_detector/VCFX_outlier_detector.h
@@ -3,33 +3,27 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 class VCFXOutlierDetector {
-public:
+  public:
     // Main entry point
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Print usage
     void displayHelp();
 
     // The function that does the reading and analysis
-    void detectOutliers(std::istream &in, std::ostream &out,
-                        const std::string &metric,
-                        double threshold,
+    void detectOutliers(std::istream &in, std::ostream &out, const std::string &metric, double threshold,
                         bool isVariantMode);
 
     // Parse the user-specified metric from INFO
-    bool parseMetricFromInfo(const std::string &info,
-                             const std::string &key,
-                             double &val) const;
+    bool parseMetricFromInfo(const std::string &info, const std::string &key, double &val) const;
 
     // Parse the user-specified metric from genotype subfields
-    bool parseMetricFromGenotype(const std::string &genotypeField,
-                                 const std::string &metric,
-                                 double &value) const;
+    bool parseMetricFromGenotype(const std::string &genotypeField, const std::string &metric, double &value) const;
 };
 
 #endif

--- a/src/VCFX_phase_checker/VCFX_phase_checker.cpp
+++ b/src/VCFX_phase_checker/VCFX_phase_checker.cpp
@@ -1,17 +1,17 @@
-#include "vcfx_core.h"
 #include "VCFX_phase_checker.h"
-#include <getopt.h>
-#include <sstream>
-#include <iostream>
-#include <vector>
-#include <cstdlib>
+#include "vcfx_core.h"
 #include <algorithm>
+#include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 #include <sys/select.h>
 #include <unistd.h>
+#include <vector>
 
-int VCFXPhaseChecker::run(int argc, char* argv[]) {
+int VCFXPhaseChecker::run(int argc, char *argv[]) {
     bool showHelp = false;
-    
+
     // Check if stdin has data available
     struct timeval tv;
     fd_set fds;
@@ -19,27 +19,24 @@ int VCFXPhaseChecker::run(int argc, char* argv[]) {
     tv.tv_usec = 0;
     FD_ZERO(&fds);
     FD_SET(STDIN_FILENO, &fds);
-    bool hasStdinInput = select(STDIN_FILENO+1, &fds, NULL, NULL, &tv) > 0;
-    
+    bool hasStdinInput = select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) > 0;
+
     // If no arguments are provided and no stdin input, display help.
     if (argc == 1 && !hasStdinInput) {
         displayHelp();
         return 0;
     }
-    
+
     int opt;
-    static struct option long_opts[] = {
-        {"help", no_argument, 0, 'h'},
-        {0, 0, 0, 0}
-    };
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
     while ((opt = getopt(argc, argv, "h")) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            default:
-                showHelp = true;
-                break;
+        case 'h':
+            showHelp = true;
+            break;
+        default:
+            showHelp = true;
+            break;
         }
     }
     if (showHelp) {
@@ -51,40 +48,44 @@ int VCFXPhaseChecker::run(int argc, char* argv[]) {
 }
 
 void VCFXPhaseChecker::displayHelp() {
-    std::cout <<
-"VCFX_phase_checker: Output only VCF variant lines in which every sample genotype is fully phased.\n\n"
-"Usage:\n"
-"  ./VCFX_phase_checker [options] < input.vcf > phased_output.vcf\n\n"
-"Options:\n"
-"  -h, --help   Display this help message and exit\n\n"
-"Description:\n"
-"  The tool reads a VCF from standard input and checks the GT field (genotype) for each sample.\n"
-"  A genotype is considered fully phased if it uses the '|' separator (e.g., \"0|1\") and contains\n"
-"  no missing alleles. If every sample in a variant line is fully phased, the line is printed to\n"
-"  standard output; otherwise, it is skipped and a warning is written to standard error.\n\n"
-"Examples:\n"
-"  To extract only fully phased variants:\n"
-"    ./VCFX_phase_checker < input.vcf > phased_output.vcf\n";
+    std::cout << "VCFX_phase_checker: Output only VCF variant lines in which every sample genotype is fully phased.\n\n"
+                 "Usage:\n"
+                 "  ./VCFX_phase_checker [options] < input.vcf > phased_output.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help   Display this help message and exit\n\n"
+                 "Description:\n"
+                 "  The tool reads a VCF from standard input and checks the GT field (genotype) for each sample.\n"
+                 "  A genotype is considered fully phased if it uses the '|' separator (e.g., \"0|1\") and contains\n"
+                 "  no missing alleles. If every sample in a variant line is fully phased, the line is printed to\n"
+                 "  standard output; otherwise, it is skipped and a warning is written to standard error.\n\n"
+                 "Examples:\n"
+                 "  To extract only fully phased variants:\n"
+                 "    ./VCFX_phase_checker < input.vcf > phased_output.vcf\n";
 }
 
 bool VCFXPhaseChecker::isFullyPhased(const std::string &gt) const {
-    if(gt.empty() || gt == "." || gt == "./." || gt == ".|.") return false;
-    
+    if (gt.empty() || gt == "." || gt == "./." || gt == ".|.")
+        return false;
+
     // Haploid genotypes (like "0" or "1") are not considered phased
-    if(gt.find('|') == std::string::npos) return false;
-    
+    if (gt.find('|') == std::string::npos)
+        return false;
+
     // A fully phased genotype should use '|' exclusively.
-    if(gt.find('/') != std::string::npos) return false;
-    
+    if (gt.find('/') != std::string::npos)
+        return false;
+
     std::vector<std::string> alleles;
     std::istringstream ss(gt);
     std::string token;
-    while(std::getline(ss, token, '|')) {
+    while (std::getline(ss, token, '|')) {
         alleles.push_back(token);
     }
-    if(alleles.empty()) return false;
-    for(const auto &al : alleles) {
-        if(al.empty() || al == ".") return false;
+    if (alleles.empty())
+        return false;
+    for (const auto &al : alleles) {
+        if (al.empty() || al == ".")
+            return false;
     }
     return true;
 }
@@ -93,28 +94,28 @@ void VCFXPhaseChecker::processVCF(std::istream &in, std::ostream &out) {
     bool headerFound = false;
     std::string line;
     while (std::getline(in, line)) {
-        if(line.empty()) {
+        if (line.empty()) {
             out << line << "\n";
             continue;
         }
-        if(line[0] == '#') {
+        if (line[0] == '#') {
             out << line << "\n";
-            if(line.rfind("#CHROM", 0) == 0) {
+            if (line.rfind("#CHROM", 0) == 0) {
                 headerFound = true;
             }
             continue;
         }
-        if(!headerFound) {
+        if (!headerFound) {
             std::cerr << "Warning: Data line encountered before #CHROM header; skipping line.\n";
             continue;
         }
         std::vector<std::string> fields;
         std::istringstream ss(line);
         std::string f;
-        while(std::getline(ss, f, '\t')) {
+        while (std::getline(ss, f, '\t')) {
             fields.push_back(f);
         }
-        if(fields.size() < 10) {
+        if (fields.size() < 10) {
             std::cerr << "Warning: Invalid VCF line with fewer than 10 columns; skipping line.\n";
             continue;
         }
@@ -122,7 +123,7 @@ void VCFXPhaseChecker::processVCF(std::istream &in, std::ostream &out) {
         {
             std::istringstream fs(fields[8]);
             std::string token;
-            while(std::getline(fs, token, ':')) {
+            while (std::getline(fs, token, ':')) {
                 fmt.push_back(token);
             }
         }
@@ -142,7 +143,7 @@ void VCFXPhaseChecker::processVCF(std::istream &in, std::ostream &out) {
             std::vector<std::string> sampleFields;
             std::istringstream ssSample(fields[i]);
             std::string sub;
-            while(std::getline(ssSample, sub, ':')) {
+            while (std::getline(ssSample, sub, ':')) {
                 sampleFields.push_back(sub);
             }
             if (gtIndex >= static_cast<int>(sampleFields.size())) {
@@ -158,16 +159,23 @@ void VCFXPhaseChecker::processVCF(std::istream &in, std::ostream &out) {
         if (allPhased) {
             out << line << "\n";
         } else {
-            std::cerr << "Unphased genotype found at CHROM=" << fields[0] 
-                      << ", POS=" << fields[1] << "; line skipped.\n";
+            std::cerr << "Unphased genotype found at CHROM=" << fields[0] << ", POS=" << fields[1]
+                      << "; line skipped.\n";
         }
     }
 }
 
-static void show_help() { VCFXPhaseChecker obj; char arg0[] = "VCFX_phase_checker"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXPhaseChecker obj;
+    char arg0[] = "VCFX_phase_checker";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_phase_checker", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_phase_checker", show_help))
+        return 0;
     VCFXPhaseChecker checker;
     return checker.run(argc, argv);
 }

--- a/src/VCFX_phase_checker/VCFX_phase_checker.h
+++ b/src/VCFX_phase_checker/VCFX_phase_checker.h
@@ -11,13 +11,13 @@
  *   If any sample is unphased (or missing GT), logs a warning and discards line.
  */
 class VCFXPhaseChecker {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
-    // Processes the input line-by-line. 
+    // Processes the input line-by-line.
     // For each data line, if all samples are phased => write to stdout, else skip.
     void processVCF(std::istream &in, std::ostream &out);
 

--- a/src/VCFX_phase_quality_filter/VCFX_phase_quality_filter.cpp
+++ b/src/VCFX_phase_quality_filter/VCFX_phase_quality_filter.cpp
@@ -1,12 +1,12 @@
-#include "vcfx_core.h"
 #include "VCFX_phase_quality_filter.h"
+#include "vcfx_core.h"
+#include <cctype>
+#include <cstdlib>
 #include <getopt.h>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <cstdlib>
-#include <cctype>
 
 static void split(const std::string &s, char delim, std::vector<std::string> &tokens) {
     tokens.clear();
@@ -17,28 +17,26 @@ static void split(const std::string &s, char delim, std::vector<std::string> &to
     }
 }
 
-int VCFXPhaseQualityFilter::run(int argc, char* argv[]) {
+int VCFXPhaseQualityFilter::run(int argc, char *argv[]) {
     bool showHelp = false;
     std::string condition;
 
     static struct option long_opts[] = {
-        {"help",       no_argument,       0, 'h'},
-        {"filter-pq",  required_argument, 0, 'f'},
-        {0,            0,                 0,  0}
-    };
+        {"help", no_argument, 0, 'h'}, {"filter-pq", required_argument, 0, 'f'}, {0, 0, 0, 0}};
 
-    while(true) {
+    while (true) {
         int c = ::getopt_long(argc, argv, "hf:", long_opts, nullptr);
-        if (c == -1) break;
+        if (c == -1)
+            break;
         switch (c) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'f':
-                condition = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'f':
+            condition = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -69,29 +67,26 @@ int VCFXPhaseQualityFilter::run(int argc, char* argv[]) {
 }
 
 void VCFXPhaseQualityFilter::displayHelp() {
-    std::cout
-        << "VCFX_phase_quality_filter: Filter variants by phasing quality (PQ) in the INFO field.\n\n"
-        << "Usage:\n"
-        << "  VCFX_phase_quality_filter --filter-pq \"PQ<OP><THRESHOLD>\" < input.vcf > output.vcf\n\n"
-        << "Options:\n"
-        << "  -h, --help             Print this help message.\n"
-        << "  -f, --filter-pq <COND> Condition like 'PQ>30', 'PQ>=20', 'PQ!=10', etc.\n\n"
-        << "Description:\n"
-        << "  Reads each variant line, extracts 'PQ=' from INFO. If missing or invalid, PQ=0.\n"
-        << "  Keeps lines if 'PQ <OP> THRESHOLD' is true. Otherwise, discards.\n\n"
-        << "Supported operators: >, >=, <, <=, ==, !=\n\n"
-        << "Examples:\n"
-        << "  1) Keep variants with PQ>30:\n"
-        << "     VCFX_phase_quality_filter --filter-pq \"PQ>30\" < in.vcf > out.vcf\n"
-        << "  2) Keep PQ<=15:\n"
-        << "     VCFX_phase_quality_filter --filter-pq \"PQ<=15\" < in.vcf > out.vcf\n";
+    std::cout << "VCFX_phase_quality_filter: Filter variants by phasing quality (PQ) in the INFO field.\n\n"
+              << "Usage:\n"
+              << "  VCFX_phase_quality_filter --filter-pq \"PQ<OP><THRESHOLD>\" < input.vcf > output.vcf\n\n"
+              << "Options:\n"
+              << "  -h, --help             Print this help message.\n"
+              << "  -f, --filter-pq <COND> Condition like 'PQ>30', 'PQ>=20', 'PQ!=10', etc.\n\n"
+              << "Description:\n"
+              << "  Reads each variant line, extracts 'PQ=' from INFO. If missing or invalid, PQ=0.\n"
+              << "  Keeps lines if 'PQ <OP> THRESHOLD' is true. Otherwise, discards.\n\n"
+              << "Supported operators: >, >=, <, <=, ==, !=\n\n"
+              << "Examples:\n"
+              << "  1) Keep variants with PQ>30:\n"
+              << "     VCFX_phase_quality_filter --filter-pq \"PQ>30\" < in.vcf > out.vcf\n"
+              << "  2) Keep PQ<=15:\n"
+              << "     VCFX_phase_quality_filter --filter-pq \"PQ<=15\" < in.vcf > out.vcf\n";
 }
 
-bool VCFXPhaseQualityFilter::parseCondition(const std::string &condition,
-                                            std::string &op,
-                                            double &threshold)
-{
-    if (condition.size() < 3) return false;
+bool VCFXPhaseQualityFilter::parseCondition(const std::string &condition, std::string &op, double &threshold) {
+    if (condition.size() < 3)
+        return false;
     if (condition.rfind("PQ", 0) != 0) {
         return false;
     }
@@ -114,26 +109,24 @@ bool VCFXPhaseQualityFilter::parseCondition(const std::string &condition,
 
     // The remainder is the threshold
     std::string valStr = sub.substr(op.size());
-    if (valStr.empty()) return false;
+    if (valStr.empty())
+        return false;
 
     try {
         threshold = std::stod(valStr);
-    } catch(...) {
+    } catch (...) {
         return false;
     }
     return true;
 }
 
-void VCFXPhaseQualityFilter::filterByPQ(std::istream &in,
-                                        std::ostream &out,
-                                        const std::string &op,
-                                        double threshold)
-{
+void VCFXPhaseQualityFilter::filterByPQ(std::istream &in, std::ostream &out, const std::string &op, double threshold) {
     bool headerFound = false;
     std::string line;
 
     while (true) {
-        if (!std::getline(in, line)) break;
+        if (!std::getline(in, line))
+            break;
         if (line.empty()) {
             out << line << "\n";
             continue;
@@ -168,12 +161,25 @@ void VCFXPhaseQualityFilter::filterByPQ(std::istream &in,
         double pq = parsePQScore(fields[7]);
         bool keep = false;
 
-        if      (op == ">")  { if (pq >  threshold) keep = true; }
-        else if (op == ">=") { if (pq >= threshold) keep = true; }
-        else if (op == "<")  { if (pq <  threshold) keep = true; }
-        else if (op == "<=") { if (pq <= threshold) keep = true; }
-        else if (op == "==") { if (pq == threshold) keep = true; }
-        else if (op == "!=") { if (pq != threshold) keep = true; }
+        if (op == ">") {
+            if (pq > threshold)
+                keep = true;
+        } else if (op == ">=") {
+            if (pq >= threshold)
+                keep = true;
+        } else if (op == "<") {
+            if (pq < threshold)
+                keep = true;
+        } else if (op == "<=") {
+            if (pq <= threshold)
+                keep = true;
+        } else if (op == "==") {
+            if (pq == threshold)
+                keep = true;
+        } else if (op == "!=") {
+            if (pq != threshold)
+                keep = true;
+        }
 
         if (keep) {
             out << line << "\n";
@@ -201,10 +207,17 @@ double VCFXPhaseQualityFilter::parsePQScore(const std::string &info) {
     return 0.0;
 }
 
-static void show_help() { VCFXPhaseQualityFilter obj; char arg0[] = "VCFX_phase_quality_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXPhaseQualityFilter obj;
+    char arg0[] = "VCFX_phase_quality_filter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_phase_quality_filter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_phase_quality_filter", show_help))
+        return 0;
     VCFXPhaseQualityFilter f;
     return f.run(argc, argv);
 }

--- a/src/VCFX_phase_quality_filter/VCFX_phase_quality_filter.h
+++ b/src/VCFX_phase_quality_filter/VCFX_phase_quality_filter.h
@@ -5,21 +5,19 @@
 #include <string>
 
 class VCFXPhaseQualityFilter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
     // Takes the final operator (>, >=, <, <=, ==, !=) plus threshold, filters lines
-    void filterByPQ(std::istream &in, std::ostream &out,
-                    const std::string &op, double threshold);
+    void filterByPQ(std::istream &in, std::ostream &out, const std::string &op, double threshold);
 
     // Extracts the "PQ=" value from INFO or returns 0.0 if missing or invalid
     double parsePQScore(const std::string &info);
 
     // Internal helper to parse the condition string, e.g. "PQ>=30" => op=">=", thr=30
-    bool parseCondition(const std::string &condition,
-                        std::string &op, double &threshold);
+    bool parseCondition(const std::string &condition, std::string &op, double &threshold);
 };
 
 #endif // VCFX_PHASE_QUALITY_FILTER_H

--- a/src/VCFX_phred_filter/VCFX_phred_filter.cpp
+++ b/src/VCFX_phred_filter/VCFX_phred_filter.cpp
@@ -1,46 +1,46 @@
-#include "vcfx_core.h"
 #include "VCFX_phred_filter.h"
+#include "vcfx_core.h"
+#include <cstdlib>
 #include <getopt.h>
 #include <iostream>
 #include <sstream>
-#include <vector>
 #include <string>
-#include <cstdlib>
+#include <vector>
 
-int VCFXPhredFilter::run(int argc, char* argv[]){
-    if(argc==1) {
+int VCFXPhredFilter::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    double threshold= 30.0;
-    bool showHelp=false;
-    bool keepMissingAsPass= false;
-    static struct option long_opts[]={
-        {"phred-filter", required_argument, 0, 'p'},
-        {"keep-missing-qual", no_argument, 0, 'k'},
-        {"help", no_argument, 0, 'h'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv, "p:kh", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'p': {
-                try { threshold= std::stod(optarg); }
-                catch(...){
-                    std::cerr<<"Error: Invalid threshold '"<< optarg<<"'.\n";
-                    return 1;
-                }
-            }break;
-            case 'k':
-                keepMissingAsPass= true;
-                break;
-            case 'h':
-            default:
-                showHelp=true;
+    double threshold = 30.0;
+    bool showHelp = false;
+    bool keepMissingAsPass = false;
+    static struct option long_opts[] = {{"phred-filter", required_argument, 0, 'p'},
+                                        {"keep-missing-qual", no_argument, 0, 'k'},
+                                        {"help", no_argument, 0, 'h'},
+                                        {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "p:kh", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'p': {
+            try {
+                threshold = std::stod(optarg);
+            } catch (...) {
+                std::cerr << "Error: Invalid threshold '" << optarg << "'.\n";
+                return 1;
+            }
+        } break;
+        case 'k':
+            keepMissingAsPass = true;
+            break;
+        case 'h':
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
@@ -48,81 +48,91 @@ int VCFXPhredFilter::run(int argc, char* argv[]){
     return 0;
 }
 
-void VCFXPhredFilter::displayHelp(){
-    std::cout <<
-"VCFX_phred_filter: Filter VCF lines by their QUAL field.\n\n"
-"Usage:\n"
-"  VCFX_phred_filter [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -p, --phred-filter <VAL>      Phred QUAL threshold (default=30)\n"
-"  -k, --keep-missing-qual       Treat '.' (missing QUAL) as pass\n"
-"  -h, --help                    Display this help and exit\n\n"
-"Description:\n"
-"  Reads VCF lines from stdin. For each data line, parse the QUAL field.\n"
-"  If QUAL >= threshold => print line. Otherwise, skip. By default, missing\n"
-"  QUAL ('.') is treated as 0. Use --keep-missing-qual to treat '.' as pass.\n\n"
-"Examples:\n"
-"  1) Keep variants with QUAL>=30:\n"
-"     VCFX_phred_filter -p 30 < in.vcf > out.vcf\n"
-"  2) Keep missing QUAL lines:\n"
-"     VCFX_phred_filter -p 30 --keep-missing-qual < in.vcf > out.vcf\n";
+void VCFXPhredFilter::displayHelp() {
+    std::cout << "VCFX_phred_filter: Filter VCF lines by their QUAL field.\n\n"
+                 "Usage:\n"
+                 "  VCFX_phred_filter [options] < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  -p, --phred-filter <VAL>      Phred QUAL threshold (default=30)\n"
+                 "  -k, --keep-missing-qual       Treat '.' (missing QUAL) as pass\n"
+                 "  -h, --help                    Display this help and exit\n\n"
+                 "Description:\n"
+                 "  Reads VCF lines from stdin. For each data line, parse the QUAL field.\n"
+                 "  If QUAL >= threshold => print line. Otherwise, skip. By default, missing\n"
+                 "  QUAL ('.') is treated as 0. Use --keep-missing-qual to treat '.' as pass.\n\n"
+                 "Examples:\n"
+                 "  1) Keep variants with QUAL>=30:\n"
+                 "     VCFX_phred_filter -p 30 < in.vcf > out.vcf\n"
+                 "  2) Keep missing QUAL lines:\n"
+                 "     VCFX_phred_filter -p 30 --keep-missing-qual < in.vcf > out.vcf\n";
 }
 
-void VCFXPhredFilter::processVCF(std::istream &in, double threshold, bool keepMissingAsPass){
+void VCFXPhredFilter::processVCF(std::istream &in, double threshold, bool keepMissingAsPass) {
     std::string line;
-    bool foundChrom=false;
-    while(true){
-        if(!std::getline(in, line)) break;
-        if(line.empty()){
-            std::cout<< line <<"\n";
+    bool foundChrom = false;
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            std::cout << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
-            std::cout<< line <<"\n";
-            if(line.rfind("#CHROM",0)==0) foundChrom=true;
+        if (line[0] == '#') {
+            std::cout << line << "\n";
+            if (line.rfind("#CHROM", 0) == 0)
+                foundChrom = true;
             continue;
         }
-        if(!foundChrom) {
-            std::cerr<<"Warning: data line before #CHROM => skipping line.\n";
+        if (!foundChrom) {
+            std::cerr << "Warning: data line before #CHROM => skipping line.\n";
             continue;
         }
         std::vector<std::string> fields;
         {
             std::stringstream ss(line);
             std::string f;
-            while(std::getline(ss,f,'\t')) {
+            while (std::getline(ss, f, '\t')) {
                 fields.push_back(f);
             }
         }
         // we need at least CHROM,POS,ID,REF,ALT,QUAL => 6 columns
-        if(fields.size()<6) {
-            std::cerr<<"Warning: line has <6 columns => skipping.\n";
+        if (fields.size() < 6) {
+            std::cerr << "Warning: line has <6 columns => skipping.\n";
             continue;
         }
-        double q= parseQUAL(fields[5], keepMissingAsPass);
-        if(q>= threshold) {
-            std::cout<< line <<"\n";
+        double q = parseQUAL(fields[5], keepMissingAsPass);
+        if (q >= threshold) {
+            std::cout << line << "\n";
         }
     }
 }
 
-double VCFXPhredFilter::parseQUAL(const std::string &qualStr, bool keepMissingAsPass){
-    if(qualStr=="." || qualStr.empty()){
-        if(keepMissingAsPass) return 1e9; 
-        else return 0.0;
+double VCFXPhredFilter::parseQUAL(const std::string &qualStr, bool keepMissingAsPass) {
+    if (qualStr == "." || qualStr.empty()) {
+        if (keepMissingAsPass)
+            return 1e9;
+        else
+            return 0.0;
     }
     try {
         return std::stod(qualStr);
-    } catch(...) {
-        std::cerr<<"Warning: Invalid QUAL '"<<qualStr<<"'. Using 0.\n";
+    } catch (...) {
+        std::cerr << "Warning: Invalid QUAL '" << qualStr << "'. Using 0.\n";
         return 0.0;
     }
 }
 
-static void show_help() { VCFXPhredFilter obj; char arg0[] = "VCFX_phred_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXPhredFilter obj;
+    char arg0[] = "VCFX_phred_filter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_phred_filter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_phred_filter", show_help))
+        return 0;
     VCFXPhredFilter pf;
-    return pf.run(argc,argv);
+    return pf.run(argc, argv);
 }

--- a/src/VCFX_phred_filter/VCFX_phred_filter.h
+++ b/src/VCFX_phred_filter/VCFX_phred_filter.h
@@ -5,10 +5,10 @@
 #include <string>
 
 class VCFXPhredFilter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
     void processVCF(std::istream &in, double threshold, bool keepMissingAsPass);
     double parseQUAL(const std::string &qualStr, bool keepMissingAsPass);

--- a/src/VCFX_population_filter/VCFX_population_filter.cpp
+++ b/src/VCFX_population_filter/VCFX_population_filter.cpp
@@ -1,199 +1,207 @@
-#include "vcfx_core.h"
 #include "VCFX_population_filter.h"
-#include <getopt.h>
+#include "vcfx_core.h"
+#include <cstdlib>
 #include <fstream>
-#include <sstream>
+#include <getopt.h>
 #include <iostream>
-#include <vector>
+#include <sstream>
 #include <string>
 #include <unordered_set>
-#include <cstdlib>
+#include <vector>
 
-int VCFXPopulationFilter::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXPopulationFilter::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
+    bool showHelp = false;
     std::string populationTag;
     std::string popMapFile;
 
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"population", required_argument, 0, 'p'},
-        {"pop-map", required_argument, 0, 'm'},
-        {0,0,0,0}
-    };
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"population", required_argument, 0, 'p'},
+                                        {"pop-map", required_argument, 0, 'm'},
+                                        {0, 0, 0, 0}};
 
-    while(true){
-        int c= ::getopt_long(argc, argv, "hp:m:", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'p':
-                populationTag= optarg;
-                break;
-            case 'm':
-                popMapFile= optarg;
-                break;
-            default:
-                showHelp=true;
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hp:m:", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'p':
+            populationTag = optarg;
+            break;
+        case 'm':
+            popMapFile = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    if(populationTag.empty()|| popMapFile.empty()){
-        std::cerr<<"Error: Must specify --population <TAG> and --pop-map <file>.\n";
+    if (populationTag.empty() || popMapFile.empty()) {
+        std::cerr << "Error: Must specify --population <TAG> and --pop-map <file>.\n";
         displayHelp();
         return 1;
     }
 
     std::unordered_set<std::string> samplesToInclude;
-    if(!loadPopulationMap(popMapFile, populationTag, samplesToInclude)){
-        std::cerr<<"Error: Unable to load or parse pop map.\n";
+    if (!loadPopulationMap(popMapFile, populationTag, samplesToInclude)) {
+        std::cerr << "Error: Unable to load or parse pop map.\n";
         return 1;
     }
-    if(samplesToInclude.empty()){
-        std::cerr<<"Warning: No samples found for population tag: "<< populationTag<<"\n";
+    if (samplesToInclude.empty()) {
+        std::cerr << "Warning: No samples found for population tag: " << populationTag << "\n";
     }
     filterPopulation(std::cin, std::cout, samplesToInclude, populationTag);
     return 0;
 }
 
-void VCFXPopulationFilter::displayHelp(){
-    std::cout <<
-"VCFX_population_filter: Subset VCF to samples in specified population.\n\n"
-"Usage:\n"
-"  VCFX_population_filter [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  --help, -h               Print this help.\n"
-"  --population, -p <TAG>   Population tag to keep (e.g. 'EUR','AFR', etc.)\n"
-"  --pop-map, -m <FILE>     Tab-delimited file: 'SampleName <tab> Population'\n\n"
-"Description:\n"
-"  Reads the pop map, finds samples that match the chosen population.\n"
-"  Then reads the VCF from stdin and prints lines with only those sample columns.\n"
-"  If a sample is not in that population, it's dropped from the #CHROM header and data columns.\n\n"
-"Example:\n"
-"  VCFX_population_filter --population AFR --pop-map pops.txt < input.vcf > out.vcf\n";
+void VCFXPopulationFilter::displayHelp() {
+    std::cout << "VCFX_population_filter: Subset VCF to samples in specified population.\n\n"
+                 "Usage:\n"
+                 "  VCFX_population_filter [options] < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  --help, -h               Print this help.\n"
+                 "  --population, -p <TAG>   Population tag to keep (e.g. 'EUR','AFR', etc.)\n"
+                 "  --pop-map, -m <FILE>     Tab-delimited file: 'SampleName <tab> Population'\n\n"
+                 "Description:\n"
+                 "  Reads the pop map, finds samples that match the chosen population.\n"
+                 "  Then reads the VCF from stdin and prints lines with only those sample columns.\n"
+                 "  If a sample is not in that population, it's dropped from the #CHROM header and data columns.\n\n"
+                 "Example:\n"
+                 "  VCFX_population_filter --population AFR --pop-map pops.txt < input.vcf > out.vcf\n";
 }
 
-bool VCFXPopulationFilter::loadPopulationMap(const std::string &popMapFile,
-                                             const std::string &popTag,
-                                             std::unordered_set<std::string> &samplesToInclude)
-{
+bool VCFXPopulationFilter::loadPopulationMap(const std::string &popMapFile, const std::string &popTag,
+                                             std::unordered_set<std::string> &samplesToInclude) {
     std::ifstream f(popMapFile);
-    if(!f.is_open()){
-        std::cerr<<"Error: cannot open "<< popMapFile<<"\n";
+    if (!f.is_open()) {
+        std::cerr << "Error: cannot open " << popMapFile << "\n";
         return false;
     }
     std::string line;
-    while(true){
-        if(!std::getline(f,line)) break;
-        if(line.empty())continue;
+    while (true) {
+        if (!std::getline(f, line))
+            break;
+        if (line.empty())
+            continue;
         std::stringstream ss(line);
         std::string samp, pop;
-        if(!(ss>>samp>>pop)){
-            std::cerr<<"Warning: popmap line invalid: "<< line<<"\n";
+        if (!(ss >> samp >> pop)) {
+            std::cerr << "Warning: popmap line invalid: " << line << "\n";
             continue;
         }
-        if(pop== popTag){
+        if (pop == popTag) {
             samplesToInclude.insert(samp);
         }
     }
     return true;
 }
 
-void VCFXPopulationFilter::filterPopulation(std::istream &in,
-                                            std::ostream &out,
+void VCFXPopulationFilter::filterPopulation(std::istream &in, std::ostream &out,
                                             const std::unordered_set<std::string> &samplesToInclude,
-                                            const std::string &popTag)
-{
-    bool foundChromLine=false;
+                                            const std::string &popTag) {
+    bool foundChromLine = false;
     std::string line;
     std::vector<std::string> finalHeader;
     std::vector<int> sampleIndices;
 
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
-            out<< line <<"\n";
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
-            if(line.rfind("#CHROM",0)==0){
-                foundChromLine=true;
+        if (line[0] == '#') {
+            if (line.rfind("#CHROM", 0) == 0) {
+                foundChromLine = true;
                 std::stringstream ss(line);
                 std::vector<std::string> fields;
                 {
                     std::string col;
-                    while(std::getline(ss,col,'\t')){
+                    while (std::getline(ss, col, '\t')) {
                         fields.push_back(col);
                     }
                 }
                 // fields[0..8] => fixed, fields[9..] => samples
                 sampleIndices.clear();
-                for(size_t i=9; i<fields.size(); i++){
-                    if(samplesToInclude.count(fields[i])>0){
+                for (size_t i = 9; i < fields.size(); i++) {
+                    if (samplesToInclude.count(fields[i]) > 0) {
                         sampleIndices.push_back((int)i);
                     }
                 }
                 // build new #CHROM line
                 std::ostringstream newChrom;
-                for(int i=0; i<9; i++){
-                    newChrom<< fields[i];
-                    if(i<8 || !sampleIndices.empty()) newChrom<<"\t";
+                for (int i = 0; i < 9; i++) {
+                    newChrom << fields[i];
+                    if (i < 8 || !sampleIndices.empty())
+                        newChrom << "\t";
                 }
-                for(size_t i=0;i< sampleIndices.size(); i++){
+                for (size_t i = 0; i < sampleIndices.size(); i++) {
                     newChrom << fields[sampleIndices[i]];
-                    if(i+1< sampleIndices.size()) newChrom<<"\t";
+                    if (i + 1 < sampleIndices.size())
+                        newChrom << "\t";
                 }
-                out<< newChrom.str()<<"\n";
+                out << newChrom.str() << "\n";
             } else {
-                out<< line <<"\n";
+                out << line << "\n";
             }
             continue;
         }
-        if(!foundChromLine) {
-            std::cerr<<"Warning: data line before #CHROM => skipping.\n";
+        if (!foundChromLine) {
+            std::cerr << "Warning: data line before #CHROM => skipping.\n";
             continue;
         }
         std::vector<std::string> columns;
         {
             std::stringstream ss(line);
             std::string x;
-            while(std::getline(ss,x,'\t')) {
+            while (std::getline(ss, x, '\t')) {
                 columns.push_back(x);
             }
         }
-        if(columns.size()<9) {
-            std::cerr<<"Warning: line with fewer than 9 columns => skipping.\n";
+        if (columns.size() < 9) {
+            std::cerr << "Warning: line with fewer than 9 columns => skipping.\n";
             continue;
         }
         // build new line
         std::ostringstream newLine;
-        for(int i=0; i<9; i++){
-            newLine<< columns[i];
-            if(i<8 || !sampleIndices.empty()) newLine<<"\t";
+        for (int i = 0; i < 9; i++) {
+            newLine << columns[i];
+            if (i < 8 || !sampleIndices.empty())
+                newLine << "\t";
         }
-        for(size_t i=0;i< sampleIndices.size(); i++){
-            newLine<< columns[sampleIndices[i]];
-            if(i+1< sampleIndices.size()) newLine<<"\t";
+        for (size_t i = 0; i < sampleIndices.size(); i++) {
+            newLine << columns[sampleIndices[i]];
+            if (i + 1 < sampleIndices.size())
+                newLine << "\t";
         }
-        out<< newLine.str()<<"\n";
+        out << newLine.str() << "\n";
     }
-    if(!foundChromLine) {
-        std::cerr<<"Error: No #CHROM header found in VCF.\n";
+    if (!foundChromLine) {
+        std::cerr << "Error: No #CHROM header found in VCF.\n";
     }
 }
 
-static void show_help() { VCFXPopulationFilter obj; char arg0[] = "VCFX_population_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXPopulationFilter obj;
+    char arg0[] = "VCFX_population_filter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_population_filter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_population_filter", show_help))
+        return 0;
     VCFXPopulationFilter pf;
     return pf.run(argc, argv);
 }

--- a/src/VCFX_population_filter/VCFX_population_filter.h
+++ b/src/VCFX_population_filter/VCFX_population_filter.h
@@ -7,18 +7,15 @@
 #include <vector>
 
 class VCFXPopulationFilter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
-    bool loadPopulationMap(const std::string &popMapFile,
-                           const std::string &popTag,
+    bool loadPopulationMap(const std::string &popMapFile, const std::string &popTag,
                            std::unordered_set<std::string> &samplesToInclude);
-    void filterPopulation(std::istream &in,
-                          std::ostream &out,
-                          const std::unordered_set<std::string> &samplesToInclude,
+    void filterPopulation(std::istream &in, std::ostream &out, const std::unordered_set<std::string> &samplesToInclude,
                           const std::string &popTag);
 };
 

--- a/src/VCFX_position_subsetter/VCFX_position_subsetter.cpp
+++ b/src/VCFX_position_subsetter/VCFX_position_subsetter.cpp
@@ -1,155 +1,155 @@
-#include "vcfx_core.h"
 #include "VCFX_position_subsetter.h"
-#include <getopt.h>
-#include <sstream>
-#include <iostream>
-#include <vector>
-#include <string>
+#include "vcfx_core.h"
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
-int VCFXPositionSubsetter::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXPositionSubsetter::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
+    bool showHelp = false;
     std::string regionStr;
 
     static struct option long_opts[] = {
-        {"region", required_argument, 0, 'r'},
-        {"help", no_argument, 0, 'h'},
-        {0,0,0,0}
-    };
+        {"region", required_argument, 0, 'r'}, {"help", no_argument, 0, 'h'}, {0, 0, 0, 0}};
 
-    while(true){
-        int c= ::getopt_long(argc, argv, "r:h", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'r':
-                regionStr= optarg;
-                break;
-            case 'h':
-            default:
-                showHelp=true;
+    while (true) {
+        int c = ::getopt_long(argc, argv, "r:h", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'r':
+            regionStr = optarg;
+            break;
+        case 'h':
+        default:
+            showHelp = true;
         }
     }
 
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    if(regionStr.empty()){
-        std::cerr<<"Error: --region <chrX:start-end> is required.\n";
+    if (regionStr.empty()) {
+        std::cerr << "Error: --region <chrX:start-end> is required.\n";
         displayHelp();
         return 1;
     }
     std::string chrom;
-    int start=0, end=0;
-    if(!parseRegion(regionStr, chrom, start, end)){
+    int start = 0, end = 0;
+    if (!parseRegion(regionStr, chrom, start, end)) {
         return 1;
     }
-    bool ok= subsetVCFByPosition(std::cin, std::cout, chrom, start, end);
-    return ok? 0: 1;
+    bool ok = subsetVCFByPosition(std::cin, std::cout, chrom, start, end);
+    return ok ? 0 : 1;
 }
 
-void VCFXPositionSubsetter::displayHelp(){
-    std::cout <<
-"VCFX_position_subsetter: Subset VCF by a single genomic region.\n\n"
-"Usage:\n"
-"  VCFX_position_subsetter --region \"chr1:10000-20000\" < in.vcf > out.vcf\n\n"
-"Options:\n"
-"  -r, --region \"CHR:START-END\"   The region to keep.\n"
-"  -h, --help                     Print this help.\n\n"
-"Description:\n"
-"  Reads lines from VCF input, and only prints data lines where:\n"
-"    1) CHROM matches 'CHR' exactly, and\n"
-"    2) POS is in [START,END].\n"
-"  All header lines (#...) are passed unmodified.\n\n"
-"Example:\n"
-"  VCFX_position_subsetter --region \"chr2:500-1000\" < input.vcf > subset.vcf\n";
+void VCFXPositionSubsetter::displayHelp() {
+    std::cout << "VCFX_position_subsetter: Subset VCF by a single genomic region.\n\n"
+                 "Usage:\n"
+                 "  VCFX_position_subsetter --region \"chr1:10000-20000\" < in.vcf > out.vcf\n\n"
+                 "Options:\n"
+                 "  -r, --region \"CHR:START-END\"   The region to keep.\n"
+                 "  -h, --help                     Print this help.\n\n"
+                 "Description:\n"
+                 "  Reads lines from VCF input, and only prints data lines where:\n"
+                 "    1) CHROM matches 'CHR' exactly, and\n"
+                 "    2) POS is in [START,END].\n"
+                 "  All header lines (#...) are passed unmodified.\n\n"
+                 "Example:\n"
+                 "  VCFX_position_subsetter --region \"chr2:500-1000\" < input.vcf > subset.vcf\n";
 }
 
-bool VCFXPositionSubsetter::parseRegion(const std::string &regionStr,
-                                        std::string &chrom,
-                                        int &start,
-                                        int &end){
+bool VCFXPositionSubsetter::parseRegion(const std::string &regionStr, std::string &chrom, int &start, int &end) {
     // find colon, dash
-    auto cpos= regionStr.find(':');
-    auto dpos= regionStr.find('-');
-    if(cpos== std::string::npos || dpos==std::string::npos || dpos<= cpos){
-        std::cerr<<"Error: invalid region: "<< regionStr<<". Expected e.g. chr1:10000-20000.\n";
+    auto cpos = regionStr.find(':');
+    auto dpos = regionStr.find('-');
+    if (cpos == std::string::npos || dpos == std::string::npos || dpos <= cpos) {
+        std::cerr << "Error: invalid region: " << regionStr << ". Expected e.g. chr1:10000-20000.\n";
         return false;
     }
-    chrom= regionStr.substr(0, cpos);
-    std::string startStr= regionStr.substr(cpos+1, dpos-(cpos+1));
-    std::string endStr= regionStr.substr(dpos+1);
+    chrom = regionStr.substr(0, cpos);
+    std::string startStr = regionStr.substr(cpos + 1, dpos - (cpos + 1));
+    std::string endStr = regionStr.substr(dpos + 1);
     try {
-        start= std::stoi(startStr);
-        end= std::stoi(endStr);
-    } catch(...){
-        std::cerr<<"Error: cannot parse region start/end.\n";
+        start = std::stoi(startStr);
+        end = std::stoi(endStr);
+    } catch (...) {
+        std::cerr << "Error: cannot parse region start/end.\n";
         return false;
     }
-    if(start> end){
-        std::cerr<<"Error: region start> end.\n";
+    if (start > end) {
+        std::cerr << "Error: region start> end.\n";
         return false;
     }
     return true;
 }
 
-bool VCFXPositionSubsetter::subsetVCFByPosition(std::istream &in,
-                                               std::ostream &out,
-                                               const std::string &regionChrom,
-                                               int regionStart,
-                                               int regionEnd)
-{
-    bool headerFound=false;
+bool VCFXPositionSubsetter::subsetVCFByPosition(std::istream &in, std::ostream &out, const std::string &regionChrom,
+                                                int regionStart, int regionEnd) {
+    bool headerFound = false;
     std::string line;
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
-            out<<line<<"\n";
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
-            out<< line <<"\n";
-            if(line.rfind("#CHROM",0)==0) headerFound=true;
+        if (line[0] == '#') {
+            out << line << "\n";
+            if (line.rfind("#CHROM", 0) == 0)
+                headerFound = true;
             continue;
         }
-        if(!headerFound){
-            std::cerr<<"Warning: data line encountered before #CHROM => skipping.\n";
+        if (!headerFound) {
+            std::cerr << "Warning: data line encountered before #CHROM => skipping.\n";
             continue;
         }
         std::vector<std::string> fields;
         {
             std::stringstream ss(line);
             std::string f;
-            while(std::getline(ss,f,'\t')) fields.push_back(f);
+            while (std::getline(ss, f, '\t'))
+                fields.push_back(f);
         }
-        if(fields.size()<2){
-            std::cerr<<"Warning: line has <2 columns => skipping.\n";
+        if (fields.size() < 2) {
+            std::cerr << "Warning: line has <2 columns => skipping.\n";
             continue;
         }
-        const std::string &chrom= fields[0];
-        const std::string &posStr= fields[1];
-        int pos=0;
+        const std::string &chrom = fields[0];
+        const std::string &posStr = fields[1];
+        int pos = 0;
         try {
-            pos= std::stoi(posStr);
-        } catch(...){
-            std::cerr<<"Warning: invalid POS '"<< posStr<<"'. Skipping.\n";
+            pos = std::stoi(posStr);
+        } catch (...) {
+            std::cerr << "Warning: invalid POS '" << posStr << "'. Skipping.\n";
             continue;
         }
-        if(chrom== regionChrom && pos>= regionStart && pos<= regionEnd){
-            out<< line <<"\n";
+        if (chrom == regionChrom && pos >= regionStart && pos <= regionEnd) {
+            out << line << "\n";
         }
     }
     return true;
 }
 
-static void show_help() { VCFXPositionSubsetter obj; char arg0[] = "VCFX_position_subsetter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXPositionSubsetter obj;
+    char arg0[] = "VCFX_position_subsetter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_position_subsetter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_position_subsetter", show_help))
+        return 0;
     VCFXPositionSubsetter subsetter;
     return subsetter.run(argc, argv);
 }

--- a/src/VCFX_position_subsetter/VCFX_position_subsetter.h
+++ b/src/VCFX_position_subsetter/VCFX_position_subsetter.h
@@ -5,21 +5,17 @@
 #include <string>
 
 class VCFXPositionSubsetter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
     // parse "chr1:10000-20000", store in regionChrom, regionStart, regionEnd
-    bool parseRegion(const std::string &regionStr,
-                     std::string &chrom,
-                     int &start, int &end);
+    bool parseRegion(const std::string &regionStr, std::string &chrom, int &start, int &end);
 
     // do the actual subsetting from in->out
-    bool subsetVCFByPosition(std::istream &in, std::ostream &out,
-                             const std::string &regionChrom,
-                             int regionStart,
+    bool subsetVCFByPosition(std::istream &in, std::ostream &out, const std::string &regionChrom, int regionStart,
                              int regionEnd);
 };
 

--- a/src/VCFX_probability_filter/VCFX_probability_filter.cpp
+++ b/src/VCFX_probability_filter/VCFX_probability_filter.cpp
@@ -1,33 +1,30 @@
-#include "vcfx_core.h"
 #include "VCFX_probability_filter.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
+#include <getopt.h>
 #include <regex>
+#include <sstream>
 
 // Implementation of VCFXProbabilityFilter
-int VCFXProbabilityFilter::run(int argc, char* argv[]) {
+int VCFXProbabilityFilter::run(int argc, char *argv[]) {
     // Parse command-line arguments
     int opt;
     bool showHelp = false;
     std::string condition;
 
     static struct option long_options[] = {
-        {"help",           no_argument,       0, 'h'},
-        {"filter-probability", required_argument, 0, 'f'},
-        {0,                0,                 0,  0 }
-    };
+        {"help", no_argument, 0, 'h'}, {"filter-probability", required_argument, 0, 'f'}, {0, 0, 0, 0}};
 
     while ((opt = getopt_long(argc, argv, "hf:", long_options, nullptr)) != -1) {
         switch (opt) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'f':
-                condition = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'f':
+            condition = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -35,7 +32,7 @@ int VCFXProbabilityFilter::run(int argc, char* argv[]) {
         displayHelp();
         return 0;
     }
-    
+
     if (condition.empty()) {
         displayHelp();
         return 1;
@@ -53,13 +50,14 @@ void VCFXProbabilityFilter::displayHelp() {
     std::cout << "  VCFX_probability_filter --filter-probability \"<CONDITION>\" [options]\n\n";
     std::cout << "Options:\n";
     std::cout << "  -h, --help                        Display this help message and exit\n";
-    std::cout << "  -f, --filter-probability <cond>    Specify the genotype probability filter condition (e.g., GP>0.9)\n\n";
+    std::cout
+        << "  -f, --filter-probability <cond>    Specify the genotype probability filter condition (e.g., GP>0.9)\n\n";
     std::cout << "Supported Operators: >, <, >=, <=, ==, !=\n\n";
     std::cout << "Example:\n";
     std::cout << "  VCFX_probability_filter --filter-probability \"GP>0.9\" < input.vcf > filtered.vcf\n";
 }
 
-void VCFXProbabilityFilter::filterByProbability(std::istream& in, std::ostream& out, const std::string& condition) {
+void VCFXProbabilityFilter::filterByProbability(std::istream &in, std::ostream &out, const std::string &condition) {
     // Parse the filter condition using regex (e.g., "GP>0.9")
     std::regex conditionRegex(R"((\w+)\s*(>=|<=|>|<|==|!=)\s*([0-9]*\.?[0-9]+))");
     std::smatch matches;
@@ -79,7 +77,8 @@ void VCFXProbabilityFilter::filterByProbability(std::istream& in, std::ostream& 
     size_t fieldIndex = std::string::npos;
 
     while (std::getline(in, line)) {
-        if (line.empty()) continue;
+        if (line.empty())
+            continue;
 
         if (line[0] == '#') {
             // Handle header lines
@@ -210,10 +209,17 @@ void VCFXProbabilityFilter::filterByProbability(std::istream& in, std::ostream& 
     }
 }
 
-static void show_help() { VCFXProbabilityFilter obj; char arg0[] = "VCFX_probability_filter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXProbabilityFilter obj;
+    char arg0[] = "VCFX_probability_filter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_probability_filter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_probability_filter", show_help))
+        return 0;
     VCFXProbabilityFilter probabilityFilter;
     return probabilityFilter.run(argc, argv);
 }

--- a/src/VCFX_probability_filter/VCFX_probability_filter.h
+++ b/src/VCFX_probability_filter/VCFX_probability_filter.h
@@ -7,16 +7,16 @@
 
 // VCFXProbabilityFilter: Header file for Genotype Probability Filter tool
 class VCFXProbabilityFilter {
-public:
+  public:
     // Entry point for the tool
-    int run(int argc, char* argv[]);
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Displays the help message
     void displayHelp();
 
     // Filters VCF input based on the specified genotype probability condition
-    void filterByProbability(std::istream& in, std::ostream& out, const std::string& condition);
+    void filterByProbability(std::istream &in, std::ostream &out, const std::string &condition);
 };
 
 #endif // VCFX_PROBABILITY_FILTER_H

--- a/src/VCFX_quality_adjuster/VCFX_quality_adjuster.cpp
+++ b/src/VCFX_quality_adjuster/VCFX_quality_adjuster.cpp
@@ -1,128 +1,120 @@
-#include "vcfx_core.h"
 #include "VCFX_quality_adjuster.h"
-#include <getopt.h>
-#include <sstream>
-#include <iostream>
-#include <cmath>
+#include "vcfx_core.h"
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 
-int VCFXQualityAdjuster::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXQualityAdjuster::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
-    bool clamp=true;
+    bool showHelp = false;
+    bool clamp = true;
     std::string transformStr;
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"adjust-qual", required_argument, 0, 'a'},
-        {"no-clamp", no_argument, 0, 'n'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c=::getopt_long(argc, argv, "ha:n", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'a':
-                transformStr= optarg;
-                break;
-            case 'n':
-                clamp=false;
-                break;
-            default:
-                showHelp=true;
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"adjust-qual", required_argument, 0, 'a'},
+                                        {"no-clamp", no_argument, 0, 'n'},
+                                        {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "ha:n", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'a':
+            transformStr = optarg;
+            break;
+        case 'n':
+            clamp = false;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    if(transformStr.empty()){
-        std::cerr<<"Error: Must specify a transformation with --adjust-qual <FUNC>.\n";
+    if (transformStr.empty()) {
+        std::cerr << "Error: Must specify a transformation with --adjust-qual <FUNC>.\n";
         displayHelp();
         return 1;
     }
     initSupportedFunctions();
     std::function<double(double)> transFunc;
-    if(!parseTransformationFunction(transformStr, transFunc)){
-        std::cerr<<"Error: unsupported transformation '"<< transformStr<<"'.\n";
+    if (!parseTransformationFunction(transformStr, transFunc)) {
+        std::cerr << "Error: unsupported transformation '" << transformStr << "'.\n";
         return 1;
     }
     adjustQualityScores(std::cin, std::cout, transFunc, clamp);
     return 0;
 }
 
-void VCFXQualityAdjuster::displayHelp(){
-    std::cout <<
-"VCFX_quality_adjuster: Apply a transformation to the QUAL field of a VCF.\n\n"
-"Usage:\n"
-"  VCFX_quality_adjuster [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -h, --help               Show this help.\n"
-"  -a, --adjust-qual <FUNC> Required. One of: log, sqrt, square, identity.\n"
-"  -n, --no-clamp           Do not clamp negative or large values.\n\n"
-"Description:\n"
-"  Reads each line from VCF. If it's a data line with >=8 columns, we parse\n"
-"  the QUAL field (6th col). We transform it with <FUNC>, e.g.:\n"
-"    log => log(QUAL + 1e-10)\n"
-"    sqrt=> sqrt(QUAL)\n"
-"    square=> (QUAL * QUAL)\n"
-"    identity=> no change\n"
-"  By default, negative results from e.g. log are clamped to 0, and large\n"
-"  results are capped at 1e12. If you do not want clamping, use --no-clamp.\n\n"
-"Examples:\n"
-"  1) Log-transform:\n"
-"     VCFX_quality_adjuster --adjust-qual log < in.vcf > out.vcf\n"
-"  2) Square, keep negative or big values as is:\n"
-"     VCFX_quality_adjuster --adjust-qual square --no-clamp < in.vcf > out.vcf\n";
+void VCFXQualityAdjuster::displayHelp() {
+    std::cout << "VCFX_quality_adjuster: Apply a transformation to the QUAL field of a VCF.\n\n"
+                 "Usage:\n"
+                 "  VCFX_quality_adjuster [options] < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help               Show this help.\n"
+                 "  -a, --adjust-qual <FUNC> Required. One of: log, sqrt, square, identity.\n"
+                 "  -n, --no-clamp           Do not clamp negative or large values.\n\n"
+                 "Description:\n"
+                 "  Reads each line from VCF. If it's a data line with >=8 columns, we parse\n"
+                 "  the QUAL field (6th col). We transform it with <FUNC>, e.g.:\n"
+                 "    log => log(QUAL + 1e-10)\n"
+                 "    sqrt=> sqrt(QUAL)\n"
+                 "    square=> (QUAL * QUAL)\n"
+                 "    identity=> no change\n"
+                 "  By default, negative results from e.g. log are clamped to 0, and large\n"
+                 "  results are capped at 1e12. If you do not want clamping, use --no-clamp.\n\n"
+                 "Examples:\n"
+                 "  1) Log-transform:\n"
+                 "     VCFX_quality_adjuster --adjust-qual log < in.vcf > out.vcf\n"
+                 "  2) Square, keep negative or big values as is:\n"
+                 "     VCFX_quality_adjuster --adjust-qual square --no-clamp < in.vcf > out.vcf\n";
 }
 
-void VCFXQualityAdjuster::initSupportedFunctions(){
+void VCFXQualityAdjuster::initSupportedFunctions() {
     supportedFunctions.clear();
-    supportedFunctions["log"] = [](double x){
+    supportedFunctions["log"] = [](double x) {
         // protect near zero with epsilon
         return std::log(x + 1e-10);
     };
-    supportedFunctions["sqrt"]= [](double x){
+    supportedFunctions["sqrt"] = [](double x) {
         return std::sqrt(std::max(0.0, x)); // can't sqrt negative
     };
-    supportedFunctions["square"]= [](double x){
-        return x*x;
-    };
-    supportedFunctions["identity"]= [](double x){
-        return x;
-    };
+    supportedFunctions["square"] = [](double x) { return x * x; };
+    supportedFunctions["identity"] = [](double x) { return x; };
 }
 
 bool VCFXQualityAdjuster::parseTransformationFunction(const std::string &funcStr,
-                                                      std::function<double(double)> &transFunc)
-{
-    auto it= supportedFunctions.find(funcStr);
-    if(it== supportedFunctions.end()){
+                                                      std::function<double(double)> &transFunc) {
+    auto it = supportedFunctions.find(funcStr);
+    if (it == supportedFunctions.end()) {
         return false;
     }
-    transFunc= it->second;
+    transFunc = it->second;
     return true;
 }
 
 void VCFXQualityAdjuster::adjustQualityScores(std::istream &in, std::ostream &out,
-                                              std::function<double(double)> transFunc,
-                                              bool clamp)
-{
+                                              std::function<double(double)> transFunc, bool clamp) {
     std::string line;
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
-            out<< line <<"\n";
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
-            out<< line <<"\n";
+        if (line[0] == '#') {
+            out << line << "\n";
             continue;
         }
         // parse fields
@@ -130,55 +122,66 @@ void VCFXQualityAdjuster::adjustQualityScores(std::istream &in, std::ostream &ou
         {
             std::stringstream ss(line);
             std::string f;
-            while(std::getline(ss,f,'\t')){
+            while (std::getline(ss, f, '\t')) {
                 fields.push_back(f);
             }
         }
-        if(fields.size()<8){
-            std::cerr<<"Warning: line with <8 fields => skipping.\n";
+        if (fields.size() < 8) {
+            std::cerr << "Warning: line with <8 fields => skipping.\n";
             continue;
         }
-        double oldQual=0.0;
-        bool valid=true;
-        if(fields[5]=="." || fields[5].empty()){
+        double oldQual = 0.0;
+        bool valid = true;
+        if (fields[5] == "." || fields[5].empty()) {
             // treat missing as 0?
-            oldQual=0.0;
+            oldQual = 0.0;
         } else {
             try {
-                oldQual= std::stod(fields[5]);
-            } catch(...){
-                std::cerr<<"Warning: invalid QUAL '"<<fields[5]<<"'. Skipping.\n";
-                valid=false;
+                oldQual = std::stod(fields[5]);
+            } catch (...) {
+                std::cerr << "Warning: invalid QUAL '" << fields[5] << "'. Skipping.\n";
+                valid = false;
             }
         }
-        if(!valid) continue;
-        double newQual= transFunc(oldQual);
-        if(clamp){
-            if(newQual< 0.0) newQual= 0.0;
+        if (!valid)
+            continue;
+        double newQual = transFunc(oldQual);
+        if (clamp) {
+            if (newQual < 0.0)
+                newQual = 0.0;
             // clamp large values
-            if(newQual>1e12) newQual= 1e12;
+            if (newQual > 1e12)
+                newQual = 1e12;
         }
         std::string qualStr;
-        if(std::isnan(newQual)){
+        if (std::isnan(newQual)) {
             // ensure consistent representation for NaN
             qualStr = "nan";
         } else {
             qualStr = std::to_string(newQual);
         }
-        fields[5]= qualStr;
+        fields[5] = qualStr;
         std::ostringstream oss;
-        for(size_t i=0; i<fields.size(); i++){
-            if(i>0) oss<<"\t";
-            oss<< fields[i];
+        for (size_t i = 0; i < fields.size(); i++) {
+            if (i > 0)
+                oss << "\t";
+            oss << fields[i];
         }
-        out<< oss.str()<<"\n";
+        out << oss.str() << "\n";
     }
 }
 
-static void show_help() { VCFXQualityAdjuster obj; char arg0[] = "VCFX_quality_adjuster"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXQualityAdjuster obj;
+    char arg0[] = "VCFX_quality_adjuster";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_quality_adjuster", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_quality_adjuster", show_help))
+        return 0;
     VCFXQualityAdjuster app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_quality_adjuster/VCFX_quality_adjuster.h
+++ b/src/VCFX_quality_adjuster/VCFX_quality_adjuster.h
@@ -1,26 +1,23 @@
 #ifndef VCFX_QUALITY_ADJUSTER_H
 #define VCFX_QUALITY_ADJUSTER_H
 
+#include <functional>
 #include <iostream>
 #include <string>
-#include <functional>
 #include <unordered_map>
 
 class VCFXQualityAdjuster {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
     // parse the transformation name and build a transform function
-    bool parseTransformationFunction(const std::string &funcStr,
-                                     std::function<double(double)> &transFunc);
+    bool parseTransformationFunction(const std::string &funcStr, std::function<double(double)> &transFunc);
 
     // read lines from 'in', transform the QUAL field (6th col),
     // write lines to 'out'. If clamp is false, do not clamp negative or large.
-    void adjustQualityScores(std::istream &in, std::ostream &out,
-                             std::function<double(double)> transFunc,
-                             bool clamp);
+    void adjustQualityScores(std::istream &in, std::ostream &out, std::function<double(double)> transFunc, bool clamp);
 
     // map of supported transformations
     std::unordered_map<std::string, std::function<double(double)>> supportedFunctions;

--- a/src/VCFX_record_filter/VCFX_record_filter.cpp
+++ b/src/VCFX_record_filter/VCFX_record_filter.cpp
@@ -1,167 +1,186 @@
-#include "vcfx_core.h"
 #include "VCFX_record_filter.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <vector>
-#include <string>
-#include <unordered_map>
 #include <cctype>
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 // Trim leading/trailing whitespace
-static std::string trim(const std::string &s){
-    size_t start=0; while(start<s.size() && isspace((unsigned char)s[start]))start++;
-    if(start==s.size()) return "";
-    size_t end=s.size()-1; 
-    while(end>start && isspace((unsigned char)s[end]))end--;
-    return s.substr(start, end-start+1);
+static std::string trim(const std::string &s) {
+    size_t start = 0;
+    while (start < s.size() && isspace((unsigned char)s[start]))
+        start++;
+    if (start == s.size())
+        return "";
+    size_t end = s.size() - 1;
+    while (end > start && isspace((unsigned char)s[end]))
+        end--;
+    return s.substr(start, end - start + 1);
 }
 
-static void split(const std::string &s, char delim, std::vector<std::string> &out){
+static void split(const std::string &s, char delim, std::vector<std::string> &out) {
     out.clear();
     std::stringstream ss(s);
     std::string t;
-    while(std::getline(ss,t,delim)){
+    while (std::getline(ss, t, delim)) {
         out.push_back(t);
     }
 }
 
 // parse an operator token: "==", "!=", ">=", "<=", ">", "<"
-static bool parseOperator(const std::string &opStr, FilterOp &op){
-    if(opStr==">") {op= FilterOp::GT;return true;}
-    if(opStr==">="){op= FilterOp::GE;return true;}
-    if(opStr=="<") {op= FilterOp::LT;return true;}
-    if(opStr=="<="){op= FilterOp::LE;return true;}
-    if(opStr=="=="){op= FilterOp::EQ;return true;}
-    if(opStr=="!="){op= FilterOp::NE;return true;}
+static bool parseOperator(const std::string &opStr, FilterOp &op) {
+    if (opStr == ">") {
+        op = FilterOp::GT;
+        return true;
+    }
+    if (opStr == ">=") {
+        op = FilterOp::GE;
+        return true;
+    }
+    if (opStr == "<") {
+        op = FilterOp::LT;
+        return true;
+    }
+    if (opStr == "<=") {
+        op = FilterOp::LE;
+        return true;
+    }
+    if (opStr == "==") {
+        op = FilterOp::EQ;
+        return true;
+    }
+    if (opStr == "!=") {
+        op = FilterOp::NE;
+        return true;
+    }
     return false;
 }
 
-// parse single token e.g. "POS>100" or "FILTER!=PASS" 
+// parse single token e.g. "POS>100" or "FILTER!=PASS"
 // returns false if invalid
-static bool parseSingleCriterion(const std::string &token, FilterCriterion &crit){
+static bool parseSingleCriterion(const std::string &token, FilterCriterion &crit) {
     // find the operator among [>=,<=,==,!=,>,<]
     // a robust approach is to search for them in descending length order
-    static std::vector<std::string> ops={">=", "<=", "==", "!=", ">", "<"};
-    size_t bestPos= std::string::npos;
+    static std::vector<std::string> ops = {">=", "<=", "==", "!=", ">", "<"};
+    size_t bestPos = std::string::npos;
     std::string bestOp;
-    for(auto &o: ops){
-        auto p= token.find(o);
-        if(p!=std::string::npos){
-            bestPos= p; 
-            bestOp= o;
+    for (auto &o : ops) {
+        auto p = token.find(o);
+        if (p != std::string::npos) {
+            bestPos = p;
+            bestOp = o;
             break; // first match
         }
     }
-    if(bestPos==std::string::npos){
-        std::cerr<<"Error: no operator found in '"<< token<<"'.\n";
+    if (bestPos == std::string::npos) {
+        std::cerr << "Error: no operator found in '" << token << "'.\n";
         return false;
     }
     // parse fieldName= token.substr(0,bestPos)
     // parse value= token.substr(bestPos+ bestOp.size())
-    crit.fieldName= trim(token.substr(0,bestPos));
-    if(crit.fieldName.empty()){
-        std::cerr<<"Error: empty field name in '"<< token<<"'.\n";
+    crit.fieldName = trim(token.substr(0, bestPos));
+    if (crit.fieldName.empty()) {
+        std::cerr << "Error: empty field name in '" << token << "'.\n";
         return false;
     }
-    if(!parseOperator(bestOp, crit.op)){
-        std::cerr<<"Error: unknown operator '"<< bestOp<<"' in '"<< token<<"'.\n";
+    if (!parseOperator(bestOp, crit.op)) {
+        std::cerr << "Error: unknown operator '" << bestOp << "' in '" << token << "'.\n";
         return false;
     }
-    std::string valPart= trim(token.substr(bestPos+ bestOp.size()));
-    if(valPart.empty()){
-        std::cerr<<"Error: no value in '"<< token<<"'.\n";
+    std::string valPart = trim(token.substr(bestPos + bestOp.size()));
+    if (valPart.empty()) {
+        std::cerr << "Error: no value in '" << token << "'.\n";
         return false;
     }
     // try parse numeric
     // if parse fails => treat as string
-    try{
-        double d= std::stod(valPart);
+    try {
+        double d = std::stod(valPart);
         // numeric
-        crit.fieldType= FieldType::NUMERIC;
-        crit.numericValue= d;
+        crit.fieldType = FieldType::NUMERIC;
+        crit.numericValue = d;
         crit.stringValue.clear();
-    } catch(...){
+    } catch (...) {
         // treat as string
-        crit.fieldType= FieldType::STRING;
-        crit.stringValue= valPart;
-        crit.numericValue= 0.0;
+        crit.fieldType = FieldType::STRING;
+        crit.stringValue = valPart;
+        crit.numericValue = 0.0;
     }
     return true;
 }
 
-bool parseCriteria(const std::string &criteriaStr,
-                   std::vector<FilterCriterion> &criteria)
-{
+bool parseCriteria(const std::string &criteriaStr, std::vector<FilterCriterion> &criteria) {
     criteria.clear();
     std::vector<std::string> tokens;
     split(criteriaStr, ';', tokens);
-    for(auto &t: tokens){
-        auto trimmed= trim(t);
-        if(trimmed.empty()) continue;
+    for (auto &t : tokens) {
+        auto trimmed = trim(t);
+        if (trimmed.empty())
+            continue;
         FilterCriterion c;
-        if(!parseSingleCriterion(trimmed, c)) {
+        if (!parseSingleCriterion(trimmed, c)) {
             return false;
         }
         criteria.push_back(c);
     }
-    if(criteria.empty()){
-        std::cerr<<"Error: no valid criteria in '"<<criteriaStr<<"'.\n";
+    if (criteria.empty()) {
+        std::cerr << "Error: no valid criteria in '" << criteriaStr << "'.\n";
         return false;
     }
     return true;
 }
 
 // split by tab
-static std::vector<std::string> tabSplit(const std::string &line){
+static std::vector<std::string> tabSplit(const std::string &line) {
     std::vector<std::string> f;
     std::stringstream ss(line);
     std::string x;
-    while(std::getline(ss,x,'\t')) f.push_back(x);
+    while (std::getline(ss, x, '\t'))
+        f.push_back(x);
     return f;
 }
 
 // parse info => either return key= or a flag
 // if numeric, parse double
 // if string => keep string
-static bool getInfoValue(const std::string &infoField,
-                         const std::string &key,
-                         bool wantNumeric,
-                         double &numericOut,
-                         std::string &stringOut)
-{
-    if(infoField.empty()|| infoField=="." ) return false;
+static bool getInfoValue(const std::string &infoField, const std::string &key, bool wantNumeric, double &numericOut,
+                         std::string &stringOut) {
+    if (infoField.empty() || infoField == ".")
+        return false;
     std::vector<std::string> tokens;
     split(infoField, ';', tokens);
-    for(auto &kv: tokens){
-        auto eq= kv.find('=');
-        if(eq!=std::string::npos){
-            std::string k= trim(kv.substr(0,eq));
-            std::string v= trim(kv.substr(eq+1));
-            if(k== key){
-                if(wantNumeric){
-                    try{
-                        double d= std::stod(v);
-                        numericOut= d;
+    for (auto &kv : tokens) {
+        auto eq = kv.find('=');
+        if (eq != std::string::npos) {
+            std::string k = trim(kv.substr(0, eq));
+            std::string v = trim(kv.substr(eq + 1));
+            if (k == key) {
+                if (wantNumeric) {
+                    try {
+                        double d = std::stod(v);
+                        numericOut = d;
                         return true;
-                    }catch(...){
+                    } catch (...) {
                         return false;
                     }
                 } else {
-                    stringOut= v;
+                    stringOut = v;
                     return true;
                 }
             }
         } else {
             // it's a flag
-            std::string fl= trim(kv);
-            if(fl== key){
-                if(wantNumeric){
-                    numericOut= 1.0;
+            std::string fl = trim(kv);
+            if (fl == key) {
+                if (wantNumeric) {
+                    numericOut = 1.0;
                 } else {
-                    stringOut= fl; 
+                    stringOut = fl;
                 }
                 return true;
             }
@@ -170,26 +189,34 @@ static bool getInfoValue(const std::string &infoField,
     return false;
 }
 
-static bool compareDouble(double x, FilterOp op, double y){
-    switch(op){
-        case FilterOp::GT: return (x> y);
-        case FilterOp::GE: return (x>=y);
-        case FilterOp::LT: return (x< y);
-        case FilterOp::LE: return (x<=y);
-        case FilterOp::EQ: return (x==y);
-        case FilterOp::NE: return (x!=y);
+static bool compareDouble(double x, FilterOp op, double y) {
+    switch (op) {
+    case FilterOp::GT:
+        return (x > y);
+    case FilterOp::GE:
+        return (x >= y);
+    case FilterOp::LT:
+        return (x < y);
+    case FilterOp::LE:
+        return (x <= y);
+    case FilterOp::EQ:
+        return (x == y);
+    case FilterOp::NE:
+        return (x != y);
     }
-    return false; 
+    return false;
 }
 
-static bool compareString(const std::string &s, FilterOp op, const std::string &t){
-    switch(op){
-        case FilterOp::EQ: return (s==t);
-        case FilterOp::NE: return (s!=t);
-        // if user tries < or > => invalid for strings in this code => fail
-        default: 
-            // we do no partial compare. We fail this criterion
-            return false;
+static bool compareString(const std::string &s, FilterOp op, const std::string &t) {
+    switch (op) {
+    case FilterOp::EQ:
+        return (s == t);
+    case FilterOp::NE:
+        return (s != t);
+    // if user tries < or > => invalid for strings in this code => fail
+    default:
+        // we do no partial compare. We fail this criterion
+        return false;
     }
 }
 
@@ -198,33 +225,34 @@ static bool compareString(const std::string &s, FilterOp op, const std::string &
 // If fieldName== "QUAL", parse fields[5] => numeric
 // If fieldName== "FILTER", parse fields[6] => string
 // else => treat as an INFO key
-static bool evaluateCriterion(const std::vector<std::string> &fields,
-                              const FilterCriterion &c){
-    if(fields.size()<8) return false;
-    if(c.fieldName=="POS"){
-        if(fields[1].empty()) return false;
-        try{
-            double p= std::stod(fields[1]);
+static bool evaluateCriterion(const std::vector<std::string> &fields, const FilterCriterion &c) {
+    if (fields.size() < 8)
+        return false;
+    if (c.fieldName == "POS") {
+        if (fields[1].empty())
+            return false;
+        try {
+            double p = std::stod(fields[1]);
             return compareDouble(p, c.op, c.numericValue);
-        } catch(...){
+        } catch (...) {
             return false;
         }
-    } else if(c.fieldName=="QUAL"){
+    } else if (c.fieldName == "QUAL") {
         // index 5
-        if(fields[5].empty()|| fields[5]=="." ) {
+        if (fields[5].empty() || fields[5] == ".") {
             // treat missing as 0? or fail?
-            double q=0.0;
+            double q = 0.0;
             return compareDouble(q, c.op, c.numericValue);
         }
-        try{
-            double q= std::stod(fields[5]);
+        try {
+            double q = std::stod(fields[5]);
             return compareDouble(q, c.op, c.numericValue);
-        }catch(...){
+        } catch (...) {
             return false;
         }
-    } else if(c.fieldName=="FILTER"){
+    } else if (c.fieldName == "FILTER") {
         // index=6 => string compare
-        if(c.fieldType== FieldType::NUMERIC) {
+        if (c.fieldType == FieldType::NUMERIC) {
             // invalid usage => fail
             return false;
         }
@@ -232,11 +260,12 @@ static bool evaluateCriterion(const std::vector<std::string> &fields,
     } else {
         // treat as info key
         // c.fieldType => numeric/string
-        double num=0.0; 
+        double num = 0.0;
         std::string st;
-        bool got= getInfoValue(fields[7], c.fieldName, (c.fieldType==FieldType::NUMERIC), num, st);
-        if(!got) return false; // can't find key => fail
-        if(c.fieldType==FieldType::NUMERIC){
+        bool got = getInfoValue(fields[7], c.fieldName, (c.fieldType == FieldType::NUMERIC), num, st);
+        if (!got)
+            return false; // can't find key => fail
+        if (c.fieldType == FieldType::NUMERIC) {
             return compareDouble(num, c.op, c.numericValue);
         } else {
             return compareString(st, c.op, c.stringValue);
@@ -244,137 +273,135 @@ static bool evaluateCriterion(const std::vector<std::string> &fields,
     }
 }
 
-bool recordPasses(const std::string &record,
-                  const std::vector<FilterCriterion> &criteria,
-                  bool useAndLogic)
-{
+bool recordPasses(const std::string &record, const std::vector<FilterCriterion> &criteria, bool useAndLogic) {
     // parse fields
-    auto fields= tabSplit(record);
-    if(fields.size()<8) return false;
-    bool anyPass= false;
+    auto fields = tabSplit(record);
+    if (fields.size() < 8)
+        return false;
+    bool anyPass = false;
     // check each criterion
-    for(auto &crit: criteria){
-        bool pass= evaluateCriterion(fields, crit);
-        if(useAndLogic){
-            if(!pass) return false; 
+    for (auto &crit : criteria) {
+        bool pass = evaluateCriterion(fields, crit);
+        if (useAndLogic) {
+            if (!pass)
+                return false;
         } else {
             // or logic
-            if(pass) anyPass= true;
+            if (pass)
+                anyPass = true;
         }
     }
-    if(useAndLogic) {
+    if (useAndLogic) {
         return true; // all pass
     } else {
-        return anyPass; 
+        return anyPass;
     }
 }
 
-void processVCF(std::istream &in,
-                std::ostream &out,
-                const std::vector<FilterCriterion> &criteria,
-                bool useAndLogic)
-{
-    bool foundChrom=false;
+void processVCF(std::istream &in, std::ostream &out, const std::vector<FilterCriterion> &criteria, bool useAndLogic) {
+    bool foundChrom = false;
     std::string line;
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
-            out<< line <<"\n";
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
-            out<< line <<"\n"; 
-            if(line.rfind("#CHROM",0)==0) foundChrom=true;
+        if (line[0] == '#') {
+            out << line << "\n";
+            if (line.rfind("#CHROM", 0) == 0)
+                foundChrom = true;
             continue;
         }
-        if(!foundChrom){
+        if (!foundChrom) {
             // data line before #CHROM => skip with a warning?
-            std::cerr<<"Warning: data line before #CHROM => skipping.\n";
+            std::cerr << "Warning: data line before #CHROM => skipping.\n";
             continue;
         }
         // apply
-        if(recordPasses(line, criteria, useAndLogic)){
-            out<< line <<"\n";
+        if (recordPasses(line, criteria, useAndLogic)) {
+            out << line << "\n";
         }
     }
 }
 
-void printHelp(){
-    std::cout <<
-"VCFX_record_filter: Filter VCF data lines by multiple criteria.\n\n"
-"Usage:\n"
-"  VCFX_record_filter [options] --filter \"CRITERIA\"\n"
-"  < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  --filter, -f \"...\"   One or more criteria separated by semicolons, e.g.\n"
-"                        \"POS>10000; QUAL>=30; AF<0.05; FILTER==PASS\"\n"
-"                        Each criterion must use an operator among >,>=,<,<=,==,!=\n\n"
-"  --logic and|or        'and' => a line must pass all criteria (default)\n"
-"                        'or'  => pass if any criterion is satisfied.\n"
-"  --help, -h            Show this help.\n\n"
-"Fields:\n"
-"  POS => numeric, QUAL => numeric, FILTER => string.\n"
-"  Others => assumed to be an INFO key. We try numeric parse if the criterion is numeric, else string.\n\n"
-"Example:\n"
-"  VCFX_record_filter --filter \"POS>=1000;FILTER==PASS;DP>10\" --logic and < in.vcf > out.vcf\n";
+void printHelp() {
+    std::cout
+        << "VCFX_record_filter: Filter VCF data lines by multiple criteria.\n\n"
+           "Usage:\n"
+           "  VCFX_record_filter [options] --filter \"CRITERIA\"\n"
+           "  < input.vcf > output.vcf\n\n"
+           "Options:\n"
+           "  --filter, -f \"...\"   One or more criteria separated by semicolons, e.g.\n"
+           "                        \"POS>10000; QUAL>=30; AF<0.05; FILTER==PASS\"\n"
+           "                        Each criterion must use an operator among >,>=,<,<=,==,!=\n\n"
+           "  --logic and|or        'and' => a line must pass all criteria (default)\n"
+           "                        'or'  => pass if any criterion is satisfied.\n"
+           "  --help, -h            Show this help.\n\n"
+           "Fields:\n"
+           "  POS => numeric, QUAL => numeric, FILTER => string.\n"
+           "  Others => assumed to be an INFO key. We try numeric parse if the criterion is numeric, else string.\n\n"
+           "Example:\n"
+           "  VCFX_record_filter --filter \"POS>=1000;FILTER==PASS;DP>10\" --logic and < in.vcf > out.vcf\n";
 }
 
 // main with typical argument parse
 static void show_help() { printHelp(); }
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_record_filter", show_help)) return 0;
-    if(argc==1){
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_record_filter", show_help))
+        return 0;
+    if (argc == 1) {
         printHelp();
         return 0;
     }
-    bool showHelp=false;
+    bool showHelp = false;
     std::string criteriaStr;
-    std::string logicStr="and";
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"filter", required_argument, 0, 'f'},
-        {"logic", required_argument, 0, 'l'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv, "hf:l:", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'f':
-                criteriaStr= optarg;
-                break;
-            case 'l':
-                logicStr= optarg;
-                break;
-            default:
-                showHelp=true;
+    std::string logicStr = "and";
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"filter", required_argument, 0, 'f'},
+                                        {"logic", required_argument, 0, 'l'},
+                                        {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hf:l:", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'f':
+            criteriaStr = optarg;
+            break;
+        case 'l':
+            logicStr = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         printHelp();
         return 0;
     }
-    if(criteriaStr.empty()){
-        std::cerr<<"Error: must provide --filter \"CRITERIA\".\n";
+    if (criteriaStr.empty()) {
+        std::cerr << "Error: must provide --filter \"CRITERIA\".\n";
         printHelp();
         return 1;
     }
-    bool useAndLogic=true;
-    if(logicStr=="and"){
-        useAndLogic=true;
-    } else if(logicStr=="or"){
-        useAndLogic=false;
+    bool useAndLogic = true;
+    if (logicStr == "and") {
+        useAndLogic = true;
+    } else if (logicStr == "or") {
+        useAndLogic = false;
     } else {
-        std::cerr<<"Error: logic must be 'and' or 'or'.\n";
+        std::cerr << "Error: logic must be 'and' or 'or'.\n";
         return 1;
     }
     std::vector<FilterCriterion> criteria;
-    if(!parseCriteria(criteriaStr, criteria)){
-        std::cerr<<"Error: failed to parse criteria.\n";
+    if (!parseCriteria(criteriaStr, criteria)) {
+        std::cerr << "Error: failed to parse criteria.\n";
         return 1;
     }
     processVCF(std::cin, std::cout, criteria, useAndLogic);

--- a/src/VCFX_record_filter/VCFX_record_filter.h
+++ b/src/VCFX_record_filter/VCFX_record_filter.h
@@ -7,43 +7,34 @@
 
 // Operator kinds
 enum class FilterOp {
-    GT,  // >
-    GE,  // >=
-    LT,  // <
-    LE,  // <=
-    EQ,  // ==
-    NE   // !=
+    GT, // >
+    GE, // >=
+    LT, // <
+    LE, // <=
+    EQ, // ==
+    NE  // !=
 };
 
 // We store whether the field is numeric or string, as we do different compares
-enum class FieldType {
-    NUMERIC,
-    STRING
-};
+enum class FieldType { NUMERIC, STRING };
 
 // A single criterion: e.g. "POS > 100", or "FILTER == PASS", or "AF >= 0.1".
 struct FilterCriterion {
     std::string fieldName;
     FilterOp op;
-    double numericValue;    // used if fieldType==NUMERIC
-    std::string stringValue;// used if fieldType==STRING
+    double numericValue;     // used if fieldType==NUMERIC
+    std::string stringValue; // used if fieldType==STRING
     FieldType fieldType;
 };
 
 // parse multiple criteria from a single string (separated by semicolon)
-bool parseCriteria(const std::string &criteriaStr,
-                   std::vector<FilterCriterion> &criteria);
+bool parseCriteria(const std::string &criteriaStr, std::vector<FilterCriterion> &criteria);
 
 // apply the (AND/OR) logic to a single VCF line
-bool recordPasses(const std::string &record,
-                  const std::vector<FilterCriterion> &criteria,
-                  bool useAndLogic);
+bool recordPasses(const std::string &record, const std::vector<FilterCriterion> &criteria, bool useAndLogic);
 
 // read lines from 'in', filter, write pass lines to 'out'
-void processVCF(std::istream &in,
-                std::ostream &out,
-                const std::vector<FilterCriterion> &criteria,
-                bool useAndLogic);
+void processVCF(std::istream &in, std::ostream &out, const std::vector<FilterCriterion> &criteria, bool useAndLogic);
 
 // display usage
 void printHelp();

--- a/src/VCFX_ref_comparator/VCFX_ref_comparator.cpp
+++ b/src/VCFX_ref_comparator/VCFX_ref_comparator.cpp
@@ -1,97 +1,97 @@
-#include "vcfx_core.h"
 #include "VCFX_ref_comparator.h"
-#include <getopt.h>
-#include <fstream>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <vector>
 #include <cctype>
+#include <fstream>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <vector>
 
 // A small helper to remove whitespace
-static inline void stripSpaces(std::string &s){
-    s.erase(std::remove_if(s.begin(), s.end(),
-        [](unsigned char c){return std::isspace(c);}), s.end());
+static inline void stripSpaces(std::string &s) {
+    s.erase(std::remove_if(s.begin(), s.end(), [](unsigned char c) { return std::isspace(c); }), s.end());
 }
 
-int VCFXRefComparator::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXRefComparator::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
+    bool showHelp = false;
     std::string referencePath;
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"reference", required_argument, 0, 'r'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv,"hr:", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'r':
-                referencePath= optarg;
-                break;
-            default:
-                showHelp=true;
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'}, {"reference", required_argument, 0, 'r'}, {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hr:", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'r':
+            referencePath = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    if(referencePath.empty()){
-        std::cerr<<"Error: must specify --reference <FASTA>.\n";
+    if (referencePath.empty()) {
+        std::cerr << "Error: must specify --reference <FASTA>.\n";
         displayHelp();
         return 1;
     }
-    if(!loadReference(referencePath)){
-        std::cerr<<"Error: failed to load reference from "<< referencePath<<"\n";
+    if (!loadReference(referencePath)) {
+        std::cerr << "Error: failed to load reference from " << referencePath << "\n";
         return 1;
     }
     compareVCF(std::cin, std::cout);
     return 0;
 }
 
-void VCFXRefComparator::displayHelp(){
-    std::cout <<
-"VCFX_ref_comparator: Compare VCF REF/ALT with a reference genome.\n\n"
-"Usage:\n"
-"  VCFX_ref_comparator --reference ref.fasta < input.vcf > output.vcf\n\n"
-"Description:\n"
-"  Reads a reference FASTA into memory. Then reads each variant line:\n"
-"   - If chromosome or position is invalid, logs a warning and sets REF_COMPARISON=UNKNOWN_CHROM or INVALID_POS.\n"
-"   - Otherwise, compares the VCF's REF vs the reference substring. Then for each ALT, indicates 'REF_MATCH' if ALT= reference substring or 'NOVEL'.\n"
-"  The result is appended to the 'INFO' field as REF_COMPARISON=...\n\n"
-"Example:\n"
-"  VCFX_ref_comparator --reference genome.fa < in.vcf > out.vcf\n";
+void VCFXRefComparator::displayHelp() {
+    std::cout << "VCFX_ref_comparator: Compare VCF REF/ALT with a reference genome.\n\n"
+                 "Usage:\n"
+                 "  VCFX_ref_comparator --reference ref.fasta < input.vcf > output.vcf\n\n"
+                 "Description:\n"
+                 "  Reads a reference FASTA into memory. Then reads each variant line:\n"
+                 "   - If chromosome or position is invalid, logs a warning and sets REF_COMPARISON=UNKNOWN_CHROM or "
+                 "INVALID_POS.\n"
+                 "   - Otherwise, compares the VCF's REF vs the reference substring. Then for each ALT, indicates "
+                 "'REF_MATCH' if ALT= reference substring or 'NOVEL'.\n"
+                 "  The result is appended to the 'INFO' field as REF_COMPARISON=...\n\n"
+                 "Example:\n"
+                 "  VCFX_ref_comparator --reference genome.fa < in.vcf > out.vcf\n";
 }
 
-bool VCFXRefComparator::loadReference(const std::string &referenceFastaPath){
+bool VCFXRefComparator::loadReference(const std::string &referenceFastaPath) {
     std::ifstream in(referenceFastaPath);
-    if(!in.is_open()){
-        std::cerr<<"Error: cannot open reference "<< referenceFastaPath<<"\n";
+    if (!in.is_open()) {
+        std::cerr << "Error: cannot open reference " << referenceFastaPath << "\n";
         return false;
     }
     referenceGenome.clear();
     std::string line, currentChrom;
     std::ostringstream seq;
-    while(true){
-        if(!std::getline(in, line)) break;
-        if(line.empty()) continue;
-        if(line[0]=='>'){
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty())
+            continue;
+        if (line[0] == '>') {
             // store old chrom
-            if(!currentChrom.empty()){
+            if (!currentChrom.empty()) {
                 referenceGenome[currentChrom] = seq.str();
             }
             seq.str("");
             seq.clear();
             // parse new chrom
-            currentChrom= line.substr(1);
+            currentChrom = line.substr(1);
             // if there's whitespace, strip it after first token
             {
                 std::istringstream iss(currentChrom);
@@ -102,42 +102,44 @@ bool VCFXRefComparator::loadReference(const std::string &referenceFastaPath){
         } else {
             stripSpaces(line);
             std::transform(line.begin(), line.end(), line.begin(), ::toupper);
-            seq<< line;
+            seq << line;
         }
     }
-    if(!currentChrom.empty()){
-        referenceGenome[currentChrom]= seq.str();
+    if (!currentChrom.empty()) {
+        referenceGenome[currentChrom] = seq.str();
     }
     return true;
 }
 
-void VCFXRefComparator::compareVCF(std::istream &vcfIn, std::ostream &vcfOut){
-    bool foundChromHeader=false;
-    infoHeaderInserted= false;
+void VCFXRefComparator::compareVCF(std::istream &vcfIn, std::ostream &vcfOut) {
+    bool foundChromHeader = false;
+    infoHeaderInserted = false;
     std::string line;
-    while(true){
-        if(!std::getline(vcfIn, line)) break;
-        if(line.empty()){
-            vcfOut<< line <<"\n";
+    while (true) {
+        if (!std::getline(vcfIn, line))
+            break;
+        if (line.empty()) {
+            vcfOut << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
+        if (line[0] == '#') {
             // check if #CHROM
-            if(line.rfind("#CHROM",0)==0){
-                foundChromHeader= true;
+            if (line.rfind("#CHROM", 0) == 0) {
+                foundChromHeader = true;
                 // Insert new INFO line BEFORE we write #CHROM
-                if(!infoHeaderInserted){
-                    vcfOut<<"##INFO=<ID=REF_COMPARISON,Number=1,Type=String,Description=\"Comparison of REF/ALT vs reference genome substring\">\n";
-                    infoHeaderInserted=true;
+                if (!infoHeaderInserted) {
+                    vcfOut << "##INFO=<ID=REF_COMPARISON,Number=1,Type=String,Description=\"Comparison of REF/ALT vs "
+                              "reference genome substring\">\n";
+                    infoHeaderInserted = true;
                 }
-                vcfOut<< line<<"\n";
+                vcfOut << line << "\n";
             } else {
-                vcfOut<< line<<"\n";
+                vcfOut << line << "\n";
             }
             continue;
         }
-        if(!foundChromHeader){
-            std::cerr<<"Warning: data line encountered before #CHROM => skipping.\n";
+        if (!foundChromHeader) {
+            std::cerr << "Warning: data line encountered before #CHROM => skipping.\n";
             continue;
         }
         // parse fields
@@ -145,138 +147,156 @@ void VCFXRefComparator::compareVCF(std::istream &vcfIn, std::ostream &vcfOut){
         std::vector<std::string> fields;
         {
             std::string col;
-            while(std::getline(ss,col,'\t')){
+            while (std::getline(ss, col, '\t')) {
                 fields.push_back(col);
             }
         }
-        if(fields.size()<8){
-            std::cerr<<"Warning: VCF line has <8 columns => skipping.\n";
+        if (fields.size() < 8) {
+            std::cerr << "Warning: VCF line has <8 columns => skipping.\n";
             continue;
         }
         // fields: 0=CHROM,1=POS,2=ID,3=REF,4=ALT,5=QUAL,6=FILTER,7=INFO,...
-        std::string &chrom= fields[0];
-        std::string &posStr= fields[1];
-        std::string &ref= fields[3];
-        std::string &alt= fields[4];
-        std::string &info= fields[7];
+        std::string &chrom = fields[0];
+        std::string &posStr = fields[1];
+        std::string &ref = fields[3];
+        std::string &alt = fields[4];
+        std::string &info = fields[7];
 
         // uppercase chrom
         std::transform(chrom.begin(), chrom.end(), chrom.begin(), ::toupper);
 
-        int pos=0;
-        try{
-            pos= std::stoi(posStr);
-        }catch(...){
+        int pos = 0;
+        try {
+            pos = std::stoi(posStr);
+        } catch (...) {
             // out of range
-            if(!info.empty() && info.back()!=';') info+=';';
-            info+= "REF_COMPARISON=INVALID_POS";
+            if (!info.empty() && info.back() != ';')
+                info += ';';
+            info += "REF_COMPARISON=INVALID_POS";
             // rewrite
             std::ostringstream newLine;
-            for(int i=0; i<7; i++){
-                newLine<< fields[i];
-                if(i<7) newLine<<"\t";
+            for (int i = 0; i < 7; i++) {
+                newLine << fields[i];
+                if (i < 7)
+                    newLine << "\t";
             }
-            newLine<< info;
-            for(size_t i=8; i<fields.size(); i++){
-                newLine<<"\t"<< fields[i];
+            newLine << info;
+            for (size_t i = 8; i < fields.size(); i++) {
+                newLine << "\t" << fields[i];
             }
-            vcfOut<< newLine.str()<<"\n";
+            vcfOut << newLine.str() << "\n";
             continue;
         }
         // find reference
-        auto it= referenceGenome.find(chrom);
-        if(it== referenceGenome.end()){
+        auto it = referenceGenome.find(chrom);
+        if (it == referenceGenome.end()) {
             // unknown chrom
-            if(!info.empty() && info.back()!=';') info+=';';
-            info+= "REF_COMPARISON=UNKNOWN_CHROM";
+            if (!info.empty() && info.back() != ';')
+                info += ';';
+            info += "REF_COMPARISON=UNKNOWN_CHROM";
             // rewrite
             std::ostringstream newLine;
-            for(int i=0; i<7; i++){
-                newLine<< fields[i];
-                if(i<7) newLine<<"\t";
+            for (int i = 0; i < 7; i++) {
+                newLine << fields[i];
+                if (i < 7)
+                    newLine << "\t";
             }
-            newLine<< info;
-            for(size_t i=8; i<fields.size(); i++){
-                newLine<<"\t"<< fields[i];
+            newLine << info;
+            for (size_t i = 8; i < fields.size(); i++) {
+                newLine << "\t" << fields[i];
             }
-            vcfOut<< newLine.str()<<"\n";
+            vcfOut << newLine.str() << "\n";
             continue;
         }
-        const std::string &seq= it->second;
-        if(pos<1 || pos>(int)seq.size()){
+        const std::string &seq = it->second;
+        if (pos < 1 || pos > (int)seq.size()) {
             // invalid pos
-            if(!info.empty() && info.back()!=';') info+=';';
-            info+= "REF_COMPARISON=INVALID_POS";
+            if (!info.empty() && info.back() != ';')
+                info += ';';
+            info += "REF_COMPARISON=INVALID_POS";
             // rewrite
             std::ostringstream newLine;
-            for(int i=0; i<7; i++){
-                newLine<< fields[i];
-                if(i<7) newLine<<"\t";
+            for (int i = 0; i < 7; i++) {
+                newLine << fields[i];
+                if (i < 7)
+                    newLine << "\t";
             }
-            newLine<< info;
-            for(size_t i=8; i<fields.size(); i++){
-                newLine<<"\t"<< fields[i];
+            newLine << info;
+            for (size_t i = 8; i < fields.size(); i++) {
+                newLine << "\t" << fields[i];
             }
-            vcfOut<< newLine.str()<<"\n";
+            vcfOut << newLine.str() << "\n";
             continue;
         }
         // ref from genome
-        std::string genomeRef= seq.substr(pos-1, ref.size()); // 1-based
+        std::string genomeRef = seq.substr(pos - 1, ref.size()); // 1-based
         // uppercase
         std::transform(ref.begin(), ref.end(), ref.begin(), ::toupper);
 
         // compare ref vs genomeRef
-        bool refMatch= (ref== genomeRef);
+        bool refMatch = (ref == genomeRef);
 
         // split alt by comma
         std::vector<std::string> altAlleles;
         {
             std::stringstream as(alt);
             std::string a;
-            while(std::getline(as,a,',')){
+            while (std::getline(as, a, ',')) {
                 std::transform(a.begin(), a.end(), a.begin(), ::toupper);
                 altAlleles.push_back(a);
             }
         }
         // for each alt, see if alt== genomeRef => "REF_MATCH" else "NOVEL"
         std::vector<std::string> comparisons;
-        for(auto &a: altAlleles){
-            if(a== genomeRef) comparisons.push_back("REF_MATCH");
-            else comparisons.push_back("NOVEL");
+        for (auto &a : altAlleles) {
+            if (a == genomeRef)
+                comparisons.push_back("REF_MATCH");
+            else
+                comparisons.push_back("NOVEL");
         }
         // build comparisonStr
         std::string comparisonStr;
-        for(size_t i=0; i< comparisons.size(); i++){
-            if(i>0) comparisonStr+=",";
-            comparisonStr+= comparisons[i];
+        for (size_t i = 0; i < comparisons.size(); i++) {
+            if (i > 0)
+                comparisonStr += ",";
+            comparisonStr += comparisons[i];
         }
-        if(!info.empty() && info.back()!=';') info+=';';
+        if (!info.empty() && info.back() != ';')
+            info += ';';
         // e.g. "REF_COMPARISON=REF_MATCH,REF_MATCH" or "NOVEL" etc.
-        if(!refMatch){
+        if (!refMatch) {
             // optionally label mismatch => we won't specifically do that
             // the alt status is in the comparisons
         }
-        info+= "REF_COMPARISON=" + comparisonStr;
+        info += "REF_COMPARISON=" + comparisonStr;
 
         // rebuild line
         std::ostringstream outLine;
-        for(int i=0;i<7;i++){
-            outLine<< fields[i];
-            if(i<6) outLine<<"\t";  // Changed from i<7 to i<6 to avoid adding an extra tab after FILTER
+        for (int i = 0; i < 7; i++) {
+            outLine << fields[i];
+            if (i < 6)
+                outLine << "\t"; // Changed from i<7 to i<6 to avoid adding an extra tab after FILTER
         }
-        outLine<<"\t"<< info;  // Add tab after FILTER, then add INFO without spaces
+        outLine << "\t" << info; // Add tab after FILTER, then add INFO without spaces
         // any other columns
-        for(size_t i=8; i< fields.size(); i++){
-            outLine<<"\t"<< fields[i];
+        for (size_t i = 8; i < fields.size(); i++) {
+            outLine << "\t" << fields[i];
         }
-        vcfOut<< outLine.str()<<"\n";
+        vcfOut << outLine.str() << "\n";
     }
 }
 
-static void show_help() { VCFXRefComparator obj; char arg0[] = "VCFX_ref_comparator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXRefComparator obj;
+    char arg0[] = "VCFX_ref_comparator";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_ref_comparator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_ref_comparator", show_help))
+        return 0;
     VCFXRefComparator refComp;
     return refComp.run(argc, argv);
 }

--- a/src/VCFX_ref_comparator/VCFX_ref_comparator.h
+++ b/src/VCFX_ref_comparator/VCFX_ref_comparator.h
@@ -6,10 +6,10 @@
 #include <unordered_map>
 
 class VCFXRefComparator {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
     bool loadReference(const std::string &referenceFastaPath);
     void compareVCF(std::istream &vcfIn, std::ostream &vcfOut);

--- a/src/VCFX_reformatter/VCFX_reformatter.cpp
+++ b/src/VCFX_reformatter/VCFX_reformatter.cpp
@@ -1,206 +1,209 @@
-#include "vcfx_core.h"
 #include "VCFX_reformatter.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <vector>
-#include <string>
 #include <cctype>
-#include <unordered_set>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 // Helper to trim whitespace
-static std::string trim(const std::string &s){
-    size_t start=0; while(start<s.size() && isspace((unsigned char)s[start])) start++;
-    if(start== s.size()) return "";
-    size_t end= s.size()-1; 
-    while(end>start && isspace((unsigned char)s[end])) end--;
-    return s.substr(start, end-start+1);
+static std::string trim(const std::string &s) {
+    size_t start = 0;
+    while (start < s.size() && isspace((unsigned char)s[start]))
+        start++;
+    if (start == s.size())
+        return "";
+    size_t end = s.size() - 1;
+    while (end > start && isspace((unsigned char)s[end]))
+        end--;
+    return s.substr(start, end - start + 1);
 }
 
 // Splits a string by a delimiter into tokens
-static void split(const std::string &s, char d, std::vector<std::string> &out){
+static void split(const std::string &s, char d, std::vector<std::string> &out) {
     out.clear();
     std::stringstream ss(s);
     std::string t;
-    while(std::getline(ss,t,d)){
+    while (std::getline(ss, t, d)) {
         out.push_back(t);
     }
 }
 
-int VCFXReformatter::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXReformatter::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
+    bool showHelp = false;
     std::vector<std::string> compressInfoFields;
     std::vector<std::string> compressFormatFields;
     std::vector<std::string> reorderInfoFields;
     std::vector<std::string> reorderFormatFields;
 
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"compress-info", required_argument, 0, 'c'},
-        {"compress-format", required_argument, 0, 'f'},
-        {"reorder-info", required_argument, 0, 'i'},
-        {"reorder-format", required_argument, 0, 'o'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv, "hc:f:i:o:", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'c': {
-                // parse comma-separated
-                std::stringstream ss(optarg);
-                std::string val;
-                while(std::getline(ss,val,',')){
-                    val= trim(val);
-                    if(!val.empty()) compressInfoFields.push_back(val);
-                }
-            }break;
-            case 'f': {
-                std::stringstream ss(optarg);
-                std::string val;
-                while(std::getline(ss,val,',')){
-                    val=trim(val);
-                    if(!val.empty()) compressFormatFields.push_back(val);
-                }
-            }break;
-            case 'i': {
-                std::stringstream ss(optarg);
-                std::string val;
-                while(std::getline(ss,val,',')){
-                    val=trim(val);
-                    if(!val.empty()) reorderInfoFields.push_back(val);
-                }
-            }break;
-            case 'o': {
-                std::stringstream ss(optarg);
-                std::string val;
-                while(std::getline(ss,val,',')){
-                    val= trim(val);
-                    if(!val.empty()) reorderFormatFields.push_back(val);
-                }
-            }break;
-            default:
-                showHelp=true;
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"compress-info", required_argument, 0, 'c'},
+                                        {"compress-format", required_argument, 0, 'f'},
+                                        {"reorder-info", required_argument, 0, 'i'},
+                                        {"reorder-format", required_argument, 0, 'o'},
+                                        {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hc:f:i:o:", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'c': {
+            // parse comma-separated
+            std::stringstream ss(optarg);
+            std::string val;
+            while (std::getline(ss, val, ',')) {
+                val = trim(val);
+                if (!val.empty())
+                    compressInfoFields.push_back(val);
+            }
+        } break;
+        case 'f': {
+            std::stringstream ss(optarg);
+            std::string val;
+            while (std::getline(ss, val, ',')) {
+                val = trim(val);
+                if (!val.empty())
+                    compressFormatFields.push_back(val);
+            }
+        } break;
+        case 'i': {
+            std::stringstream ss(optarg);
+            std::string val;
+            while (std::getline(ss, val, ',')) {
+                val = trim(val);
+                if (!val.empty())
+                    reorderInfoFields.push_back(val);
+            }
+        } break;
+        case 'o': {
+            std::stringstream ss(optarg);
+            std::string val;
+            while (std::getline(ss, val, ',')) {
+                val = trim(val);
+                if (!val.empty())
+                    reorderFormatFields.push_back(val);
+            }
+        } break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    reformatVCF(std::cin, std::cout, 
-                compressInfoFields, 
-                compressFormatFields,
-                reorderInfoFields, 
-                reorderFormatFields);
+    reformatVCF(std::cin, std::cout, compressInfoFields, compressFormatFields, reorderInfoFields, reorderFormatFields);
     return 0;
 }
 
-void VCFXReformatter::displayHelp(){
-    std::cout <<
-"VCFX_reformatter: Reformat INFO/FORMAT fields in a VCF.\n\n"
-"Usage:\n"
-"  VCFX_reformatter [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -h, --help                     Show this help.\n"
-"  -c, --compress-info <keys>     Remove these INFO keys, comma-separated.\n"
-"  -f, --compress-format <keys>   Remove these FORMAT keys, comma-separated.\n"
-"  -i, --reorder-info <keys>      Reorder these INFO keys at the front, leftover appended.\n"
-"  -o, --reorder-format <keys>    Reorder these FORMAT keys at the front, leftover appended.\n\n"
-"Example:\n"
-"  VCFX_reformatter --compress-info AF,DP --reorder-info AF,DP < in.vcf > out.vcf\n"
-"Description:\n"
-"  This tool modifies data lines:\n"
-"   * 'compress-info': remove specified keys from the semicolon INFO field.\n"
-"   * 'compress-format': remove specified keys from the colon FORMAT field,\n"
-"      and also remove them from each sample's subfield.\n"
-"   * 'reorder-info': place specified keys in that order at the front, then\n"
-"      append leftover keys in the order encountered.\n"
-"   * 'reorder-format': reorder the FORMAT colon-delimited keys in #8 col,\n"
-"      then reorder each sample's subfields accordingly.\n"
-"  Lines with <8 columns are skipped with a warning. Header lines (#) are\n"
-"  passed unmodified.\n";
+void VCFXReformatter::displayHelp() {
+    std::cout << "VCFX_reformatter: Reformat INFO/FORMAT fields in a VCF.\n\n"
+                 "Usage:\n"
+                 "  VCFX_reformatter [options] < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help                     Show this help.\n"
+                 "  -c, --compress-info <keys>     Remove these INFO keys, comma-separated.\n"
+                 "  -f, --compress-format <keys>   Remove these FORMAT keys, comma-separated.\n"
+                 "  -i, --reorder-info <keys>      Reorder these INFO keys at the front, leftover appended.\n"
+                 "  -o, --reorder-format <keys>    Reorder these FORMAT keys at the front, leftover appended.\n\n"
+                 "Example:\n"
+                 "  VCFX_reformatter --compress-info AF,DP --reorder-info AF,DP < in.vcf > out.vcf\n"
+                 "Description:\n"
+                 "  This tool modifies data lines:\n"
+                 "   * 'compress-info': remove specified keys from the semicolon INFO field.\n"
+                 "   * 'compress-format': remove specified keys from the colon FORMAT field,\n"
+                 "      and also remove them from each sample's subfield.\n"
+                 "   * 'reorder-info': place specified keys in that order at the front, then\n"
+                 "      append leftover keys in the order encountered.\n"
+                 "   * 'reorder-format': reorder the FORMAT colon-delimited keys in #8 col,\n"
+                 "      then reorder each sample's subfields accordingly.\n"
+                 "  Lines with <8 columns are skipped with a warning. Header lines (#) are\n"
+                 "  passed unmodified.\n";
 }
 
 void VCFXReformatter::reformatVCF(std::istream &in, std::ostream &out,
                                   const std::vector<std::string> &compressInfoFields,
                                   const std::vector<std::string> &compressFormatFields,
                                   const std::vector<std::string> &reorderInfoFields,
-                                  const std::vector<std::string> &reorderFormatFields)
-{
+                                  const std::vector<std::string> &reorderFormatFields) {
     // We'll store them in sets for faster removal checks
     std::unordered_set<std::string> infoToRemove(compressInfoFields.begin(), compressInfoFields.end());
     std::unordered_set<std::string> formatToRemove(compressFormatFields.begin(), compressFormatFields.end());
 
-    bool foundChrom=false;
+    bool foundChrom = false;
     std::string line;
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
-            out<< line <<"\n";
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
-            out<< line <<"\n";
-            if(line.rfind("#CHROM",0)==0) foundChrom=true;
+        if (line[0] == '#') {
+            out << line << "\n";
+            if (line.rfind("#CHROM", 0) == 0)
+                foundChrom = true;
             continue;
         }
-        if(!foundChrom){
-            std::cerr<<"Warning: data line before #CHROM => skipping.\n";
+        if (!foundChrom) {
+            std::cerr << "Warning: data line before #CHROM => skipping.\n";
             continue;
         }
         std::vector<std::string> fields;
         {
             std::stringstream ss(line);
             std::string col;
-            while(std::getline(ss,col,'\t')){
+            while (std::getline(ss, col, '\t')) {
                 fields.push_back(col);
             }
         }
-        if(fields.size()<8){
-            std::cerr<<"Warning: line with <8 columns => skipping.\n";
+        if (fields.size() < 8) {
+            std::cerr << "Warning: line with <8 columns => skipping.\n";
             continue;
         }
-        std::string &infoField= fields[7];
+        std::string &infoField = fields[7];
         // compress info
-        if(!infoToRemove.empty() && !infoField.empty() && infoField!="."){
-            infoField= compressInfo(infoField, infoToRemove);
+        if (!infoToRemove.empty() && !infoField.empty() && infoField != ".") {
+            infoField = compressInfo(infoField, infoToRemove);
         }
         // reorder info
-        if(!reorderInfoFields.empty() && !infoField.empty() && infoField!="."){
-            infoField= reorderInfo(infoField, reorderInfoFields);
+        if (!reorderInfoFields.empty() && !infoField.empty() && infoField != ".") {
+            infoField = reorderInfo(infoField, reorderInfoFields);
         }
 
         // if there's format => fields.size() might be >=9
-        if(fields.size()>8){
+        if (fields.size() > 8) {
             // compress format
-            std::string &formatField= fields[8];
-            if(!formatField.empty() && formatField!="."){
+            std::string &formatField = fields[8];
+            if (!formatField.empty() && formatField != ".") {
                 // remove keys
                 std::vector<int> keepIndices;
-                if(!formatToRemove.empty()){
-                    formatField= compressFormat(formatField, formatToRemove, keepIndices);
+                if (!formatToRemove.empty()) {
+                    formatField = compressFormat(formatField, formatToRemove, keepIndices);
                 } else {
                     // if not removing anything, keep all
                     std::vector<std::string> fsplit;
                     split(formatField, ':', fsplit);
                     keepIndices.resize(fsplit.size());
-                    for(size_t i=0;i<fsplit.size();i++){
-                        keepIndices[i]=(int)i;
+                    for (size_t i = 0; i < fsplit.size(); i++) {
+                        keepIndices[i] = (int)i;
                     }
                 }
                 // reorder format
-                if(!reorderFormatFields.empty() && !formatField.empty() && formatField!="."){
+                if (!reorderFormatFields.empty() && !formatField.empty() && formatField != ".") {
                     std::vector<int> newIndices;
-                    formatField= reorderFormat(formatField, reorderFormatFields, newIndices);
+                    formatField = reorderFormat(formatField, reorderFormatFields, newIndices);
                     // apply new reorder to keepIndices
                     // we now want to chain keepIndices -> newIndices
                     // but if keepIndices had removed some, we must unify
@@ -208,263 +211,285 @@ void VCFXReformatter::reformatVCF(std::istream &in, std::ostream &out,
                     // newIndices has size = final # of keys
                     // each newIndices[i] => oldIndex
                     // but that oldIndex references the 'kept' keys from the original?
-                    // Actually let's do a simpler approach: we do reorder first, then compress second. 
+                    // Actually let's do a simpler approach: we do reorder first, then compress second.
                     // But we do the user-specified approach in the order we coded => let's keep it.
-                    // We'll do: if we reorder after compress, we must reorder the 'formatField' that came from compress, 
-                    // but that's fine. We'll just do the reorder ignoring keepIndices for now.
+                    // We'll do: if we reorder after compress, we must reorder the 'formatField' that came from
+                    // compress, but that's fine. We'll just do the reorder ignoring keepIndices for now.
                     keepIndices.clear();
                     // We must re-split the formatField to see how many remain
                     std::vector<std::string> finalFmtSplit;
-                    split(formatField,':', finalFmtSplit);
+                    split(formatField, ':', finalFmtSplit);
                     keepIndices.resize(finalFmtSplit.size());
-                    for(size_t i=0;i< finalFmtSplit.size(); i++){
-                        keepIndices[i]= (int)i; 
+                    for (size_t i = 0; i < finalFmtSplit.size(); i++) {
+                        keepIndices[i] = (int)i;
                     }
                 }
 
                 // Now we must apply the final format structure to each sample
-                for(size_t sampleI=9; sampleI< fields.size(); sampleI++){
-                    fields[sampleI]= applyFormatReorderToSample(fields[sampleI], /*currently we do not reorder again*/ keepIndices);
+                for (size_t sampleI = 9; sampleI < fields.size(); sampleI++) {
+                    fields[sampleI] =
+                        applyFormatReorderToSample(fields[sampleI], /*currently we do not reorder again*/ keepIndices);
                 }
             }
         }
         // rebuild line
         std::ostringstream oss;
-        for(size_t i=0; i<fields.size(); i++){
-            if(i>0) oss<<"\t";
-            oss<< fields[i];
+        for (size_t i = 0; i < fields.size(); i++) {
+            if (i > 0)
+                oss << "\t";
+            oss << fields[i];
         }
-        out<< oss.str()<<"\n";
+        out << oss.str() << "\n";
     }
 }
 
 std::string VCFXReformatter::compressInfo(const std::string &infoStr,
-                                         const std::unordered_set<std::string> &keysToRemove)
-{
-    if(infoStr=="."|| infoStr.empty()) return infoStr;
+                                          const std::unordered_set<std::string> &keysToRemove) {
+    if (infoStr == "." || infoStr.empty())
+        return infoStr;
     std::vector<std::string> tokens;
     split(infoStr, ';', tokens);
     std::vector<std::string> keep;
-    for(auto &kv : tokens){
-        if(kv.empty()) continue;
+    for (auto &kv : tokens) {
+        if (kv.empty())
+            continue;
         // parse key=...
-        auto eq= kv.find('=');
-        if(eq== std::string::npos){
+        auto eq = kv.find('=');
+        if (eq == std::string::npos) {
             // flag
-            if(keysToRemove.count(kv)==0){
+            if (keysToRemove.count(kv) == 0) {
                 keep.push_back(kv);
             }
         } else {
-            std::string k= kv.substr(0,eq);
-            if(keysToRemove.count(k)==0){
+            std::string k = kv.substr(0, eq);
+            if (keysToRemove.count(k) == 0) {
                 keep.push_back(kv);
             }
         }
     }
-    if(keep.empty()) return ".";
+    if (keep.empty())
+        return ".";
     std::ostringstream oss;
-    for(size_t i=0; i< keep.size(); i++){
-        if(i>0) oss<<";";
-        oss<< keep[i];
+    for (size_t i = 0; i < keep.size(); i++) {
+        if (i > 0)
+            oss << ";";
+        oss << keep[i];
     }
     return oss.str();
 }
 
 // remove keys from format column => rebuild format => store the indices of the keys we keep in keepIndices
 std::string VCFXReformatter::compressFormat(const std::string &formatStr,
-                                           const std::unordered_set<std::string> &keysToRemove,
-                                           std::vector<int> &keepIndices)
-{
-    if(formatStr=="."||formatStr.empty()){
-        keepIndices.clear(); 
+                                            const std::unordered_set<std::string> &keysToRemove,
+                                            std::vector<int> &keepIndices) {
+    if (formatStr == "." || formatStr.empty()) {
+        keepIndices.clear();
         return formatStr;
     }
     std::vector<std::string> keys;
-    split(formatStr,':', keys);
+    split(formatStr, ':', keys);
     keepIndices.clear();
-    for(size_t i=0;i<keys.size();i++){
-        if(keysToRemove.count(keys[i])==0){
+    for (size_t i = 0; i < keys.size(); i++) {
+        if (keysToRemove.count(keys[i]) == 0) {
             keepIndices.push_back((int)i);
         }
     }
-    if(keepIndices.empty()) return "."; 
+    if (keepIndices.empty())
+        return ".";
     // rebuild
     std::ostringstream oss;
-    bool first=true;
-    for(size_t i=0;i< keepIndices.size(); i++){
-        if(!first) oss<<":";
-        else first=false;
-        oss<< keys[ keepIndices[i] ];
+    bool first = true;
+    for (size_t i = 0; i < keepIndices.size(); i++) {
+        if (!first)
+            oss << ":";
+        else
+            first = false;
+        oss << keys[keepIndices[i]];
     }
     return oss.str();
 }
 
-std::string VCFXReformatter::reorderInfo(const std::string &infoStr, 
-                                         const std::vector<std::string> &order)
-{
-    if(infoStr=="."|| infoStr.empty()) return infoStr;
+std::string VCFXReformatter::reorderInfo(const std::string &infoStr, const std::vector<std::string> &order) {
+    if (infoStr == "." || infoStr.empty())
+        return infoStr;
     std::vector<std::string> tokens;
-    split(infoStr,';', tokens);
+    split(infoStr, ';', tokens);
     // parse into map + remember original order
-    std::unordered_map<std::string,std::string> kvMap;
+    std::unordered_map<std::string, std::string> kvMap;
     std::vector<std::string> originalKeys;
-    for(auto &item: tokens){
-        if(item.empty()) continue;
-        auto eq= item.find('=');
-        if(eq==std::string::npos){
+    for (auto &item : tokens) {
+        if (item.empty())
+            continue;
+        auto eq = item.find('=');
+        if (eq == std::string::npos) {
             // flag
-            kvMap[item]="";
+            kvMap[item] = "";
             originalKeys.push_back(item);
         } else {
-            std::string k= item.substr(0,eq);
-            std::string v= item.substr(eq+1);
-            kvMap[k]= v;
+            std::string k = item.substr(0, eq);
+            std::string v = item.substr(eq + 1);
+            kvMap[k] = v;
             originalKeys.push_back(k);
         }
     }
     // build new list
     std::vector<std::string> result;
     // 1) add items from 'order' if exist in kvMap
-    for(auto &k : order){
-        auto it= kvMap.find(k);
-        if(it!= kvMap.end()){
-            if(it->second==""){
+    for (auto &k : order) {
+        auto it = kvMap.find(k);
+        if (it != kvMap.end()) {
+            if (it->second == "") {
                 result.push_back(k); // flag
             } else {
-                result.push_back(k+"="+ it->second);
+                result.push_back(k + "=" + it->second);
             }
             kvMap.erase(it);
         }
     }
     // 2) append leftover in original order
-    for(auto &k: originalKeys){
-        auto it= kvMap.find(k);
-        if(it!= kvMap.end()){
-            if(it->second==""){
+    for (auto &k : originalKeys) {
+        auto it = kvMap.find(k);
+        if (it != kvMap.end()) {
+            if (it->second == "") {
                 result.push_back(k);
             } else {
-                result.push_back(k+"="+ it->second);
+                result.push_back(k + "=" + it->second);
             }
             kvMap.erase(it);
         }
     }
-    if(result.empty()) return ".";
+    if (result.empty())
+        return ".";
     // join
     std::ostringstream oss;
-    for(size_t i=0;i< result.size(); i++){
-        if(i>0) oss<<";";
-        oss<< result[i];
+    for (size_t i = 0; i < result.size(); i++) {
+        if (i > 0)
+            oss << ";";
+        oss << result[i];
     }
     return oss.str();
 }
 
-std::string VCFXReformatter::reorderFormat(const std::string &fmtStr,
-                                          const std::vector<std::string> &order,
-                                          std::vector<int> &oldToNew)
-{
-    if(fmtStr=="."|| fmtStr.empty()){
+std::string VCFXReformatter::reorderFormat(const std::string &fmtStr, const std::vector<std::string> &order,
+                                           std::vector<int> &oldToNew) {
+    if (fmtStr == "." || fmtStr.empty()) {
         oldToNew.clear();
         return fmtStr;
     }
     std::vector<std::string> keys;
-    split(fmtStr,':', keys);
+    split(fmtStr, ':', keys);
     // build result
     std::vector<std::string> newOrder;
     newOrder.reserve(keys.size());
     oldToNew.assign(keys.size(), -1); // -1 => removed
 
     // first place the requested keys in order
-    int usedCount=0;
+    int usedCount = 0;
     // keep track of which old indices are used
     std::vector<bool> used(keys.size(), false);
 
     // For each key in 'order', see if we find it in keys
-    for(auto &k : order){
-        auto it= std::find(keys.begin(), keys.end(), k);
-        if(it!= keys.end()){
-            int oldI= (int)std::distance(keys.begin(), it);
+    for (auto &k : order) {
+        auto it = std::find(keys.begin(), keys.end(), k);
+        if (it != keys.end()) {
+            int oldI = (int)std::distance(keys.begin(), it);
             newOrder.push_back(k);
-            oldToNew[oldI]= usedCount;
+            oldToNew[oldI] = usedCount;
             usedCount++;
-            used[oldI]=true;
+            used[oldI] = true;
         }
     }
     // then append leftover in original order
-    for(int i=0; i<(int)keys.size(); i++){
-        if(!used[i]){
+    for (int i = 0; i < (int)keys.size(); i++) {
+        if (!used[i]) {
             newOrder.push_back(keys[i]);
-            oldToNew[i]= usedCount;
+            oldToNew[i] = usedCount;
             usedCount++;
         }
     }
     // build final string
-    if(newOrder.empty()) {
+    if (newOrder.empty()) {
         oldToNew.clear();
         return ".";
     }
     std::ostringstream oss;
-    for(size_t i=0;i< newOrder.size(); i++){
-        if(i>0) oss<<":";
-        oss<< newOrder[i];
+    for (size_t i = 0; i < newOrder.size(); i++) {
+        if (i > 0)
+            oss << ":";
+        oss << newOrder[i];
     }
     return oss.str();
 }
 
 // We reorder or remove subfields in each sample column
 std::string VCFXReformatter::applyFormatReorderToSample(const std::string &sampleStr,
-                                                        const std::vector<int> &oldToNew)
-{
+                                                        const std::vector<int> &oldToNew) {
     // if oldToNew is empty, means format is "." => no sample data
-    if(oldToNew.empty()){
-        return sampleStr; 
+    if (oldToNew.empty()) {
+        return sampleStr;
     }
-    if(sampleStr=="."|| sampleStr.empty()) return sampleStr;
+    if (sampleStr == "." || sampleStr.empty())
+        return sampleStr;
     std::vector<std::string> subs;
     split(sampleStr, ':', subs);
     // build a new list of same length as oldToNew, initially "."
     // if oldToNew[i] < 0 => that subfield is removed
     // else => newIndex= oldToNew[i]
     // we want final vector with size = maxIndex+1
-    int maxIndex= -1;
-    for(auto idx: oldToNew){
-        if(idx> maxIndex) maxIndex= idx;
+    int maxIndex = -1;
+    for (auto idx : oldToNew) {
+        if (idx > maxIndex)
+            maxIndex = idx;
     }
-    if(maxIndex<0) {
+    if (maxIndex < 0) {
         // means everything removed
-        return "."; 
+        return ".";
     }
-    std::vector<std::string> newSubs(maxIndex+1, ".");
-    for(int oldI=0; oldI<(int)subs.size() && oldI<(int)oldToNew.size(); oldI++){
-        int ni= oldToNew[oldI];
-        if(ni>=0){
-            if((size_t)oldI< subs.size()){
-                newSubs[ni]= subs[oldI];
+    std::vector<std::string> newSubs(maxIndex + 1, ".");
+    for (int oldI = 0; oldI < (int)subs.size() && oldI < (int)oldToNew.size(); oldI++) {
+        int ni = oldToNew[oldI];
+        if (ni >= 0) {
+            if ((size_t)oldI < subs.size()) {
+                newSubs[ni] = subs[oldI];
             } else {
-                newSubs[ni]=".";
+                newSubs[ni] = ".";
             }
         }
     }
     // if all are "." => return "."
-    bool allDot=true;
-    for(auto &x: newSubs){
-        if(x!=".") { allDot=false; break;}
+    bool allDot = true;
+    for (auto &x : newSubs) {
+        if (x != ".") {
+            allDot = false;
+            break;
+        }
     }
-    if(allDot) return ".";
+    if (allDot)
+        return ".";
     // join with colon
     std::ostringstream oss;
-    bool first=true;
-    for(size_t i=0;i< newSubs.size(); i++){
-        if(!first) oss<<":";
-        else first=false;
-        oss<< newSubs[i];
+    bool first = true;
+    for (size_t i = 0; i < newSubs.size(); i++) {
+        if (!first)
+            oss << ":";
+        else
+            first = false;
+        oss << newSubs[i];
     }
     return oss.str();
 }
 
-static void show_help() { VCFXReformatter obj; char arg0[] = "VCFX_reformatter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXReformatter obj;
+    char arg0[] = "VCFX_reformatter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_reformatter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_reformatter", show_help))
+        return 0;
     VCFXReformatter reformatter;
     return reformatter.run(argc, argv);
 }

--- a/src/VCFX_reformatter/VCFX_reformatter.h
+++ b/src/VCFX_reformatter/VCFX_reformatter.h
@@ -3,48 +3,41 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 class VCFXReformatter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
     // Reformat the VCF from 'in' to 'out' using the user-specified lists
-    void reformatVCF(std::istream &in, std::ostream &out,
-                     const std::vector<std::string> &compressInfoFields,
-                     const std::vector<std::string> &compressFormatFields,
-                     const std::vector<std::string> &reorderInfo,
+    void reformatVCF(std::istream &in, std::ostream &out, const std::vector<std::string> &compressInfoFields,
+                     const std::vector<std::string> &compressFormatFields, const std::vector<std::string> &reorderInfo,
                      const std::vector<std::string> &reorderFormat);
 
     // Remove user-specified fields from the semicolon-based INFO
     // (Used for compressing info keys)
-    std::string compressInfo(const std::string &infoStr,
-                             const std::unordered_set<std::string> &keysToRemove);
+    std::string compressInfo(const std::string &infoStr, const std::unordered_set<std::string> &keysToRemove);
 
     // Remove user-specified keys from colon-based FORMAT
     // and from each genotype subfield in that position
     // Returns the new format string, plus an index mapping
-    std::string compressFormat(const std::string &formatStr,
-                               const std::unordered_set<std::string> &keysToRemove,
+    std::string compressFormat(const std::string &formatStr, const std::unordered_set<std::string> &keysToRemove,
                                std::vector<int> &keepIndices);
 
     // Reorder a semicolon-based INFO
-    std::string reorderInfo(const std::string &infoStr,
-                            const std::vector<std::string> &order);
+    std::string reorderInfo(const std::string &infoStr, const std::vector<std::string> &order);
 
     // Reorder a colon-based FORMAT; returns new format, plus old->new index mapping
-    std::string reorderFormat(const std::string &fmtStr,
-                              const std::vector<std::string> &order,
+    std::string reorderFormat(const std::string &fmtStr, const std::vector<std::string> &order,
                               std::vector<int> &oldToNew);
 
     // reorder genotype subfields for each sample based on oldToNew
     // or remove subfields if the new index is negative
-    std::string applyFormatReorderToSample(const std::string &sampleStr,
-                                           const std::vector<int> &oldToNew);
+    std::string applyFormatReorderToSample(const std::string &sampleStr, const std::vector<int> &oldToNew);
 };
 
 #endif

--- a/src/VCFX_region_subsampler/VCFX_region_subsampler.cpp
+++ b/src/VCFX_region_subsampler/VCFX_region_subsampler.cpp
@@ -1,23 +1,20 @@
-#include "vcfx_core.h"
 #include "VCFX_region_subsampler.h"
-#include <getopt.h>
-#include <sstream>
-#include <fstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <iostream>
-#include <vector>
-#include <string>
 #include <cctype>
 #include <cstdlib>
+#include <fstream>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 static void mergeIntervals(std::vector<Region> &ivs) {
-    if (ivs.empty()) return;
-    std::sort(ivs.begin(), ivs.end(),
-        [](const Region &a, const Region &b) {
-            return a.start < b.start;
-        }
-    );
+    if (ivs.empty())
+        return;
+    std::sort(ivs.begin(), ivs.end(), [](const Region &a, const Region &b) { return a.start < b.start; });
     std::vector<Region> merged;
     merged.push_back(ivs[0]);
     for (size_t i = 1; i < ivs.size(); i++) {
@@ -52,29 +49,27 @@ static bool inRegions(const std::vector<Region> &ivs, int pos) {
     return false;
 }
 
-int VCFXRegionSubsampler::run(int argc, char* argv[]) {
+int VCFXRegionSubsampler::run(int argc, char *argv[]) {
     bool showHelp = false;
     std::string bedFile;
 
     static struct option long_opts[] = {
-        {"help",       no_argument,       0, 'h'},
-        {"region-bed", required_argument, 0, 'b'},
-        {0,            0,                 0,  0}
-    };
+        {"help", no_argument, 0, 'h'}, {"region-bed", required_argument, 0, 'b'}, {0, 0, 0, 0}};
 
     // Parse arguments
     while (true) {
         int c = ::getopt_long(argc, argv, "hb:", long_opts, nullptr);
-        if (c == -1) break;
+        if (c == -1)
+            break;
         switch (c) {
-            case 'h':
-                showHelp = true;
-                break;
-            case 'b':
-                bedFile = optarg;
-                break;
-            default:
-                showHelp = true;
+        case 'h':
+            showHelp = true;
+            break;
+        case 'b':
+            bedFile = optarg;
+            break;
+        default:
+            showHelp = true;
         }
     }
 
@@ -106,25 +101,22 @@ int VCFXRegionSubsampler::run(int argc, char* argv[]) {
 }
 
 void VCFXRegionSubsampler::displayHelp() {
-    std::cout
-        << "VCFX_region_subsampler: Keep only variants whose (CHROM,POS) is in a set of regions.\n\n"
-        << "Usage:\n"
-        << "  VCFX_region_subsampler --region-bed FILE < input.vcf > out.vcf\n\n"
-        << "Options:\n"
-        << "  -h, --help             Show help.\n"
-        << "  -b, --region-bed FILE  BED file listing multiple regions.\n\n"
-        << "Description:\n"
-        << "  Reads the BED, which is <chrom> <start> <end> in 0-based. This tool converts\n"
-        << "  them to 1-based [start+1 .. end]. Then merges intervals per chrom.\n"
-        << "  Then only lines in the VCF that fall in those intervals for that CHROM are printed.\n\n"
-        << "Example:\n"
-        << "  VCFX_region_subsampler --region-bed myregions.bed < input.vcf > out.vcf\n";
+    std::cout << "VCFX_region_subsampler: Keep only variants whose (CHROM,POS) is in a set of regions.\n\n"
+              << "Usage:\n"
+              << "  VCFX_region_subsampler --region-bed FILE < input.vcf > out.vcf\n\n"
+              << "Options:\n"
+              << "  -h, --help             Show help.\n"
+              << "  -b, --region-bed FILE  BED file listing multiple regions.\n\n"
+              << "Description:\n"
+              << "  Reads the BED, which is <chrom> <start> <end> in 0-based. This tool converts\n"
+              << "  them to 1-based [start+1 .. end]. Then merges intervals per chrom.\n"
+              << "  Then only lines in the VCF that fall in those intervals for that CHROM are printed.\n\n"
+              << "Example:\n"
+              << "  VCFX_region_subsampler --region-bed myregions.bed < input.vcf > out.vcf\n";
 }
 
-bool VCFXRegionSubsampler::loadRegions(
-    const std::string &bedFilePath,
-    std::unordered_map<std::string, std::vector<Region>> &chromRegions)
-{
+bool VCFXRegionSubsampler::loadRegions(const std::string &bedFilePath,
+                                       std::unordered_map<std::string, std::vector<Region>> &chromRegions) {
     std::ifstream in(bedFilePath);
     if (!in.is_open()) {
         std::cerr << "Error: cannot open BED " << bedFilePath << "\n";
@@ -134,9 +126,11 @@ bool VCFXRegionSubsampler::loadRegions(
     int lineCount = 0;
 
     while (true) {
-        if (!std::getline(in, line)) break;
+        if (!std::getline(in, line))
+            break;
         lineCount++;
-        if (line.empty() || line[0] == '#') continue;
+        if (line.empty() || line[0] == '#')
+            continue;
 
         std::stringstream ss(line);
         std::string chrom;
@@ -145,10 +139,11 @@ bool VCFXRegionSubsampler::loadRegions(
             std::cerr << "Warning: skipping invalid bed line " << lineCount << ": " << line << "\n";
             continue;
         }
-        if (start < 0) start = 0;
+        if (start < 0)
+            start = 0;
         Region r;
         r.start = start + 1; // 1-based
-        r.end   = end;
+        r.end = end;
 
         if (r.end < r.start) {
             // ignore negative or zero-length intervals
@@ -162,8 +157,7 @@ bool VCFXRegionSubsampler::loadRegions(
 void VCFXRegionSubsampler::sortAndMergeIntervals(std::unordered_map<std::string, std::vector<Region>> &chromRegions) {
     for (auto &kv : chromRegions) {
         auto &ivs = kv.second;
-        std::sort(ivs.begin(), ivs.end(),
-                  [](const Region &a, const Region &b){ return a.start < b.start; });
+        std::sort(ivs.begin(), ivs.end(), [](const Region &a, const Region &b) { return a.start < b.start; });
 
         std::vector<Region> merged;
         merged.reserve(ivs.size());
@@ -185,7 +179,8 @@ void VCFXRegionSubsampler::sortAndMergeIntervals(std::unordered_map<std::string,
 
 bool VCFXRegionSubsampler::isInAnyRegion(const std::string &chrom, int pos) const {
     auto it = regions.find(chrom);
-    if (it == regions.end()) return false;
+    if (it == regions.end())
+        return false;
     const auto &ivs = it->second;
 
     int left = 0, right = (int)ivs.size() - 1;
@@ -208,7 +203,8 @@ void VCFXRegionSubsampler::processVCF(std::istream &in, std::ostream &out) {
     std::string line;
 
     while (true) {
-        if (!std::getline(in, line)) break;
+        if (!std::getline(in, line))
+            break;
         if (line.empty()) {
             out << line << "\n";
             continue;
@@ -243,7 +239,7 @@ void VCFXRegionSubsampler::processVCF(std::istream &in, std::ostream &out) {
         int pos = 0;
         try {
             pos = std::stoi(posStr);
-        } catch(...) {
+        } catch (...) {
             std::cerr << "Warning: invalid POS => skipping.\n";
             continue;
         }
@@ -254,10 +250,17 @@ void VCFXRegionSubsampler::processVCF(std::istream &in, std::ostream &out) {
     }
 }
 
-static void show_help() { VCFXRegionSubsampler obj; char arg0[] = "VCFX_region_subsampler"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXRegionSubsampler obj;
+    char arg0[] = "VCFX_region_subsampler";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_region_subsampler", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_region_subsampler", show_help))
+        return 0;
     VCFXRegionSubsampler app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_region_subsampler/VCFX_region_subsampler.h
+++ b/src/VCFX_region_subsampler/VCFX_region_subsampler.h
@@ -12,17 +12,16 @@ struct Region {
     int end;
 };
 
-// VCFXRegionSubsampler: 
+// VCFXRegionSubsampler:
 // Reads a BED file with multiple lines => chromosome -> sorted intervals
 // Then reads a VCF and keeps lines whose POS is within any interval for that CHROM.
 class VCFXRegionSubsampler {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
-    bool loadRegions(const std::string &bedFile,
-                     std::unordered_map<std::string, std::vector<Region>> &chromRegions);
+    bool loadRegions(const std::string &bedFile, std::unordered_map<std::string, std::vector<Region>> &chromRegions);
     // after loading, we sort the intervals for each chromosome, possibly merge them
     void sortAndMergeIntervals(std::unordered_map<std::string, std::vector<Region>> &chromRegions);
 
@@ -32,7 +31,6 @@ private:
     std::unordered_map<std::string, std::vector<Region>> regions;
 
     void processVCF(std::istream &in, std::ostream &out);
-
 };
 
 #endif

--- a/src/VCFX_sample_extractor/VCFX_sample_extractor.cpp
+++ b/src/VCFX_sample_extractor/VCFX_sample_extractor.cpp
@@ -1,71 +1,73 @@
-#include "vcfx_core.h"
 #include "VCFX_sample_extractor.h"
+#include "vcfx_core.h"
+#include <algorithm>
+#include <cctype>
 #include <getopt.h>
-#include <sstream>
 #include <iostream>
-#include <vector>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <algorithm>
-#include <cctype>
+#include <vector>
 
 // Helper to trim whitespace
-static std::string trim(const std::string &s){
-    size_t start=0; 
-    while(start<s.size() && isspace((unsigned char)s[start])) start++;
-    if(start== s.size()) return "";
-    size_t end= s.size()-1;
-    while(end> start && isspace((unsigned char)s[end])) end--;
-    return s.substr(start, end-start+1);
+static std::string trim(const std::string &s) {
+    size_t start = 0;
+    while (start < s.size() && isspace((unsigned char)s[start]))
+        start++;
+    if (start == s.size())
+        return "";
+    size_t end = s.size() - 1;
+    while (end > start && isspace((unsigned char)s[end]))
+        end--;
+    return s.substr(start, end - start + 1);
 }
 
-int VCFXSampleExtractor::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXSampleExtractor::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
+    bool showHelp = false;
     std::vector<std::string> samples;
 
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"samples", required_argument, 0, 's'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c=::getopt_long(argc, argv, "hs:", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 's': {
-                // parse comma or space delimited
-                std::stringstream ss(optarg);
-                // we allow e.g. --samples "SampleA,SampleB"
-                // or --samples "SampleA SampleB"
-                std::string token;
-                while(ss>> token){
-                    // also check for comma splitting
-                    std::stringstream s2(token);
-                    std::string sub;
-                    while(std::getline(s2, sub, ',')){
-                        sub= trim(sub);
-                        if(!sub.empty()) samples.push_back(sub);
-                    }
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'}, {"samples", required_argument, 0, 's'}, {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hs:", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 's': {
+            // parse comma or space delimited
+            std::stringstream ss(optarg);
+            // we allow e.g. --samples "SampleA,SampleB"
+            // or --samples "SampleA SampleB"
+            std::string token;
+            while (ss >> token) {
+                // also check for comma splitting
+                std::stringstream s2(token);
+                std::string sub;
+                while (std::getline(s2, sub, ',')) {
+                    sub = trim(sub);
+                    if (!sub.empty())
+                        samples.push_back(sub);
                 }
-            }break;
-            default:
-                showHelp=true;
+            }
+        } break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    if(samples.empty()){
-        std::cerr<<"Error: must specify at least one sample with --samples.\n";
+    if (samples.empty()) {
+        std::cerr << "Error: must specify at least one sample with --samples.\n";
         return 1;
     }
     // do it
@@ -73,29 +75,26 @@ int VCFXSampleExtractor::run(int argc, char* argv[]){
     return 0;
 }
 
-void VCFXSampleExtractor::displayHelp(){
-    std::cout <<
-"VCFX_sample_extractor: Subset a VCF to a chosen set of samples.\n\n"
-"Usage:\n"
-"  VCFX_sample_extractor --samples \"Sample1,Sample2\" < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -h, --help              Print this help.\n"
-"  -s, --samples <LIST>    Comma or space separated list of sample names.\n\n"
-"Description:\n"
-"  Reads #CHROM line to identify sample columns. Keeps only user-specified samples.\n"
-"  Rewrites #CHROM line with that subset. For each variant data line, we keep only the\n"
-"  chosen sample columns. If a sample isn't found in the header, logs a warning.\n\n"
-"Example:\n"
-"  VCFX_sample_extractor --samples \"IndivA IndivB\" < input.vcf > subset.vcf\n";
+void VCFXSampleExtractor::displayHelp() {
+    std::cout << "VCFX_sample_extractor: Subset a VCF to a chosen set of samples.\n\n"
+                 "Usage:\n"
+                 "  VCFX_sample_extractor --samples \"Sample1,Sample2\" < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help              Print this help.\n"
+                 "  -s, --samples <LIST>    Comma or space separated list of sample names.\n\n"
+                 "Description:\n"
+                 "  Reads #CHROM line to identify sample columns. Keeps only user-specified samples.\n"
+                 "  Rewrites #CHROM line with that subset. For each variant data line, we keep only the\n"
+                 "  chosen sample columns. If a sample isn't found in the header, logs a warning.\n\n"
+                 "Example:\n"
+                 "  VCFX_sample_extractor --samples \"IndivA IndivB\" < input.vcf > subset.vcf\n";
 }
 
-void VCFXSampleExtractor::extractSamples(std::istream &in, std::ostream &out,
-                                         const std::vector<std::string> &samples)
-{
+void VCFXSampleExtractor::extractSamples(std::istream &in, std::ostream &out, const std::vector<std::string> &samples) {
     // store the samples in a set for quick membership check
     std::unordered_set<std::string> sampleSet(samples.begin(), samples.end());
 
-    bool foundChromLine=false;
+    bool foundChromLine = false;
     std::string line;
     // We'll keep track of the sample name -> index
     // We'll build a vector of indices we want to keep in data lines
@@ -104,24 +103,25 @@ void VCFXSampleExtractor::extractSamples(std::istream &in, std::ostream &out,
     keepSampleIndices.reserve(samples.size());
     // We'll also store them in the final #CHROM order
     std::vector<std::string> finalSampleNames;
-    bool headerProcessed=false;
+    bool headerProcessed = false;
 
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
-            out<< line <<"\n";
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
+            out << line << "\n";
             continue;
         }
-        if(line[0]=='#'){
+        if (line[0] == '#') {
             // pass header lines
-            if(line.rfind("#CHROM",0)==0){
-                foundChromLine= true;
+            if (line.rfind("#CHROM", 0) == 0) {
+                foundChromLine = true;
                 // parse
                 std::stringstream ss(line);
                 std::vector<std::string> headerFields;
                 {
                     std::string col;
-                    while(std::getline(ss, col, '\t')){
+                    while (std::getline(ss, col, '\t')) {
                         headerFields.push_back(col);
                     }
                 }
@@ -129,46 +129,47 @@ void VCFXSampleExtractor::extractSamples(std::istream &in, std::ostream &out,
                 // find which ones are in sampleSet
                 keepSampleIndices.clear();
                 finalSampleNames.clear();
-                if(headerFields.size()<9){
+                if (headerFields.size() < 9) {
                     // means no samples in this VCF => skip
-                    out<< line<<"\n";
+                    out << line << "\n";
                     continue;
                 }
                 // standard columns 0..8 => CHROM,POS,ID,REF,ALT,QUAL,FILTER,INFO,FORMAT
-                for(size_t i=9;i< headerFields.size(); i++){
+                for (size_t i = 9; i < headerFields.size(); i++) {
                     // if it's in sampleSet => keep
-                    if(sampleSet.count(headerFields[i])>0){
+                    if (sampleSet.count(headerFields[i]) > 0) {
                         keepSampleIndices.push_back((int)i);
                         finalSampleNames.push_back(headerFields[i]);
                     }
                 }
                 // for any sample in sampleSet that wasn't found => warn
-                for(auto &s: samples){
-                    if(std::find(finalSampleNames.begin(), finalSampleNames.end(), s) == finalSampleNames.end()){
-                        std::cerr<<"Warning: sample '"<< s <<"' not found in header.\n";
+                for (auto &s : samples) {
+                    if (std::find(finalSampleNames.begin(), finalSampleNames.end(), s) == finalSampleNames.end()) {
+                        std::cerr << "Warning: sample '" << s << "' not found in header.\n";
                     }
                 }
                 // now rewrite the #CHROM line
                 // keep the first 9 columns, then only the chosen sample columns
                 std::ostringstream newHeader;
                 // 0..8
-                for(int i=0;i<9;i++){
-                    if(i>0) newHeader<<"\t";
-                    newHeader<< headerFields[i];
+                for (int i = 0; i < 9; i++) {
+                    if (i > 0)
+                        newHeader << "\t";
+                    newHeader << headerFields[i];
                 }
                 // then each sample
-                for(size_t i=0;i< finalSampleNames.size(); i++){
-                    newHeader<<"\t"<< finalSampleNames[i];
+                for (size_t i = 0; i < finalSampleNames.size(); i++) {
+                    newHeader << "\t" << finalSampleNames[i];
                 }
-                out<< newHeader.str()<<"\n";
-                headerProcessed=true;
+                out << newHeader.str() << "\n";
+                headerProcessed = true;
             } else {
-                out<< line<<"\n";
+                out << line << "\n";
             }
             continue;
         }
-        if(!foundChromLine){
-            std::cerr<<"Warning: data line encountered before #CHROM => skipping.\n";
+        if (!foundChromLine) {
+            std::cerr << "Warning: data line encountered before #CHROM => skipping.\n";
             continue;
         }
         // parse data line
@@ -176,49 +177,57 @@ void VCFXSampleExtractor::extractSamples(std::istream &in, std::ostream &out,
         std::vector<std::string> fields;
         {
             std::string col;
-            while(std::getline(ss,col,'\t')){
+            while (std::getline(ss, col, '\t')) {
                 fields.push_back(col);
             }
         }
-        if(fields.size()<8){
-            std::cerr<<"Warning: line has <8 columns => skipping.\n";
+        if (fields.size() < 8) {
+            std::cerr << "Warning: line has <8 columns => skipping.\n";
             continue;
         }
         // if there's no sample columns => we can just keep line, but that wouldn't make sense
         // actually if there's < 10 columns => no sample data. Then there's no subset to do
         // We'll keep it if there's no sample columns? It's up to us. We'll do the standard approach:
         // we need at least 9 => CHROM..FORMAT plus at least one sample => if not => just print as is
-        if(fields.size()<9){
+        if (fields.size() < 9) {
             // no sample columns
             // keep or skip? We'll keep it to keep it consistent. Or we skip because it's an invalid VCF?
             // We'll just skip
-            std::cerr<<"Warning: data line with no sample columns => skipping.\n";
+            std::cerr << "Warning: data line with no sample columns => skipping.\n";
             continue;
         }
         // now we keep 0..8 plus only the chosen samples
         std::ostringstream newLine;
         // 0..8
-        for(int i=0;i<9;i++){
-            if(i>0) newLine<<"\t";
-            newLine<< fields[i];
+        for (int i = 0; i < 9; i++) {
+            if (i > 0)
+                newLine << "\t";
+            newLine << fields[i];
         }
         // now each chosen sample
-        for(auto idx: keepSampleIndices){
-            if((size_t)idx < fields.size()){
-                newLine<<"\t"<< fields[idx];
+        for (auto idx : keepSampleIndices) {
+            if ((size_t)idx < fields.size()) {
+                newLine << "\t" << fields[idx];
             } else {
                 // out of range => sample column not present => put "."
-                newLine<<"\t.";
+                newLine << "\t.";
             }
         }
-        out<< newLine.str()<<"\n";
+        out << newLine.str() << "\n";
     }
 }
 
-static void show_help() { VCFXSampleExtractor obj; char arg0[] = "VCFX_sample_extractor"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXSampleExtractor obj;
+    char arg0[] = "VCFX_sample_extractor";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_sample_extractor", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_sample_extractor", show_help))
+        return 0;
     VCFXSampleExtractor app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_sample_extractor/VCFX_sample_extractor.h
+++ b/src/VCFX_sample_extractor/VCFX_sample_extractor.h
@@ -3,21 +3,19 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 class VCFXSampleExtractor {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
     // read the user’s --samples list => store them
     // read VCF from in => output a valid VCF with only those samples
-    void extractSamples(std::istream &in, std::ostream &out,
-                        const std::vector<std::string> &samples);
-
+    void extractSamples(std::istream &in, std::ostream &out, const std::vector<std::string> &samples);
 };
 
 #endif

--- a/src/VCFX_sorter/VCFX_sorter.cpp
+++ b/src/VCFX_sorter/VCFX_sorter.cpp
@@ -1,145 +1,147 @@
-#include "vcfx_core.h"
 #include "VCFX_sorter.h"
-#include <getopt.h>
-#include <iostream>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
 
-void VCFXSorter::displayHelp(){
-    std::cout <<
-"VCFX_sorter: Sort a VCF by chromosome and position.\n\n"
-"Usage:\n"
-"  VCFX_sorter [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -h, --help          Show help.\n"
-"  -n, --natural-chr   Use a natural chromosome sort (chr1 < chr2 < chr10) instead of lexicographic.\n\n"
-"Description:\n"
-"  Reads all data lines into memory, sorts by (CHROM,POS). Preserves all header lines\n"
-"  in original order, and outputs them first, then prints sorted data lines.\n\n"
-"Examples:\n"
-"  1) Lexicographic:\n"
-"     VCFX_sorter < unsorted.vcf > sorted.vcf\n"
-"  2) Natural order:\n"
-"     VCFX_sorter --natural-chr < unsorted.vcf > sorted.vcf\n";
+void VCFXSorter::displayHelp() {
+    std::cout
+        << "VCFX_sorter: Sort a VCF by chromosome and position.\n\n"
+           "Usage:\n"
+           "  VCFX_sorter [options] < input.vcf > output.vcf\n\n"
+           "Options:\n"
+           "  -h, --help          Show help.\n"
+           "  -n, --natural-chr   Use a natural chromosome sort (chr1 < chr2 < chr10) instead of lexicographic.\n\n"
+           "Description:\n"
+           "  Reads all data lines into memory, sorts by (CHROM,POS). Preserves all header lines\n"
+           "  in original order, and outputs them first, then prints sorted data lines.\n\n"
+           "Examples:\n"
+           "  1) Lexicographic:\n"
+           "     VCFX_sorter < unsorted.vcf > sorted.vcf\n"
+           "  2) Natural order:\n"
+           "     VCFX_sorter --natural-chr < unsorted.vcf > sorted.vcf\n";
 }
 
 // A function to parse chromosome name in a natural manner if possible
 // e.g. "chr10" => (chr,10) so that chr2 < chr10 in numeric sense
 // We'll remove "chr" prefix if present, then parse leading digits
-static bool parseChromNat(const std::string &chrom,
-                          std::string &prefix,
-                          long &num,
-                          std::string &suffix)
-{
+static bool parseChromNat(const std::string &chrom, std::string &prefix, long &num, std::string &suffix) {
     // e.g. "chr10_gl000" => prefix="chr", then 10, then suffix="_gl000"
     // We'll do a naive approach: remove leading "chr" or "Chr" or "CHR"
-    std::string c= chrom;
+    std::string c = chrom;
     // uppercase to check
     std::string up;
     up.reserve(c.size());
-    for(char ch: c) up.push_back(std::toupper(ch));
-    if(up.rfind("CHR",0)==0) {
+    for (char ch : c)
+        up.push_back(std::toupper(ch));
+    if (up.rfind("CHR", 0) == 0) {
         // remove "chr" prefix
-        prefix= c.substr(0,3); 
-        c= c.substr(3);
+        prefix = c.substr(0, 3);
+        c = c.substr(3);
     } else {
-        prefix="";
+        prefix = "";
     }
     // now parse leading digits
     // e.g. c="10_gl000"
     // we parse digits until non-digit
-    size_t idx=0;
-    while(idx< c.size() && std::isdigit((unsigned char)c[idx])) idx++;
-    if(idx==0){
+    size_t idx = 0;
+    while (idx < c.size() && std::isdigit((unsigned char)c[idx]))
+        idx++;
+    if (idx == 0) {
         // means no leading digit
-        num=-1;
-        suffix= c;
+        num = -1;
+        suffix = c;
         return true;
     }
     // parse c[0..idx-1] as a number
     try {
-        num= std::stol(c.substr(0,idx));
-    } catch(...){
+        num = std::stol(c.substr(0, idx));
+    } catch (...) {
         return false;
     }
-    suffix= c.substr(idx);
+    suffix = c.substr(idx);
     return true;
 }
 
 // We'll define the lexCompare
-bool VCFRecord::lexCompare(const VCFRecord &a, const VCFRecord &b){
-    if(a.chrom != b.chrom) return a.chrom < b.chrom;
+bool VCFRecord::lexCompare(const VCFRecord &a, const VCFRecord &b) {
+    if (a.chrom != b.chrom)
+        return a.chrom < b.chrom;
     return a.pos < b.pos;
 }
 
 // We'll define the naturalCompare
-bool VCFRecord::naturalCompare(const VCFRecord &a, const VCFRecord &b){
+bool VCFRecord::naturalCompare(const VCFRecord &a, const VCFRecord &b) {
     // parse each
     std::string apfx, asuf, bpfx, bsuf;
     long anum, bnum;
-    if(!parseChromNat(a.chrom, apfx, anum, asuf) || 
-       !parseChromNat(b.chrom, bpfx, bnum, bsuf)) {
+    if (!parseChromNat(a.chrom, apfx, anum, asuf) || !parseChromNat(b.chrom, bpfx, bnum, bsuf)) {
         // fallback to lex
-        if(a.chrom != b.chrom) return a.chrom < b.chrom;
-        return a.pos< b.pos;
+        if (a.chrom != b.chrom)
+            return a.chrom < b.chrom;
+        return a.pos < b.pos;
     }
     // if prefix differs, lex compare them
-    if(apfx != bpfx) return (apfx< bpfx);
+    if (apfx != bpfx)
+        return (apfx < bpfx);
     // if both have num>=0
-    if(anum>=0 && bnum>=0){
-        if(anum!= bnum) return (anum< bnum);
+    if (anum >= 0 && bnum >= 0) {
+        if (anum != bnum)
+            return (anum < bnum);
         // if suffix differs => lex compare
-        if(asuf!= bsuf) return asuf< bsuf;
+        if (asuf != bsuf)
+            return asuf < bsuf;
         // else compare pos
-        if(a.pos!= b.pos) return a.pos< b.pos;
+        if (a.pos != b.pos)
+            return a.pos < b.pos;
         // all tie
         return false;
-    } else if(anum>=0 && bnum<0){
+    } else if (anum >= 0 && bnum < 0) {
         // numeric < no numeric
         return true;
-    } else if(anum<0 && bnum>=0){
+    } else if (anum < 0 && bnum >= 0) {
         return false;
     } else {
         // both have no numeric => fallback to lex compare
-        if(a.chrom!= b.chrom) return a.chrom< b.chrom;
-        return a.pos< b.pos;
+        if (a.chrom != b.chrom)
+            return a.chrom < b.chrom;
+        return a.pos < b.pos;
     }
 }
 
-int VCFXSorter::run(int argc, char* argv[]){
-    bool showHelp=false;
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"natural-chr", no_argument, 0, 'n'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv, "hn", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'n':
-                naturalChromOrder= true;
-                break;
-            default:
-                showHelp=true;
+int VCFXSorter::run(int argc, char *argv[]) {
+    bool showHelp = false;
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'}, {"natural-chr", no_argument, 0, 'n'}, {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hn", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'n':
+            naturalChromOrder = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    
+
     // Check if stdin has data
     if (std::cin.peek() == EOF) {
         displayHelp();
         return 0;
     }
-    
+
     loadVCF(std::cin);
     sortRecords();
     outputVCF(std::cout);
@@ -147,19 +149,21 @@ int VCFXSorter::run(int argc, char* argv[]){
 }
 
 // loads lines into memory
-void VCFXSorter::loadVCF(std::istream &in){
-    bool foundChrom=false;
+void VCFXSorter::loadVCF(std::istream &in) {
+    bool foundChrom = false;
     std::string line;
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
             // we keep it in the header or skip? We'll keep it in header
             headerLines.push_back(line);
             continue;
         }
-        if(line[0]=='#'){
+        if (line[0] == '#') {
             headerLines.push_back(line);
-            if(line.rfind("#CHROM",0)==0) foundChrom=true;
+            if (line.rfind("#CHROM", 0) == 0)
+                foundChrom = true;
             continue;
         }
         // parse data
@@ -167,61 +171,70 @@ void VCFXSorter::loadVCF(std::istream &in){
         std::vector<std::string> fields;
         {
             std::string col;
-            while(std::getline(ss,col,'\t')){
+            while (std::getline(ss, col, '\t')) {
                 fields.push_back(col);
             }
         }
-        if(fields.size()<8){
-            std::cerr<<"Warning: skipping line with <8 columns.\n";
+        if (fields.size() < 8) {
+            std::cerr << "Warning: skipping line with <8 columns.\n";
             continue;
         }
         VCFRecord rec;
-        rec.chrom= fields[0];
+        rec.chrom = fields[0];
         try {
-            rec.pos= std::stoi(fields[1]);
-        } catch(...){
-            std::cerr<<"Warning: invalid POS => skipping line.\n";
+            rec.pos = std::stoi(fields[1]);
+        } catch (...) {
+            std::cerr << "Warning: invalid POS => skipping line.\n";
             continue;
         }
-        rec.fields= std::move(fields);
+        rec.fields = std::move(fields);
         records.push_back(rec);
     }
-    if(!foundChrom){
-        std::cerr<<"Warning: no #CHROM line found in input.\n";
+    if (!foundChrom) {
+        std::cerr << "Warning: no #CHROM line found in input.\n";
     }
 }
 
 // sort them in memory
-void VCFXSorter::sortRecords(){
-    if(naturalChromOrder){
+void VCFXSorter::sortRecords() {
+    if (naturalChromOrder) {
         std::sort(records.begin(), records.end(), VCFRecord::naturalCompare);
     } else {
         std::sort(records.begin(), records.end(), VCFRecord::lexCompare);
     }
 }
 
-void VCFXSorter::outputVCF(std::ostream &out){
+void VCFXSorter::outputVCF(std::ostream &out) {
     // print all header lines
-    for(auto &l : headerLines){
-        out<< l <<"\n";
+    for (auto &l : headerLines) {
+        out << l << "\n";
     }
     // then print sorted data
-    for(auto &rec: records){
+    for (auto &rec : records) {
         // rebuild line from rec.fields
-        bool first=true;
-        for(size_t i=0;i< rec.fields.size(); i++){
-            if(!first) out<<"\t";
-            else first=false;
-            out<< rec.fields[i];
+        bool first = true;
+        for (size_t i = 0; i < rec.fields.size(); i++) {
+            if (!first)
+                out << "\t";
+            else
+                first = false;
+            out << rec.fields[i];
         }
-        out<<"\n";
+        out << "\n";
     }
 }
 
-static void show_help() { VCFXSorter obj; char arg0[] = "VCFX_sorter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXSorter obj;
+    char arg0[] = "VCFX_sorter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_sorter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_sorter", show_help))
+        return 0;
     VCFXSorter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_sorter/VCFX_sorter.h
+++ b/src/VCFX_sorter/VCFX_sorter.h
@@ -16,10 +16,10 @@ struct VCFRecord {
 
 // A class to hold main logic
 class VCFXSorter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // parse arguments, then read lines
     // store header lines, store data lines in memory
     // sort data lines
@@ -30,7 +30,7 @@ private:
     void outputVCF(std::ostream &out);
 
     // read an environment var or a CLI option to decide lexicographic or natural
-    bool naturalChromOrder= false;
+    bool naturalChromOrder = false;
 
     // store all lines that begin with '#'
     std::vector<std::string> headerLines;

--- a/src/VCFX_subsampler/VCFX_subsampler.cpp
+++ b/src/VCFX_subsampler/VCFX_subsampler.cpp
@@ -1,34 +1,33 @@
-#include "vcfx_core.h"
 #include "VCFX_subsampler.h"
+#include "vcfx_core.h"
+#include <cstdlib>
+#include <ctime>
 #include <getopt.h>
 #include <iostream>
-#include <sstream>
-#include <vector>
-#include <string>
 #include <random>
-#include <ctime>
-#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <vector>
 
-void VCFXSubsampler::displayHelp(){
-    std::cout <<
-"VCFX_subsampler: Randomly pick N lines from a VCF data section.\n\n"
-"Usage:\n"
-"  VCFX_subsampler [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -s, --subsample <N>   Required: number of data lines (variants) to keep.\n"
-"  --seed <INT>          Use a reproducible random seed.\n"
-"  -h, --help            Show this help.\n\n"
-"Description:\n"
-"  We read all header lines (#...) first and output them as-is. Then we do\n"
-"  reservoir sampling on subsequent lines (the data lines). If the file has\n"
-"  fewer than N lines, we keep them all. We skip lines with <8 columns.\n\n"
-"Example:\n"
-"  VCFX_subsampler --subsample 1000 < big.vcf > subset.vcf\n"
-"  VCFX_subsampler --subsample 1000 --seed 1234 < big.vcf > subset2.vcf\n";
+void VCFXSubsampler::displayHelp() {
+    std::cout << "VCFX_subsampler: Randomly pick N lines from a VCF data section.\n\n"
+                 "Usage:\n"
+                 "  VCFX_subsampler [options] < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  -s, --subsample <N>   Required: number of data lines (variants) to keep.\n"
+                 "  --seed <INT>          Use a reproducible random seed.\n"
+                 "  -h, --help            Show this help.\n\n"
+                 "Description:\n"
+                 "  We read all header lines (#...) first and output them as-is. Then we do\n"
+                 "  reservoir sampling on subsequent lines (the data lines). If the file has\n"
+                 "  fewer than N lines, we keep them all. We skip lines with <8 columns.\n\n"
+                 "Example:\n"
+                 "  VCFX_subsampler --subsample 1000 < big.vcf > subset.vcf\n"
+                 "  VCFX_subsampler --subsample 1000 --seed 1234 < big.vcf > subset2.vcf\n";
 }
 
-int VCFXSubsampler::run(int argc, char* argv[]){
-    if(argc == 1){
+int VCFXSubsampler::run(int argc, char *argv[]) {
+    if (argc == 1) {
         // No arguments => show help
         displayHelp();
         return 0;
@@ -38,51 +37,50 @@ int VCFXSubsampler::run(int argc, char* argv[]){
     int sampleSize = 0;
     unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
 
-    static struct option long_opts[] = {
-        {"help",       no_argument,       0, 'h'},
-        {"subsample",  required_argument, 0, 's'},
-        {"seed",       required_argument, 0, 1000},
-        {0,0,0,0}
-    };
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"subsample", required_argument, 0, 's'},
+                                        {"seed", required_argument, 0, 1000},
+                                        {0, 0, 0, 0}};
 
-    while(true) {
+    while (true) {
         int c = ::getopt_long(argc, argv, "hs:", long_opts, nullptr);
-        if(c == -1) break;
-        switch(c){
-            case 'h':
-                showHelp = true;
-                break;
-            case 's':
-                try {
-                    sampleSize = std::stoi(optarg);
-                    if(sampleSize <= 0) {
-                        throw std::invalid_argument("must be >0");
-                    }
-                } catch(...) {
-                    std::cerr << "Error: invalid subsample size.\n";
-                    return 1;
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 's':
+            try {
+                sampleSize = std::stoi(optarg);
+                if (sampleSize <= 0) {
+                    throw std::invalid_argument("must be >0");
                 }
-                break;
-            case 1000: {
-                try {
-                    long long val = std::stoll(optarg);
-                    seed = static_cast<unsigned int>(val);
-                } catch(...) {
-                    std::cerr << "Error: invalid seed.\n";
-                    return 1;
-                }
-            } break;
-            default:
-                showHelp = true;
+            } catch (...) {
+                std::cerr << "Error: invalid subsample size.\n";
+                return 1;
+            }
+            break;
+        case 1000: {
+            try {
+                long long val = std::stoll(optarg);
+                seed = static_cast<unsigned int>(val);
+            } catch (...) {
+                std::cerr << "Error: invalid seed.\n";
+                return 1;
+            }
+        } break;
+        default:
+            showHelp = true;
         }
     }
 
-    if(showHelp) {
+    if (showHelp) {
         displayHelp();
         return 0;
     }
 
-    if(sampleSize <= 0) {
+    if (sampleSize <= 0) {
         std::cerr << "Error: must specify --subsample <N> with N>0.\n";
         return 1;
     }
@@ -91,11 +89,7 @@ int VCFXSubsampler::run(int argc, char* argv[]){
     return 0;
 }
 
-void VCFXSubsampler::subsampleLines(std::istream &in,
-                                    std::ostream &out,
-                                    int sampleSize,
-                                    unsigned int seed)
-{
+void VCFXSubsampler::subsampleLines(std::istream &in, std::ostream &out, int sampleSize, unsigned int seed) {
     std::string line;
     bool readingHeader = true; // We begin by reading header lines (#...)
 
@@ -108,18 +102,19 @@ void VCFXSubsampler::subsampleLines(std::istream &in,
 
     // Read the file line by line
     while (true) {
-        if(!std::getline(in, line)) break;  // end of file
-        if(line.empty()) {
+        if (!std::getline(in, line))
+            break; // end of file
+        if (line.empty()) {
             // If an empty line, let's just output if we are still in the header,
             // or skip it otherwise. This is optional; typically, empty lines are uncommon in VCF.
-            if(readingHeader) {
+            if (readingHeader) {
                 out << line << "\n";
             }
             continue;
         }
 
         // If still reading header lines...
-        if(readingHeader && line[0] == '#') {
+        if (readingHeader && line[0] == '#') {
             // This is a header/comment line => pass it through
             out << line << "\n";
             continue;
@@ -132,23 +127,23 @@ void VCFXSubsampler::subsampleLines(std::istream &in,
                 std::stringstream ss(line);
                 std::vector<std::string> fields;
                 std::string tmp;
-                while(std::getline(ss, tmp, '\t')) {
+                while (std::getline(ss, tmp, '\t')) {
                     fields.push_back(tmp);
                 }
-                if(fields.size() < 8) {
+                if (fields.size() < 8) {
                     std::cerr << "Warning: skipping line with <8 columns.\n";
                     continue;
                 }
             }
 
             // Reservoir sampling logic
-            if(count < sampleSize) {
+            if (count < sampleSize) {
                 reservoir.push_back(line);
             } else {
                 // pick random int in [0..count]
                 std::uniform_int_distribution<int> dist(0, count);
                 int j = dist(rng);
-                if(j < sampleSize) {
+                if (j < sampleSize) {
                     reservoir[j] = line;
                 }
             }
@@ -157,15 +152,22 @@ void VCFXSubsampler::subsampleLines(std::istream &in,
     }
 
     // Output reservoir
-    for(const auto &r : reservoir) {
+    for (const auto &r : reservoir) {
         out << r << "\n";
     }
 }
 
-static void show_help() { VCFXSubsampler obj; char arg0[] = "VCFX_subsampler"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXSubsampler obj;
+    char arg0[] = "VCFX_subsampler";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_subsampler", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_subsampler", show_help))
+        return 0;
     VCFXSubsampler app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_subsampler/VCFX_subsampler.h
+++ b/src/VCFX_subsampler/VCFX_subsampler.h
@@ -6,16 +6,14 @@
 #include <vector>
 
 class VCFXSubsampler {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
     // Reservoir sampling method
-    void subsampleLines(std::istream &in, std::ostream &out,
-                        int sampleSize, unsigned int seed);
-
+    void subsampleLines(std::istream &in, std::ostream &out, int sampleSize, unsigned int seed);
 };
 
 #endif

--- a/src/VCFX_sv_handler/VCFX_sv_handler.cpp
+++ b/src/VCFX_sv_handler/VCFX_sv_handler.cpp
@@ -1,39 +1,45 @@
-#include "vcfx_core.h"
 #include "VCFX_sv_handler.h"
-#include <getopt.h>
-#include <sstream>
+#include "vcfx_core.h"
 #include <algorithm>
-#include <vector>
-#include <string>
-#include <iostream>
 #include <cstdlib>
+#include <getopt.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
-int VCFXSvHandler::run(int argc, char* argv[]){
-    if(argc==1){
+int VCFXSvHandler::run(int argc, char *argv[]) {
+    if (argc == 1) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
-    bool filterOnly=false;
-    bool modifySV=false;
+    bool showHelp = false;
+    bool filterOnly = false;
+    bool modifySV = false;
 
-    static struct option longOpts[]={
-        {"help", no_argument, 0,'h'},
-        {"sv-filter-only", no_argument, 0,'f'},
-        {"sv-modify", no_argument, 0,'m'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv, "hfm", longOpts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h': showHelp=true; break;
-            case 'f': filterOnly=true; break;
-            case 'm': modifySV=true; break;
-            default: showHelp=true;
+    static struct option longOpts[] = {{"help", no_argument, 0, 'h'},
+                                       {"sv-filter-only", no_argument, 0, 'f'},
+                                       {"sv-modify", no_argument, 0, 'm'},
+                                       {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hfm", longOpts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'f':
+            filterOnly = true;
+            break;
+        case 'm':
+            modifySV = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
@@ -42,108 +48,106 @@ int VCFXSvHandler::run(int argc, char* argv[]){
     return 0;
 }
 
-void VCFXSvHandler::displayHelp(){
-    std::cout <<
-"VCFX_sv_handler: Filter or modify structural variants in a VCF.\n\n"
-"Usage:\n"
-"  VCFX_sv_handler [options] < input.vcf > output.vcf\n\n"
-"Options:\n"
-"  -h, --help           Show this help.\n"
-"  -f, --sv-filter-only Keep only lines that have 'SVTYPE=' in their INFO.\n"
-"  -m, --sv-modify      Modify the INFO field of structural variants.\n\n"
-"Description:\n"
-"  * If --sv-filter-only is set, we skip lines without structural variant.\n"
-"  * If --sv-modify is set, we add 'SV_VALIDATED=1', 'SV_SIZE=...' for DEL/DUP.\n"
-"    Also 'INV_TYPE=PARALLEL' for INV, 'BND_ORIENTATION=PAIR' for BND. etc.\n"
-"  * If both are set, we do both filtering and modification.\n"
-"  * Non-SV lines are only included if !filterOnly.\n\n"
-"Example:\n"
-"  1) Keep only structural variants:\n"
-"     VCFX_sv_handler --sv-filter-only < in.vcf > out.vcf\n"
-"  2) Modify structural variants:\n"
-"     VCFX_sv_handler --sv-modify < in.vcf > out.vcf\n"
-"  3) Do both:\n"
-"     VCFX_sv_handler --sv-filter-only --sv-modify < in.vcf > out.vcf\n";
+void VCFXSvHandler::displayHelp() {
+    std::cout << "VCFX_sv_handler: Filter or modify structural variants in a VCF.\n\n"
+                 "Usage:\n"
+                 "  VCFX_sv_handler [options] < input.vcf > output.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help           Show this help.\n"
+                 "  -f, --sv-filter-only Keep only lines that have 'SVTYPE=' in their INFO.\n"
+                 "  -m, --sv-modify      Modify the INFO field of structural variants.\n\n"
+                 "Description:\n"
+                 "  * If --sv-filter-only is set, we skip lines without structural variant.\n"
+                 "  * If --sv-modify is set, we add 'SV_VALIDATED=1', 'SV_SIZE=...' for DEL/DUP.\n"
+                 "    Also 'INV_TYPE=PARALLEL' for INV, 'BND_ORIENTATION=PAIR' for BND. etc.\n"
+                 "  * If both are set, we do both filtering and modification.\n"
+                 "  * Non-SV lines are only included if !filterOnly.\n\n"
+                 "Example:\n"
+                 "  1) Keep only structural variants:\n"
+                 "     VCFX_sv_handler --sv-filter-only < in.vcf > out.vcf\n"
+                 "  2) Modify structural variants:\n"
+                 "     VCFX_sv_handler --sv-modify < in.vcf > out.vcf\n"
+                 "  3) Do both:\n"
+                 "     VCFX_sv_handler --sv-filter-only --sv-modify < in.vcf > out.vcf\n";
 }
 
-bool VCFXSvHandler::isStructuralVariant(const std::string &infoField) const{
-    return infoField.find("SVTYPE=")!= std::string::npos;
+bool VCFXSvHandler::isStructuralVariant(const std::string &infoField) const {
+    return infoField.find("SVTYPE=") != std::string::npos;
 }
 
-std::string VCFXSvHandler::parseSVType(const std::string &infoField) const{
+std::string VCFXSvHandler::parseSVType(const std::string &infoField) const {
     // find "SVTYPE="
-    auto pos= infoField.find("SVTYPE=");
-    if(pos== std::string::npos) return "";
-    size_t start= pos+7; 
+    auto pos = infoField.find("SVTYPE=");
+    if (pos == std::string::npos)
+        return "";
+    size_t start = pos + 7;
     // read until next ; or end
-    auto semicol= infoField.find(';', start);
-    if(semicol== std::string::npos){
+    auto semicol = infoField.find(';', start);
+    if (semicol == std::string::npos) {
         return infoField.substr(start);
     } else {
         return infoField.substr(start, semicol - start);
     }
 }
 
-int VCFXSvHandler::parseEndPosition(const std::string &infoField) const{
-    auto pos= infoField.find("END=");
-    if(pos== std::string::npos) return -1;
-    size_t start= pos+4;
-    auto semicol= infoField.find(';', start);
-    std::string endStr= (semicol== std::string::npos) ? infoField.substr(start)
-                                                      : infoField.substr(start, semicol - start);
+int VCFXSvHandler::parseEndPosition(const std::string &infoField) const {
+    auto pos = infoField.find("END=");
+    if (pos == std::string::npos)
+        return -1;
+    size_t start = pos + 4;
+    auto semicol = infoField.find(';', start);
+    std::string endStr =
+        (semicol == std::string::npos) ? infoField.substr(start) : infoField.substr(start, semicol - start);
     try {
         return std::stoi(endStr);
-    } catch(...){
+    } catch (...) {
         return -1;
     }
 }
 
-int VCFXSvHandler::parsePos(const std::string &posField) const{
-    try{
+int VCFXSvHandler::parsePos(const std::string &posField) const {
+    try {
         return std::stoi(posField);
-    }catch(...){
+    } catch (...) {
         return -1;
     }
 }
 
-std::string VCFXSvHandler::manipulateSVInfo(const std::string &infoField,
-                                            const std::string &svType,
-                                            int pos,
-                                            int endPos) const
-{
-    std::string modified= infoField;
-    if(!modified.empty() && modified.back()!=';'){
-        modified+=";";
+std::string VCFXSvHandler::manipulateSVInfo(const std::string &infoField, const std::string &svType, int pos,
+                                            int endPos) const {
+    std::string modified = infoField;
+    if (!modified.empty() && modified.back() != ';') {
+        modified += ";";
     }
-    modified+= "SV_VALIDATED=1"; // a sample annotation
+    modified += "SV_VALIDATED=1"; // a sample annotation
 
     // if we have endPos>0 and pos>0 => maybe we compute size
-    if(endPos>0 && pos>0 && (svType=="DEL"||svType=="DUP")){
-        int svSize= endPos - pos;
+    if (endPos > 0 && pos > 0 && (svType == "DEL" || svType == "DUP")) {
+        int svSize = endPos - pos;
         // possibly handle negative
-        if(svSize<0) svSize= -svSize; 
+        if (svSize < 0)
+            svSize = -svSize;
         modified += ";SV_SIZE=" + std::to_string(svSize);
     }
-    if(svType=="INV"){
+    if (svType == "INV") {
         modified += ";INV_TYPE=PARALLEL";
-    } else if(svType=="BND"){
+    } else if (svType == "BND") {
         modified += ";BND_ORIENTATION=PAIR";
     }
     // other types?
     return modified;
 }
 
-void VCFXSvHandler::handleStructuralVariants(std::istream &in, std::ostream &out,
-                                            bool filterOnly, bool modifySV)
-{
+void VCFXSvHandler::handleStructuralVariants(std::istream &in, std::ostream &out, bool filterOnly, bool modifySV) {
     std::string line;
-    while(true){
-        if(!std::getline(in,line)) break;
-        if(line.empty()){
+    while (true) {
+        if (!std::getline(in, line))
+            break;
+        if (line.empty()) {
             continue;
         }
-        if(line[0]=='#'){
-            out<< line<<"\n";
+        if (line[0] == '#') {
+            out << line << "\n";
             continue;
         }
         // parse
@@ -151,64 +155,73 @@ void VCFXSvHandler::handleStructuralVariants(std::istream &in, std::ostream &out
         std::vector<std::string> fields;
         {
             std::string col;
-            while(std::getline(ss,col,'\t')){
+            while (std::getline(ss, col, '\t')) {
                 fields.push_back(col);
             }
         }
-        if(fields.size()<8){
-            std::cerr<<"Warning: skipping line with <8 columns.\n";
+        if (fields.size() < 8) {
+            std::cerr << "Warning: skipping line with <8 columns.\n";
             continue;
         }
-        bool isSV= isStructuralVariant(fields[7]);
-        if(isSV){
+        bool isSV = isStructuralVariant(fields[7]);
+        if (isSV) {
             // if filterOnly && !modify => just output
             // if modify => we parse and rewrite info
-            if(filterOnly && !modifySV){
-                out<< line<<"\n";
+            if (filterOnly && !modifySV) {
+                out << line << "\n";
                 continue;
             }
-            if(modifySV){
+            if (modifySV) {
                 // parse svtype
-                std::string svType= parseSVType(fields[7]);
-                if(svType.empty()){
-                    std::cerr<<"Warning: no SVTYPE => skipping line.\n";
+                std::string svType = parseSVType(fields[7]);
+                if (svType.empty()) {
+                    std::cerr << "Warning: no SVTYPE => skipping line.\n";
                     continue;
                 }
-                int pos= parsePos(fields[1]);
-                int endPos= parseEndPosition(fields[7]);
-                if(pos<0){
-                    std::cerr<<"Warning: invalid POS => skipping.\n";
+                int pos = parsePos(fields[1]);
+                int endPos = parseEndPosition(fields[7]);
+                if (pos < 0) {
+                    std::cerr << "Warning: invalid POS => skipping.\n";
                     continue;
                 }
-                std::string newInfo= manipulateSVInfo(fields[7], svType, pos, endPos);
-                fields[7]= newInfo;
+                std::string newInfo = manipulateSVInfo(fields[7], svType, pos, endPos);
+                fields[7] = newInfo;
                 // rebuild
-                bool first=true;
-                for(size_t i=0;i<fields.size(); i++){
-                    if(!first) out<<"\t";
-                    else first=false;
-                    out<< fields[i];
+                bool first = true;
+                for (size_t i = 0; i < fields.size(); i++) {
+                    if (!first)
+                        out << "\t";
+                    else
+                        first = false;
+                    out << fields[i];
                 }
-                out<<"\n";
+                out << "\n";
                 continue;
             }
             // if we get here => isSV, but not filterOnly or modify => just output
-            out<< line<<"\n";
+            out << line << "\n";
         } else {
             // not an SV
-            if(!filterOnly){
+            if (!filterOnly) {
                 // keep it
-                out<< line<<"\n";
+                out << line << "\n";
             }
             // else skip
         }
     }
 }
 
-static void show_help() { VCFXSvHandler obj; char arg0[] = "VCFX_sv_handler"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXSvHandler obj;
+    char arg0[] = "VCFX_sv_handler";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_sv_handler", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_sv_handler", show_help))
+        return 0;
     VCFXSvHandler app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_sv_handler/VCFX_sv_handler.h
+++ b/src/VCFX_sv_handler/VCFX_sv_handler.h
@@ -5,10 +5,10 @@
 #include <string>
 
 class VCFXSvHandler {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     void displayHelp();
 
     // The main method to read lines from 'in' and apply filtering/modify logic, then write to 'out'.
@@ -27,9 +27,7 @@ private:
     int parsePos(const std::string &posField) const;
 
     // If we are modifying, do the manipulations (like adding SV_SIZE=..., etc.)
-    std::string manipulateSVInfo(const std::string &infoField,
-                                 const std::string &svType,
-                                 int pos, int endPos) const;
+    std::string manipulateSVInfo(const std::string &infoField, const std::string &svType, int pos, int endPos) const;
 };
 
 #endif

--- a/src/VCFX_validator/VCFX_validator.cpp
+++ b/src/VCFX_validator/VCFX_validator.cpp
@@ -1,152 +1,168 @@
-#include "vcfx_core.h"
 #include "VCFX_validator.h"
-#include <getopt.h>
-#include <sstream>
-#include <vector>
+#include "vcfx_core.h"
 #include <cctype>
 #include <cstdlib>
-#include <unistd.h>
+#include <getopt.h>
 #include <regex>
+#include <sstream>
+#include <unistd.h>
+#include <vector>
 
-static std::string trim(const std::string &s){
-    size_t start=0;
-    while(start<s.size() && std::isspace((unsigned char)s[start])) start++;
-    if(start== s.size()) return "";
-    size_t end= s.size()-1;
-    while(end> start && std::isspace((unsigned char)s[end])) end--;
-    return s.substr(start, end-start+1);
+static std::string trim(const std::string &s) {
+    size_t start = 0;
+    while (start < s.size() && std::isspace((unsigned char)s[start]))
+        start++;
+    if (start == s.size())
+        return "";
+    size_t end = s.size() - 1;
+    while (end > start && std::isspace((unsigned char)s[end]))
+        end--;
+    return s.substr(start, end - start + 1);
 }
 
-static std::vector<std::string> split(const std::string &s, char delim){
+static std::vector<std::string> split(const std::string &s, char delim) {
     std::vector<std::string> out;
     std::stringstream ss(s);
     std::string item;
-    while(std::getline(ss, item, delim)) out.push_back(item);
+    while (std::getline(ss, item, delim))
+        out.push_back(item);
     return out;
 }
 
-static bool valid_dna(const std::string& s){
-    if(s.empty()) return false;
-    for(char c: s){
+static bool valid_dna(const std::string &s) {
+    if (s.empty())
+        return false;
+    for (char c : s) {
         char u = std::toupper(static_cast<unsigned char>(c));
-        if(u!='A' && u!='C' && u!='G' && u!='T' && u!='N') return false;
+        if (u != 'A' && u != 'C' && u != 'G' && u != 'T' && u != 'N')
+            return false;
     }
     return true;
 }
 
-int VCFXValidator::run(int argc, char* argv[]){
+int VCFXValidator::run(int argc, char *argv[]) {
     bool hasStdin = !isatty(fileno(stdin));
-    if(argc==1 && !hasStdin){
+    if (argc == 1 && !hasStdin) {
         displayHelp();
         return 0;
     }
-    bool showHelp=false;
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"strict", no_argument, 0, 's'},
-        {"report-dups", no_argument, 0, 'd'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv, "hsd", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h': showHelp=true; break;
-            case 's': strictMode= true; break;
-            case 'd': reportDuplicates = true; break;
-            default: showHelp= true;
+    bool showHelp = false;
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'},
+                                        {"strict", no_argument, 0, 's'},
+                                        {"report-dups", no_argument, 0, 'd'},
+                                        {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "hsd", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 's':
+            strictMode = true;
+            break;
+        case 'd':
+            reportDuplicates = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    bool ok= validateVCF(std::cin);
+    bool ok = validateVCF(std::cin);
     return (ok ? 0 : 1);
 }
 
-void VCFXValidator::displayHelp(){
-    std::cout <<
-"VCFX_validator: Checks basic validity of a VCF.\n\n"
-"Usage:\n"
-"  VCFX_validator [options] < input.vcf\n\n"
-"Options:\n"
-"  -h, --help     Show this help.\n"
-"  -s, --strict   Enable stricter checks.\n"
-"  -d, --report-dups Report duplicate records.\n\n"
-"Description:\n"
-"  Validates:\n"
-"   * All '##' lines are recognized as meta lines.\n"
-"   * #CHROM line is present and well formed.\n"
-"   * Each data line has >=8 columns, checks CHROM non-empty, POS>0,\n"
-"     REF/ALT non-empty, QUAL is '.' or non-negative float, FILTER non-empty,\n"
-"     INFO fields are checked against header definitions.\n"
-"   * FORMAT fields and genotype values are validated.\n"
-"   * REF and ALT sequences must contain only A,C,G,T,N.\n"
-"   * Duplicate variants are detected when --report-dups is used.\n"
-"  In strict mode additional checks are performed:\n"
-"   * Data line column count must match the #CHROM header.\n"
-"   * Sample columns must match the FORMAT field structure.\n"
-"   * Any warning is treated as an error.\n"
-"  Exits 0 if pass, 1 if fail.\n";
+void VCFXValidator::displayHelp() {
+    std::cout << "VCFX_validator: Checks basic validity of a VCF.\n\n"
+                 "Usage:\n"
+                 "  VCFX_validator [options] < input.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help     Show this help.\n"
+                 "  -s, --strict   Enable stricter checks.\n"
+                 "  -d, --report-dups Report duplicate records.\n\n"
+                 "Description:\n"
+                 "  Validates:\n"
+                 "   * All '##' lines are recognized as meta lines.\n"
+                 "   * #CHROM line is present and well formed.\n"
+                 "   * Each data line has >=8 columns, checks CHROM non-empty, POS>0,\n"
+                 "     REF/ALT non-empty, QUAL is '.' or non-negative float, FILTER non-empty,\n"
+                 "     INFO fields are checked against header definitions.\n"
+                 "   * FORMAT fields and genotype values are validated.\n"
+                 "   * REF and ALT sequences must contain only A,C,G,T,N.\n"
+                 "   * Duplicate variants are detected when --report-dups is used.\n"
+                 "  In strict mode additional checks are performed:\n"
+                 "   * Data line column count must match the #CHROM header.\n"
+                 "   * Sample columns must match the FORMAT field structure.\n"
+                 "   * Any warning is treated as an error.\n"
+                 "  Exits 0 if pass, 1 if fail.\n";
 }
 
-bool VCFXValidator::validateMetaLine(const std::string &line, int lineNumber){
-    if(line.size()<2) return false;
-    if(line.rfind("##INFO=",0)==0 || line.rfind("##FORMAT=",0)==0){
-        size_t start=line.find('<');
-        size_t end=line.rfind('>');
-        if(start==std::string::npos || end==std::string::npos || end<=start){
-            std::cerr<<"Error: malformed header at line "<<lineNumber<<".\n";
+bool VCFXValidator::validateMetaLine(const std::string &line, int lineNumber) {
+    if (line.size() < 2)
+        return false;
+    if (line.rfind("##INFO=", 0) == 0 || line.rfind("##FORMAT=", 0) == 0) {
+        size_t start = line.find('<');
+        size_t end = line.rfind('>');
+        if (start == std::string::npos || end == std::string::npos || end <= start) {
+            std::cerr << "Error: malformed header at line " << lineNumber << ".\n";
             return false;
         }
-        std::string inside=line.substr(start+1,end-start-1);
-        auto fields=split(inside,',');
-        std::string id,number,type;
-        for(auto &f:fields){
-            auto eq=f.find('=');
-            if(eq==std::string::npos) continue;
-            std::string key=trim(f.substr(0,eq));
-            std::string val=trim(f.substr(eq+1));
-            if(key=="ID") id=val;
-            else if(key=="Number") number=val;
-            else if(key=="Type") type=val;
+        std::string inside = line.substr(start + 1, end - start - 1);
+        auto fields = split(inside, ',');
+        std::string id, number, type;
+        for (auto &f : fields) {
+            auto eq = f.find('=');
+            if (eq == std::string::npos)
+                continue;
+            std::string key = trim(f.substr(0, eq));
+            std::string val = trim(f.substr(eq + 1));
+            if (key == "ID")
+                id = val;
+            else if (key == "Number")
+                number = val;
+            else if (key == "Type")
+                type = val;
         }
-        if(id.empty()){
-            std::cerr<<"Error: header line missing ID at "<<lineNumber<<".\n";
+        if (id.empty()) {
+            std::cerr << "Error: header line missing ID at " << lineNumber << ".\n";
             return false;
         }
-        FieldDef def{number,type};
-        if(line.rfind("##INFO=",0)==0){
-            infoDefs[id]=def;
-        }else{
-            formatDefs[id]=def;
+        FieldDef def{number, type};
+        if (line.rfind("##INFO=", 0) == 0) {
+            infoDefs[id] = def;
+        } else {
+            formatDefs[id] = def;
         }
         return true;
     }
-    if(line[0]=='#' && line[1]=='#'){
+    if (line[0] == '#' && line[1] == '#') {
         return true;
     }
-    std::cerr<<"Error: line "<< lineNumber <<" is a header line but doesn't start with '##'.\n";
+    std::cerr << "Error: line " << lineNumber << " is a header line but doesn't start with '##'.\n";
     return false;
 }
 
-bool VCFXValidator::validateChromHeader(const std::string &line, int lineNumber){
+bool VCFXValidator::validateChromHeader(const std::string &line, int lineNumber) {
     // parse by tab
     std::vector<std::string> f;
     {
         std::stringstream ss(line);
         std::string col;
-        while(std::getline(ss,col,'\t')){
+        while (std::getline(ss, col, '\t')) {
             f.push_back(col);
         }
     }
-    if(f.size()<8){
-        std::cerr<<"Error: #CHROM line at "<< lineNumber <<" has <8 columns.\n";
+    if (f.size() < 8) {
+        std::cerr << "Error: #CHROM line at " << lineNumber << " has <8 columns.\n";
         return false;
     }
-    if(f[0]!="#CHROM"){
-        std::cerr<<"Error: #CHROM line doesn't start with '#CHROM' at line "<< lineNumber <<".\n";
+    if (f[0] != "#CHROM") {
+        std::cerr << "Error: #CHROM line doesn't start with '#CHROM' at line " << lineNumber << ".\n";
         return false;
     }
 
@@ -154,9 +170,9 @@ bool VCFXValidator::validateChromHeader(const std::string &line, int lineNumber)
     headerHasFormat = (headerColumnCount > 8);
     sampleCount = headerHasFormat ? headerColumnCount - 9 : 0;
 
-    if(headerHasFormat && f[8] != "FORMAT"){
+    if (headerHasFormat && f[8] != "FORMAT") {
         std::string msg = "Warning: column 9 of #CHROM header is not 'FORMAT'.";
-        if(strictMode){
+        if (strictMode) {
             std::cerr << "Error: " << msg << "\n";
             return false;
         } else {
@@ -166,233 +182,233 @@ bool VCFXValidator::validateChromHeader(const std::string &line, int lineNumber)
     return true;
 }
 
-bool VCFXValidator::validateDataLine(const std::string &line, int lineNumber){
+bool VCFXValidator::validateDataLine(const std::string &line, int lineNumber) {
     // parse
     std::vector<std::string> f;
     {
         std::stringstream ss(line);
         std::string col;
-        while(std::getline(ss,col,'\t')){
+        while (std::getline(ss, col, '\t')) {
             f.push_back(trim(col));
         }
     }
-    if(f.size()<8){
-        std::cerr<<"Error: line "<< lineNumber <<" has <8 columns.\n";
+    if (f.size() < 8) {
+        std::cerr << "Error: line " << lineNumber << " has <8 columns.\n";
         return false;
     }
-    if(headerColumnCount>0){
-        if(strictMode && static_cast<int>(f.size()) != headerColumnCount){
-            std::cerr << "Error: line "<<lineNumber<<" has "<<f.size()
-                      <<" columns but header specifies "<<headerColumnCount<<".\n";
+    if (headerColumnCount > 0) {
+        if (strictMode && static_cast<int>(f.size()) != headerColumnCount) {
+            std::cerr << "Error: line " << lineNumber << " has " << f.size() << " columns but header specifies "
+                      << headerColumnCount << ".\n";
             return false;
-        } else if(static_cast<int>(f.size()) != headerColumnCount){
-            std::cerr << "Warning: line "<<lineNumber<<" column count "<<f.size()
-                      <<" differs from header ("<<headerColumnCount<<").\n";
+        } else if (static_cast<int>(f.size()) != headerColumnCount) {
+            std::cerr << "Warning: line " << lineNumber << " column count " << f.size() << " differs from header ("
+                      << headerColumnCount << ").\n";
         }
     }
     // CHROM
-    if(f[0].empty()){
-        std::cerr<<"Error: line "<<lineNumber<<" CHROM is empty.\n";
+    if (f[0].empty()) {
+        std::cerr << "Error: line " << lineNumber << " CHROM is empty.\n";
         return false;
     }
     // POS
     {
-        int pos=0;
-        try{
-            pos= std::stoi(f[1]);
-            if(pos<=0){
-                std::cerr<<"Error: line "<<lineNumber<<" POS must be >0.\n";
+        int pos = 0;
+        try {
+            pos = std::stoi(f[1]);
+            if (pos <= 0) {
+                std::cerr << "Error: line " << lineNumber << " POS must be >0.\n";
                 return false;
             }
-        } catch(...){
-            std::cerr<<"Error: line "<<lineNumber<<" POS not parseable.\n";
+        } catch (...) {
+            std::cerr << "Error: line " << lineNumber << " POS not parseable.\n";
             return false;
         }
     }
     // ID can be empty => that's fine
     // REF
-    if(f[3].empty()){
-        std::cerr<<"Error: line "<< lineNumber<<" REF is empty.\n";
+    if (f[3].empty()) {
+        std::cerr << "Error: line " << lineNumber << " REF is empty.\n";
         return false;
     }
-    if(!valid_dna(f[3])){
-        std::cerr<<"Error: line "<<lineNumber<<" REF has invalid characters.\n";
+    if (!valid_dna(f[3])) {
+        std::cerr << "Error: line " << lineNumber << " REF has invalid characters.\n";
         return false;
     }
     // ALT
-    if(f[4].empty()){
-        std::cerr<<"Error: line "<< lineNumber<<" ALT is empty.\n";
+    if (f[4].empty()) {
+        std::cerr << "Error: line " << lineNumber << " ALT is empty.\n";
         return false;
     }
-    if(!valid_dna(f[4])){
-        std::cerr<<"Error: line "<<lineNumber<<" ALT has invalid characters.\n";
+    if (!valid_dna(f[4])) {
+        std::cerr << "Error: line " << lineNumber << " ALT has invalid characters.\n";
         return false;
     }
     // QUAL => '.' or non-neg float
-    if(f[5]!="."){
-        try{
-            double q= std::stod(f[5]);
-            if(q<0){
-                std::cerr<<"Error: line "<<lineNumber<<" negative QUAL.\n";
+    if (f[5] != ".") {
+        try {
+            double q = std::stod(f[5]);
+            if (q < 0) {
+                std::cerr << "Error: line " << lineNumber << " negative QUAL.\n";
                 return false;
             }
-        } catch(...){
-            std::cerr<<"Error: line "<<lineNumber<<" invalid QUAL.\n";
+        } catch (...) {
+            std::cerr << "Error: line " << lineNumber << " invalid QUAL.\n";
             return false;
         }
     }
     // FILTER => must not be empty
-    if(f[6].empty()){
-        std::cerr<<"Error: line "<<lineNumber<<" FILTER is empty.\n";
+    if (f[6].empty()) {
+        std::cerr << "Error: line " << lineNumber << " FILTER is empty.\n";
         return false;
     }
     // INFO field validation
-    if(f[7]!="."){
+    if (f[7] != ".") {
         std::stringstream infoSS(f[7]);
         std::string token;
-        bool anyValid=false;
-        while(std::getline(infoSS, token, ';')){
-            token=trim(token);
-            if(token.empty()) continue;
-            auto eq=token.find('=');
-            if(eq==std::string::npos){
-                std::string k=token;
-                auto it=infoDefs.find(k);
-                if(it==infoDefs.end()){
-                    std::string msg="INFO field " + k + " not defined in header";
-                    if(strictMode){
-                        std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+        bool anyValid = false;
+        while (std::getline(infoSS, token, ';')) {
+            token = trim(token);
+            if (token.empty())
+                continue;
+            auto eq = token.find('=');
+            if (eq == std::string::npos) {
+                std::string k = token;
+                auto it = infoDefs.find(k);
+                if (it == infoDefs.end()) {
+                    std::string msg = "INFO field " + k + " not defined in header";
+                    if (strictMode) {
+                        std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                         return false;
-                    }else{
-                        std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+                    } else {
+                        std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
                     }
                 }
-                anyValid=true;
-            }else{
-                std::string k=token.substr(0,eq);
-                std::string v=token.substr(eq+1);
-                if(k.empty()){
-                    std::cerr<<"Error: line "<<lineNumber<<" has INFO with empty key.\n";
+                anyValid = true;
+            } else {
+                std::string k = token.substr(0, eq);
+                std::string v = token.substr(eq + 1);
+                if (k.empty()) {
+                    std::cerr << "Error: line " << lineNumber << " has INFO with empty key.\n";
                     return false;
                 }
-                auto it=infoDefs.find(k);
-                if(it==infoDefs.end()){
-                    std::string msg="INFO field " + k + " not defined in header";
-                    if(strictMode){
-                        std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+                auto it = infoDefs.find(k);
+                if (it == infoDefs.end()) {
+                    std::string msg = "INFO field " + k + " not defined in header";
+                    if (strictMode) {
+                        std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                         return false;
-                    }else{
-                        std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+                    } else {
+                        std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
                     }
-                }else if(!it->second.number.empty() &&
-                         std::all_of(it->second.number.begin(), it->second.number.end(), ::isdigit)){
-                    size_t expected=static_cast<size_t>(std::stoi(it->second.number));
-                    size_t have=split(v, ',').size();
-                    if(have!=expected){
-                        std::string msg="INFO field " + k + " expected " + it->second.number +
-                                         " values";
-                        if(strictMode){
-                            std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+                } else if (!it->second.number.empty() &&
+                           std::all_of(it->second.number.begin(), it->second.number.end(), ::isdigit)) {
+                    size_t expected = static_cast<size_t>(std::stoi(it->second.number));
+                    size_t have = split(v, ',').size();
+                    if (have != expected) {
+                        std::string msg = "INFO field " + k + " expected " + it->second.number + " values";
+                        if (strictMode) {
+                            std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                             return false;
-                        }else{
-                            std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+                        } else {
+                            std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
                         }
                     }
                 }
-                anyValid=true;
+                anyValid = true;
             }
         }
-        if(!anyValid){
-            std::cerr<<"Error: line "<<lineNumber<<" INFO not valid.\n";
+        if (!anyValid) {
+            std::cerr << "Error: line " << lineNumber << " INFO not valid.\n";
             return false;
         }
     }
 
-    if(headerHasFormat){
-        if(f.size()<9){
-            std::cerr<<"Error: line "<<lineNumber<<" missing FORMAT/sample columns."<<"\n";
+    if (headerHasFormat) {
+        if (f.size() < 9) {
+            std::cerr << "Error: line " << lineNumber << " missing FORMAT/sample columns." << "\n";
             return false;
         }
         std::vector<std::string> formatParts = split(f[8], ':');
-        for(const auto &fp : formatParts){
+        for (const auto &fp : formatParts) {
             auto it = formatDefs.find(fp);
-            if(it==formatDefs.end()){
+            if (it == formatDefs.end()) {
                 std::string msg = "FORMAT field " + fp + " not defined in header";
-                if(strictMode){
-                    std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+                if (strictMode) {
+                    std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                     return false;
                 } else {
-                    std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+                    std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
                 }
             }
         }
-        for(size_t i=9;i<f.size();++i){
-            if(f[i]=="." || f[i].empty()) continue;
+        for (size_t i = 9; i < f.size(); ++i) {
+            if (f[i] == "." || f[i].empty())
+                continue;
             std::vector<std::string> sampleParts = split(f[i], ':');
-            if(sampleParts.size()!=formatParts.size()){
-                std::string msg = "Warning: sample column " + std::to_string(i-8) +
-                    " does not match FORMAT field";
-                if(strictMode){
-                    std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+            if (sampleParts.size() != formatParts.size()) {
+                std::string msg = "Warning: sample column " + std::to_string(i - 8) + " does not match FORMAT field";
+                if (strictMode) {
+                    std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                     return false;
                 } else {
-                    std::cerr<<msg<<" on line "<<lineNumber<<".\n";
+                    std::cerr << msg << " on line " << lineNumber << ".\n";
                 }
             }
-            for(size_t j=0;j<sampleParts.size() && j<formatParts.size();++j){
+            for (size_t j = 0; j < sampleParts.size() && j < formatParts.size(); ++j) {
                 const std::string &key = formatParts[j];
                 const std::string &val = sampleParts[j];
                 auto it = formatDefs.find(key);
-                if(it!=formatDefs.end() && !it->second.number.empty() &&
-                   std::all_of(it->second.number.begin(), it->second.number.end(), ::isdigit)){
+                if (it != formatDefs.end() && !it->second.number.empty() &&
+                    std::all_of(it->second.number.begin(), it->second.number.end(), ::isdigit)) {
                     size_t expected = static_cast<size_t>(std::stoi(it->second.number));
                     size_t have = split(val, ',').size();
-                    if(have!=expected){
+                    if (have != expected) {
                         std::string msg = "FORMAT field " + key + " expected " + it->second.number + " values";
-                        if(strictMode){
-                            std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+                        if (strictMode) {
+                            std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                             return false;
                         } else {
-                            std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+                            std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
                         }
                     }
                 }
-                if(key=="GT" && !val.empty()){
+                if (key == "GT" && !val.empty()) {
                     static const std::regex gtRegex("^(\\.|(\\d+([/|]\\d+)*))$");
-                    if(!std::regex_match(val, gtRegex)){
+                    if (!std::regex_match(val, gtRegex)) {
                         std::string msg = "invalid genotype";
-                        if(strictMode){
-                            std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+                        if (strictMode) {
+                            std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
                             return false;
                         } else {
-                            std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+                            std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
                         }
                     }
                 }
             }
         }
-    } else if(f.size()>8){
+    } else if (f.size() > 8) {
         std::string msg = "Warning: data line has sample columns but header lacks FORMAT";
-        if(strictMode){
-            std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+        if (strictMode) {
+            std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
             return false;
         } else {
-            std::cerr<<msg<<" on line "<<lineNumber<<".\n";
+            std::cerr << msg << " on line " << lineNumber << ".\n";
         }
     }
 
     // duplicate detection
     std::string key = f[0] + ":" + f[1] + ":" + f[3] + ":" + f[4];
-    if(seenVariants.count(key)){
+    if (seenVariants.count(key)) {
         std::string msg = "duplicate variant";
-        if(reportDuplicates){
-            std::cerr<<"Duplicate at line "<<lineNumber<<"\n";
+        if (reportDuplicates) {
+            std::cerr << "Duplicate at line " << lineNumber << "\n";
         }
-        if(strictMode){
-            std::cerr<<"Error: "<<msg<<" on line "<<lineNumber<<".\n";
+        if (strictMode) {
+            std::cerr << "Error: " << msg << " on line " << lineNumber << ".\n";
             return false;
         } else {
-            std::cerr<<"Warning: "<<msg<<" on line "<<lineNumber<<".\n";
+            std::cerr << "Warning: " << msg << " on line " << lineNumber << ".\n";
         }
     } else {
         seenVariants.insert(key);
@@ -401,64 +417,76 @@ bool VCFXValidator::validateDataLine(const std::string &line, int lineNumber){
     return true;
 }
 
-bool VCFXValidator::validateVCF(std::istream &in){
+bool VCFXValidator::validateVCF(std::istream &in) {
     std::string data;
-    if(!vcfx::read_maybe_compressed(in, data)){
-        std::cerr<<"Error: failed to read input stream.\n";
+    if (!vcfx::read_maybe_compressed(in, data)) {
+        std::cerr << "Error: failed to read input stream.\n";
         return false;
     }
     std::istringstream iss(data);
     std::string line;
-    int lineNum=0;
-    bool foundChromLine=false;
+    int lineNum = 0;
+    bool foundChromLine = false;
     std::vector<std::string> lines;
 
-    while(true){
-        if(!std::getline(iss, line)) break;
+    while (true) {
+        if (!std::getline(iss, line))
+            break;
         lineNum++;
-        if(line.empty()){
+        if (line.empty()) {
             // skip
             continue;
         }
-        if(line[0]=='#'){
+        if (line[0] == '#') {
             // could be ## or #CHROM
-            if(line.rfind("##",0)==0){
+            if (line.rfind("##", 0) == 0) {
                 // validate meta
-                if(!validateMetaLine(line, lineNum)) return false;
-            } else if(line.rfind("#CHROM",0)==0){
+                if (!validateMetaLine(line, lineNum))
+                    return false;
+            } else if (line.rfind("#CHROM", 0) == 0) {
                 // validate #CHROM
-                if(!validateChromHeader(line, lineNum)) return false;
-                foundChromLine= true;
+                if (!validateChromHeader(line, lineNum))
+                    return false;
+                foundChromLine = true;
             } else {
                 // Any line starting with '#' but not "##" or "#CHROM" is invalid
-                std::cerr<<"Error: line "<<lineNum<<" is a header line but neither starts with '##' nor is a #CHROM header line.\n";
+                std::cerr << "Error: line " << lineNum
+                          << " is a header line but neither starts with '##' nor is a #CHROM header line.\n";
                 return false;
             }
         } else {
             // data line
-            if(!foundChromLine){
-                std::cerr<<"Error: data line encountered before #CHROM at line "<<lineNum<<".\n";
+            if (!foundChromLine) {
+                std::cerr << "Error: data line encountered before #CHROM at line " << lineNum << ".\n";
                 return false;
             }
-            if(!validateDataLine(line, lineNum)) return false;
+            if (!validateDataLine(line, lineNum))
+                return false;
         }
         lines.push_back(line);
     }
-    if(!foundChromLine){
-        std::cerr<<"Error: no #CHROM line found in file.\n";
+    if (!foundChromLine) {
+        std::cerr << "Error: no #CHROM line found in file.\n";
         return false;
     }
-    for(const auto &l : lines){
+    for (const auto &l : lines) {
         std::cout << l << '\n';
     }
-    std::cerr<<"VCF file is valid.\n";
+    std::cerr << "VCF file is valid.\n";
     return true;
 }
 
-static void show_help() { VCFXValidator obj; char arg0[] = "VCFX_validator"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXValidator obj;
+    char arg0[] = "VCFX_validator";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_validator", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_validator", show_help))
+        return 0;
     VCFXValidator validator;
     return validator.run(argc, argv);
 }

--- a/src/VCFX_validator/VCFX_validator.h
+++ b/src/VCFX_validator/VCFX_validator.h
@@ -7,10 +7,10 @@
 #include <unordered_set>
 
 class VCFXValidator {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // If we add advanced checks for e.g. "strict" mode, we store a bool
     bool strictMode = false;
     bool reportDuplicates = false;

--- a/src/VCFX_variant_classifier/VCFX_variant_classifier.cpp
+++ b/src/VCFX_variant_classifier/VCFX_variant_classifier.cpp
@@ -1,65 +1,66 @@
-#include "vcfx_core.h"
 #include "VCFX_variant_classifier.h"
-#include <getopt.h>
-#include <iostream>
-#include <sstream>
-#include <vector>
-#include <string>
+#include "vcfx_core.h"
 #include <algorithm>
 #include <cctype>
+#include <getopt.h>
+#include <iostream>
+#include <poll.h> // Add this for poll() function
+#include <sstream>
+#include <string>
 #include <unordered_set>
-#include <poll.h>  // Add this for poll() function
+#include <vector>
 
 // A helper to trim spaces
-static std::string trim(const std::string &s){
-    size_t start=0; 
-    while(start<s.size() && std::isspace((unsigned char)s[start])) start++;
-    if(start== s.size()) return "";
-    size_t end= s.size()-1;
-    while(end> start && std::isspace((unsigned char)s[end])) end--;
-    return s.substr(start, end-start+1);
+static std::string trim(const std::string &s) {
+    size_t start = 0;
+    while (start < s.size() && std::isspace((unsigned char)s[start]))
+        start++;
+    if (start == s.size())
+        return "";
+    size_t end = s.size() - 1;
+    while (end > start && std::isspace((unsigned char)s[end]))
+        end--;
+    return s.substr(start, end - start + 1);
 }
 
-int VCFXVariantClassifier::run(int argc, char* argv[]){
+int VCFXVariantClassifier::run(int argc, char *argv[]) {
     bool showHelp = false;
-    
+
     // Check if stdin has data available when no arguments
-    if(argc == 1) {
+    if (argc == 1) {
         // Check if stdin has data using poll
         struct pollfd fds;
         fds.fd = 0; // stdin
         fds.events = POLLIN;
-        
+
         // Poll stdin with 0 timeout to check if data is available
         int ret = poll(&fds, 1, 0);
-        
+
         // Show help if no data is available on stdin
         if (ret <= 0 || !(fds.revents & POLLIN)) {
             displayHelp();
             return 0;
         }
     }
-    
-    static struct option long_opts[]={
-        {"help", no_argument, 0, 'h'},
-        {"append-info", no_argument, 0, 'a'},
-        {0,0,0,0}
-    };
-    while(true){
-        int c= ::getopt_long(argc, argv,"ha", long_opts, nullptr);
-        if(c==-1) break;
-        switch(c){
-            case 'h':
-                showHelp=true;
-                break;
-            case 'a':
-                appendInfo=true;
-                break;
-            default:
-                showHelp=true;
+
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'}, {"append-info", no_argument, 0, 'a'}, {0, 0, 0, 0}};
+    while (true) {
+        int c = ::getopt_long(argc, argv, "ha", long_opts, nullptr);
+        if (c == -1)
+            break;
+        switch (c) {
+        case 'h':
+            showHelp = true;
+            break;
+        case 'a':
+            appendInfo = true;
+            break;
+        default:
+            showHelp = true;
         }
     }
-    if(showHelp){
+    if (showHelp) {
         displayHelp();
         return 0;
     }
@@ -67,46 +68,46 @@ int VCFXVariantClassifier::run(int argc, char* argv[]){
     return 0;
 }
 
-void VCFXVariantClassifier::displayHelp(){
-    std::cout <<
-"VCFX_variant_classifier: Classify variants in a VCF as SNP, INDEL, MNV, or STRUCTURAL.\n\n"
-"Usage:\n"
-"  VCFX_variant_classifier [options] < input.vcf > output.vcf_or_tsv\n\n"
-"Options:\n"
-"  -h, --help         Show help.\n"
-"  -a, --append-info  Instead of producing a TSV, output a valid VCF\n"
-"                     with a new 'VCF_CLASS' subfield in the INFO.\n\n"
-"Description:\n"
-"  Reads each variant line, determines if it is:\n"
-"    SNP: single base ref & alt,\n"
-"    INDEL: length mismatch (less than 50 bp difference) in ref vs alt,\n"
-"    MNV: same length >1,\n"
-"    STRUCTURAL: alt is symbolic (<DEL>, <INS>, <DUP>), or breakend ([chr etc.)\n"
-"                or length difference >=50.\n"
-"  If --append-info, prints original columns + updated INFO. Otherwise prints\n"
-"  'CHROM POS ID REF ALT Classification' as TSV.\n\n"
-"Examples:\n"
-"  1) TSV classification:\n"
-"     VCFX_variant_classifier < input.vcf > classified.tsv\n"
-"  2) Modify INFO in output VCF:\n"
-"     VCFX_variant_classifier --append-info < input.vcf > annotated.vcf\n";
+void VCFXVariantClassifier::displayHelp() {
+    std::cout << "VCFX_variant_classifier: Classify variants in a VCF as SNP, INDEL, MNV, or STRUCTURAL.\n\n"
+                 "Usage:\n"
+                 "  VCFX_variant_classifier [options] < input.vcf > output.vcf_or_tsv\n\n"
+                 "Options:\n"
+                 "  -h, --help         Show help.\n"
+                 "  -a, --append-info  Instead of producing a TSV, output a valid VCF\n"
+                 "                     with a new 'VCF_CLASS' subfield in the INFO.\n\n"
+                 "Description:\n"
+                 "  Reads each variant line, determines if it is:\n"
+                 "    SNP: single base ref & alt,\n"
+                 "    INDEL: length mismatch (less than 50 bp difference) in ref vs alt,\n"
+                 "    MNV: same length >1,\n"
+                 "    STRUCTURAL: alt is symbolic (<DEL>, <INS>, <DUP>), or breakend ([chr etc.)\n"
+                 "                or length difference >=50.\n"
+                 "  If --append-info, prints original columns + updated INFO. Otherwise prints\n"
+                 "  'CHROM POS ID REF ALT Classification' as TSV.\n\n"
+                 "Examples:\n"
+                 "  1) TSV classification:\n"
+                 "     VCFX_variant_classifier < input.vcf > classified.tsv\n"
+                 "  2) Modify INFO in output VCF:\n"
+                 "     VCFX_variant_classifier --append-info < input.vcf > annotated.vcf\n";
 }
 
-std::vector<std::string> VCFXVariantClassifier::split(const std::string &s, char delim) const{
+std::vector<std::string> VCFXVariantClassifier::split(const std::string &s, char delim) const {
     std::vector<std::string> out;
     std::stringstream ss(s);
     std::string t;
-    while(std::getline(ss,t,delim)){
+    while (std::getline(ss, t, delim)) {
         out.push_back(t);
     }
     return out;
 }
 
-bool VCFXVariantClassifier::isStructuralAllele(const std::string &alt) const{
+bool VCFXVariantClassifier::isStructuralAllele(const std::string &alt) const {
     // If alt is symbolic: <DEL>, <INS>, ...
-    if(!alt.empty() && alt.front()=='<' && alt.back()=='>') return true;
+    if (!alt.empty() && alt.front() == '<' && alt.back() == '>')
+        return true;
     // If alt has breakend notation: [chr..., ]chr...
-    if(alt.find('[')!=std::string::npos || alt.find(']')!= std::string::npos){
+    if (alt.find('[') != std::string::npos || alt.find(']') != std::string::npos) {
         return true;
     }
     // If alt length or ref length > 50 => structural
@@ -114,167 +115,184 @@ bool VCFXVariantClassifier::isStructuralAllele(const std::string &alt) const{
     return false;
 }
 
-VariantType VCFXVariantClassifier::classifyAllele(const std::string &ref, const std::string &alt) const{
+VariantType VCFXVariantClassifier::classifyAllele(const std::string &ref, const std::string &alt) const {
     // check structural
-    if(isStructuralAllele(alt)){
+    if (isStructuralAllele(alt)) {
         return VariantType::STRUCTURAL;
     }
-    
+
     // if length difference >=50 => structural
-    if(std::abs((int)ref.size() - (int)alt.size()) >= 50){
+    if (std::abs((int)ref.size() - (int)alt.size()) >= 50) {
         return VariantType::STRUCTURAL;
     }
-    
+
     // If REF and ALT are identical, this should be UNKNOWN
-    if(ref == alt) {
+    if (ref == alt) {
         return VariantType::UNKNOWN;
     }
-    
+
     // if both single base
-    if(ref.size()==1 && alt.size()==1 &&
-       std::isalpha((unsigned char)ref[0]) && std::isalpha((unsigned char)alt[0])){
+    if (ref.size() == 1 && alt.size() == 1 && std::isalpha((unsigned char)ref[0]) &&
+        std::isalpha((unsigned char)alt[0])) {
         return VariantType::SNP;
     }
-    
+
     // if length differs => small INDEL
-    if(ref.size()!= alt.size()){
+    if (ref.size() != alt.size()) {
         // Additional check for large variants
-        if(ref.size() >= 40 || alt.size() >= 40){
+        if (ref.size() >= 40 || alt.size() >= 40) {
             return VariantType::STRUCTURAL;
         }
         return VariantType::INDEL;
     }
-    
+
     // same length >1 => MNV
-    if(ref.size()>1){
+    if (ref.size() > 1) {
         return VariantType::MNV;
     }
     return VariantType::UNKNOWN;
 }
 
-VariantType VCFXVariantClassifier::classifyVariant(const std::string &ref,
-                                                  const std::vector<std::string> &alts) const
-{
-    bool anyStruct= false, anyMNV=false, anyIndel=false, anySNP=false;
-    for(auto &a: alts){
-        VariantType vt= classifyAllele(ref,a);
-        if(vt== VariantType::STRUCTURAL) anyStruct= true;
-        else if(vt== VariantType::MNV) anyMNV= true;
-        else if(vt== VariantType::INDEL) anyIndel= true;
-        else if(vt== VariantType::SNP) anySNP= true;
+VariantType VCFXVariantClassifier::classifyVariant(const std::string &ref, const std::vector<std::string> &alts) const {
+    bool anyStruct = false, anyMNV = false, anyIndel = false, anySNP = false;
+    for (auto &a : alts) {
+        VariantType vt = classifyAllele(ref, a);
+        if (vt == VariantType::STRUCTURAL)
+            anyStruct = true;
+        else if (vt == VariantType::MNV)
+            anyMNV = true;
+        else if (vt == VariantType::INDEL)
+            anyIndel = true;
+        else if (vt == VariantType::SNP)
+            anySNP = true;
     }
     // priority: STRUCTURAL> MNV> INDEL> SNP> UNKNOWN
-    if(anyStruct) return VariantType::STRUCTURAL;
-    if(anyMNV) return VariantType::MNV;
-    if(anyIndel) return VariantType::INDEL;
-    if(anySNP) return VariantType::SNP;
+    if (anyStruct)
+        return VariantType::STRUCTURAL;
+    if (anyMNV)
+        return VariantType::MNV;
+    if (anyIndel)
+        return VariantType::INDEL;
+    if (anySNP)
+        return VariantType::SNP;
     return VariantType::UNKNOWN;
 }
 
-std::string VCFXVariantClassifier::typeToStr(VariantType t) const{
-    switch(t){
-        case VariantType::SNP: return "SNP";
-        case VariantType::INDEL: return "INDEL";
-        case VariantType::MNV: return "MNV";
-        case VariantType::STRUCTURAL: return "STRUCTURAL";
-        default: return "UNKNOWN";
+std::string VCFXVariantClassifier::typeToStr(VariantType t) const {
+    switch (t) {
+    case VariantType::SNP:
+        return "SNP";
+    case VariantType::INDEL:
+        return "INDEL";
+    case VariantType::MNV:
+        return "MNV";
+    case VariantType::STRUCTURAL:
+        return "STRUCTURAL";
+    default:
+        return "UNKNOWN";
     }
 }
 
 // If we want to keep the line as a valid VCF, we parse the line, classify, then append to INFO "VCF_CLASS=XYZ"
-std::string VCFXVariantClassifier::appendClassification(const std::string &line){
+std::string VCFXVariantClassifier::appendClassification(const std::string &line) {
     // split by tab
-    auto fields= split(line, '\t');
-    if(fields.size()<8){
+    auto fields = split(line, '\t');
+    if (fields.size() < 8) {
         // skip
         return line;
     }
     // parse alt
-    auto alts= split(fields[4], ',');
-    VariantType vt= classifyVariant(fields[3], alts);
-    std::string cstr= typeToStr(vt);
+    auto alts = split(fields[4], ',');
+    VariantType vt = classifyVariant(fields[3], alts);
+    std::string cstr = typeToStr(vt);
 
     // append to INFO
-    if(fields[7]=="."|| fields[7].empty()){
-        fields[7]= "VCF_CLASS="+ cstr;
+    if (fields[7] == "." || fields[7].empty()) {
+        fields[7] = "VCF_CLASS=" + cstr;
     } else {
         // add semicolon if needed
-        if(!fields[7].empty() && fields[7].back()!=';'){
-            fields[7]+= ";";
+        if (!fields[7].empty() && fields[7].back() != ';') {
+            fields[7] += ";";
         }
-        fields[7]+= "VCF_CLASS="+ cstr;
+        fields[7] += "VCF_CLASS=" + cstr;
     }
     // reconstruct line
     std::ostringstream oss;
-    for(size_t i=0; i<fields.size(); i++){
-        if(i>0) oss<<"\t";
-        oss<< fields[i];
+    for (size_t i = 0; i < fields.size(); i++) {
+        if (i > 0)
+            oss << "\t";
+        oss << fields[i];
     }
     return oss.str();
 }
 
-void VCFXVariantClassifier::classifyStream(std::istream &in, std::ostream &out){
-    bool foundChromHeader= false;
+void VCFXVariantClassifier::classifyStream(std::istream &in, std::ostream &out) {
+    bool foundChromHeader = false;
     std::string line;
-    if(appendInfo){
+    if (appendInfo) {
         // we produce a valid VCF. We'll pass all # lines unmodified
-        while(true){
-            if(!std::getline(in,line)) break;
-            if(line.empty()){
-                out<< line<<"\n";
+        while (true) {
+            if (!std::getline(in, line))
+                break;
+            if (line.empty()) {
+                out << line << "\n";
                 continue;
             }
-            if(line[0]=='#'){
-                out<< line<<"\n";
-                if(line.rfind("#CHROM",0)==0) foundChromHeader= true;
+            if (line[0] == '#') {
+                out << line << "\n";
+                if (line.rfind("#CHROM", 0) == 0)
+                    foundChromHeader = true;
                 continue;
             }
             // data line
-            if(!foundChromHeader){
-                std::cerr<<"Warning: data line encountered before #CHROM => skipping.\n";
+            if (!foundChromHeader) {
+                std::cerr << "Warning: data line encountered before #CHROM => skipping.\n";
                 continue;
             }
             // parse, classify, re-output
-            auto fields= split(line,'\t');
-            if(fields.size()<8){
-                std::cerr<<"Warning: skipping line <8 columns.\n";
+            auto fields = split(line, '\t');
+            if (fields.size() < 8) {
+                std::cerr << "Warning: skipping line <8 columns.\n";
                 continue;
             }
             // append classification in INFO
-            std::string newLine= appendClassification(line);
-            out<< newLine<<"\n";
+            std::string newLine = appendClassification(line);
+            out << newLine << "\n";
         }
     } else {
         // produce a TSV: CHROM POS ID REF ALT CLASS
         // Output the TSV header first
         out << "CHROM\tPOS\tID\tREF\tALT\tClassification\n";
-        
+
         // skip all # lines
-        while(true){
-            if(!std::getline(in,line)) break;
-            if(line.empty()) continue;
-            if(line[0]=='#'){
-                if(line.rfind("#CHROM",0)==0) foundChromHeader= true;
+        while (true) {
+            if (!std::getline(in, line))
+                break;
+            if (line.empty())
+                continue;
+            if (line[0] == '#') {
+                if (line.rfind("#CHROM", 0) == 0)
+                    foundChromHeader = true;
                 continue;
             }
-            if(!foundChromHeader){
-                std::cerr<<"Warning: data line before #CHROM => skipping.\n";
+            if (!foundChromHeader) {
+                std::cerr << "Warning: data line before #CHROM => skipping.\n";
                 continue;
             }
             // parse
-            auto fields= split(line,'\t');
-            if(fields.size()<8){
-                std::cerr<<"Warning: skipping line <8 columns.\n";
+            auto fields = split(line, '\t');
+            if (fields.size() < 8) {
+                std::cerr << "Warning: skipping line <8 columns.\n";
                 continue;
             }
-            
+
             // Additional validation for malformed input
             // 1. Validate CHROM format (should start with "chr")
             if (fields[0].substr(0, 3) != "chr") {
-                std::cerr<<"Warning: invalid chromosome format => skipping.\n";
+                std::cerr << "Warning: invalid chromosome format => skipping.\n";
                 continue;
             }
-            
+
             // 2. Validate POS is numeric
             bool validPos = true;
             for (char c : fields[1]) {
@@ -284,16 +302,16 @@ void VCFXVariantClassifier::classifyStream(std::istream &in, std::ostream &out){
                 }
             }
             if (!validPos) {
-                std::cerr<<"Warning: position is not numeric => skipping.\n";
+                std::cerr << "Warning: position is not numeric => skipping.\n";
                 continue;
             }
-            
+
             // 3. Validate REF and ALT are not empty
             if (fields[3].empty() || fields[4].empty()) {
-                std::cerr<<"Warning: REF or ALT is empty => skipping.\n";
+                std::cerr << "Warning: REF or ALT is empty => skipping.\n";
                 continue;
             }
-            
+
             // 4. Validate REF contains only valid bases
             bool validRef = true;
             for (char c : fields[3]) {
@@ -303,33 +321,40 @@ void VCFXVariantClassifier::classifyStream(std::istream &in, std::ostream &out){
                 }
             }
             if (!validRef) {
-                std::cerr<<"Warning: REF contains non-alphabetic characters => skipping.\n";
+                std::cerr << "Warning: REF contains non-alphabetic characters => skipping.\n";
                 continue;
             }
-            
+
             // 5. Validate ALT format
             // Allow special cases like <DEL>, but disallow trailing commas
             if (fields[4].back() == ',') {
-                std::cerr<<"Warning: ALT ends with a comma => skipping.\n";
+                std::cerr << "Warning: ALT ends with a comma => skipping.\n";
                 continue;
             }
-            
+
             // alt => split by comma
-            auto altList= split(fields[4], ',');
-            VariantType vt= classifyVariant(fields[3], altList);
+            auto altList = split(fields[4], ',');
+            VariantType vt = classifyVariant(fields[3], altList);
             // build alt string
-            std::string altJoined= fields[4];
+            std::string altJoined = fields[4];
             // Output the classification line
-            out<< fields[0]<<"\t"<< fields[1]<<"\t"<< fields[2]
-               <<"\t"<< fields[3]<<"\t"<< altJoined<<"\t"<< typeToStr(vt)<<"\n";
+            out << fields[0] << "\t" << fields[1] << "\t" << fields[2] << "\t" << fields[3] << "\t" << altJoined << "\t"
+                << typeToStr(vt) << "\n";
         }
     }
 }
 
-static void show_help() { VCFXVariantClassifier obj; char arg0[] = "VCFX_variant_classifier"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXVariantClassifier obj;
+    char arg0[] = "VCFX_variant_classifier";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]){
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_variant_classifier", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_variant_classifier", show_help))
+        return 0;
     VCFXVariantClassifier app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_variant_classifier/VCFX_variant_classifier.h
+++ b/src/VCFX_variant_classifier/VCFX_variant_classifier.h
@@ -4,19 +4,13 @@
 #include <string>
 #include <vector>
 
-enum class VariantType {
-    SNP,
-    INDEL,
-    MNV,
-    STRUCTURAL,
-    UNKNOWN
-};
+enum class VariantType { SNP, INDEL, MNV, STRUCTURAL, UNKNOWN };
 
 class VCFXVariantClassifier {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // Show usage
     void displayHelp();
 
@@ -27,7 +21,8 @@ private:
     // The main method that reads lines from input, classifies, and writes output
     void classifyStream(std::istream &in, std::ostream &out);
 
-    // Detect alt allele as structural if it is symbolic (<DEL>) or breakend notation ([chr or ]chr) or length difference >=50
+    // Detect alt allele as structural if it is symbolic (<DEL>) or breakend notation ([chr or ]chr) or length
+    // difference >=50
     bool isStructuralAllele(const std::string &alt) const;
 
     // Classify a single (ref, alt)
@@ -39,7 +34,8 @@ private:
     // Stringify the variant type
     std::string typeToStr(VariantType t) const;
 
-    // If we are in append‐info mode, we parse line into columns, parse alt as multiple, classify, then append e.g. VCF_CLASS=xxx
+    // If we are in append‐info mode, we parse line into columns, parse alt as multiple, classify, then append e.g.
+    // VCF_CLASS=xxx
     std::string appendClassification(const std::string &line);
 
     // Splitting helper

--- a/src/VCFX_variant_counter/VCFX_variant_counter.cpp
+++ b/src/VCFX_variant_counter/VCFX_variant_counter.cpp
@@ -1,110 +1,107 @@
 #include "VCFX_variant_counter.h"
+#include "vcfx_core.h"
+#include <cstring>
 #include <getopt.h>
-#include <string>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <vector>
-#include "vcfx_core.h"
 #include <zlib.h>
-#include <cstring>
 
-void VCFXVariantCounter::displayHelp(){
-    std::cout <<
-"VCFX_variant_counter: Counts the total number of valid variants in a VCF.\n\n"
-"Usage:\n"
-"  VCFX_variant_counter [options] < input.vcf\n\n"
-"Options:\n"
-"  -h, --help        Show this help.\n"
-"  -s, --strict      Fail on any data line with <8 columns.\n\n"
-"Description:\n"
-"  Reads a VCF from stdin, ignores all header lines (#). For each data line,\n"
-"  we check if it has >=8 columns; if it does, we count it; if fewer columns:\n"
-"   * if --strict => we exit with error,\n"
-"   * otherwise => we skip with a warning.\n"
-"  Finally, we print 'Total Variants: X'.\n\n"
-"Example:\n"
-"  VCFX_variant_counter < input.vcf\n"
-"  VCFX_variant_counter --strict < input.vcf\n";
+void VCFXVariantCounter::displayHelp() {
+    std::cout << "VCFX_variant_counter: Counts the total number of valid variants in a VCF.\n\n"
+                 "Usage:\n"
+                 "  VCFX_variant_counter [options] < input.vcf\n\n"
+                 "Options:\n"
+                 "  -h, --help        Show this help.\n"
+                 "  -s, --strict      Fail on any data line with <8 columns.\n\n"
+                 "Description:\n"
+                 "  Reads a VCF from stdin, ignores all header lines (#). For each data line,\n"
+                 "  we check if it has >=8 columns; if it does, we count it; if fewer columns:\n"
+                 "   * if --strict => we exit with error,\n"
+                 "   * otherwise => we skip with a warning.\n"
+                 "  Finally, we print 'Total Variants: X'.\n\n"
+                 "Example:\n"
+                 "  VCFX_variant_counter < input.vcf\n"
+                 "  VCFX_variant_counter --strict < input.vcf\n";
 }
 
-int VCFXVariantCounter::run(int argc, char* argv[]){
-    bool showHelp=false;
-    static struct option long_opts[]={
-        {"help", no_argument, 0,'h'},
-        {"strict", no_argument, 0,'s'},
-        {0,0,0,0}
-    };
-    
+int VCFXVariantCounter::run(int argc, char *argv[]) {
+    bool showHelp = false;
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'}, {"strict", no_argument, 0, 's'}, {0, 0, 0, 0}};
+
     // Check for options/flags
     if (argc > 1) {
-        while(true){
-            int c= ::getopt_long(argc, argv,"hs", long_opts,nullptr);
-            if(c==-1) break;
-            switch(c){
-                case 'h':
-                    showHelp=true;
-                    break;
-                case 's':
-                    strictMode= true;
-                    break;
-                default:
-                    showHelp=true;
+        while (true) {
+            int c = ::getopt_long(argc, argv, "hs", long_opts, nullptr);
+            if (c == -1)
+                break;
+            switch (c) {
+            case 'h':
+                showHelp = true;
+                break;
+            case 's':
+                strictMode = true;
+                break;
+            default:
+                showHelp = true;
             }
         }
     }
-    
-    if(showHelp){
+
+    if (showHelp) {
         displayHelp();
         return 0;
     }
-    
+
     auto peek1 = std::cin.peek();
     bool isEmpty = (peek1 == EOF);
     bool isGzip = false;
-    if(!isEmpty){
+    if (!isEmpty) {
         int c1 = std::cin.get();
         int c2 = std::cin.get();
-        if(c2 != EOF){
-            isGzip = (static_cast<unsigned char>(c1) == 0x1f &&
-                      static_cast<unsigned char>(c2) == 0x8b);
+        if (c2 != EOF) {
+            isGzip = (static_cast<unsigned char>(c1) == 0x1f && static_cast<unsigned char>(c2) == 0x8b);
             std::cin.putback(static_cast<char>(c2));
         }
         std::cin.putback(static_cast<char>(c1));
     }
 
     int total = -1;
-    if(isEmpty){
+    if (isEmpty) {
         total = 0;
-    } else if(isGzip){
+    } else if (isGzip) {
         total = countVariantsGzip(std::cin);
     } else {
         total = countVariants(std::cin);
     }
-    if(total<0){
+    if (total < 0) {
         // indicates an error if strict
         return 1;
     }
-    std::cout<<"Total Variants: "<< total <<"\n";
+    std::cout << "Total Variants: " << total << "\n";
     return 0;
 }
 
-bool VCFXVariantCounter::processLine(const std::string &line, int lineNumber, int &count){
-    if(line.empty()) return true;
-    if(line[0]=='#') return true;
+bool VCFXVariantCounter::processLine(const std::string &line, int lineNumber, int &count) {
+    if (line.empty())
+        return true;
+    if (line[0] == '#')
+        return true;
     std::stringstream ss(line);
     std::vector<std::string> fields;
     {
         std::string col;
-        while(std::getline(ss,col,'\t')){
+        while (std::getline(ss, col, '\t')) {
             fields.push_back(col);
         }
     }
-    if(fields.size()<8){
-        if(strictMode){
-            std::cerr<<"Error: line "<< lineNumber <<" has <8 columns.\n";
+    if (fields.size() < 8) {
+        if (strictMode) {
+            std::cerr << "Error: line " << lineNumber << " has <8 columns.\n";
             return false;
         } else {
-            std::cerr<<"Warning: skipping line "<<lineNumber<<" with <8 columns.\n";
+            std::cerr << "Warning: skipping line " << lineNumber << " with <8 columns.\n";
             return true;
         }
     }
@@ -112,61 +109,67 @@ bool VCFXVariantCounter::processLine(const std::string &line, int lineNumber, in
     return true;
 }
 
-int VCFXVariantCounter::countVariants(std::istream &in){
-    int count=0;
-    int lineNumber=0;
+int VCFXVariantCounter::countVariants(std::istream &in) {
+    int count = 0;
+    int lineNumber = 0;
     std::string line;
-    while(std::getline(in,line)){
+    while (std::getline(in, line)) {
         lineNumber++;
-        if(!processLine(line, lineNumber, count)) return -1;
+        if (!processLine(line, lineNumber, count))
+            return -1;
     }
     return count;
 }
 
-int VCFXVariantCounter::countVariantsGzip(std::istream &in){
+int VCFXVariantCounter::countVariantsGzip(std::istream &in) {
     constexpr int CHUNK = 16384;
     char inBuf[CHUNK];
     char outBuf[CHUNK];
-    z_stream strm; std::memset(&strm,0,sizeof(strm));
-    if(inflateInit2(&strm,15+32)!=Z_OK){
-        std::cerr<<"Error: inflateInit2 failed.\n";
+    z_stream strm;
+    std::memset(&strm, 0, sizeof(strm));
+    if (inflateInit2(&strm, 15 + 32) != Z_OK) {
+        std::cerr << "Error: inflateInit2 failed.\n";
         return -1;
     }
-    int count=0; int lineNumber=0; std::string buffer; int ret=Z_OK;
+    int count = 0;
+    int lineNumber = 0;
+    std::string buffer;
+    int ret = Z_OK;
     do {
         in.read(inBuf, CHUNK);
         strm.avail_in = static_cast<uInt>(in.gcount());
-        if(strm.avail_in==0 && in.eof()) break;
-        strm.next_in = reinterpret_cast<Bytef*>(inBuf);
+        if (strm.avail_in == 0 && in.eof())
+            break;
+        strm.next_in = reinterpret_cast<Bytef *>(inBuf);
         do {
             strm.avail_out = CHUNK;
-            strm.next_out = reinterpret_cast<Bytef*>(outBuf);
+            strm.next_out = reinterpret_cast<Bytef *>(outBuf);
             ret = inflate(&strm, Z_NO_FLUSH);
-            if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR){
-                std::cerr<<"Error: decompression failed.\n";
+            if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR) {
+                std::cerr << "Error: decompression failed.\n";
                 inflateEnd(&strm);
                 return -1;
             }
             size_t have = CHUNK - strm.avail_out;
-            if(have>0){
+            if (have > 0) {
                 buffer.append(outBuf, have);
                 size_t pos;
-                while((pos = buffer.find('\n')) != std::string::npos){
-                    std::string line = buffer.substr(0,pos);
-                    buffer.erase(0,pos+1);
+                while ((pos = buffer.find('\n')) != std::string::npos) {
+                    std::string line = buffer.substr(0, pos);
+                    buffer.erase(0, pos + 1);
                     lineNumber++;
-                    if(!processLine(line,lineNumber,count)){
+                    if (!processLine(line, lineNumber, count)) {
                         inflateEnd(&strm);
                         return -1;
                     }
                 }
             }
-        } while(strm.avail_out==0);
-    } while(ret != Z_STREAM_END);
+        } while (strm.avail_out == 0);
+    } while (ret != Z_STREAM_END);
 
-    if(!buffer.empty()){
+    if (!buffer.empty()) {
         lineNumber++;
-        if(!processLine(buffer,lineNumber,count)){
+        if (!processLine(buffer, lineNumber, count)) {
             inflateEnd(&strm);
             return -1;
         }
@@ -175,10 +178,17 @@ int VCFXVariantCounter::countVariantsGzip(std::istream &in){
     return count;
 }
 
-static void show_help() { VCFXVariantCounter obj; char arg0[] = "VCFX_variant_counter"; char arg1[] = "--help"; char* argv2[] = {arg0, arg1, nullptr}; obj.run(2, argv2); }
+static void show_help() {
+    VCFXVariantCounter obj;
+    char arg0[] = "VCFX_variant_counter";
+    char arg1[] = "--help";
+    char *argv2[] = {arg0, arg1, nullptr};
+    obj.run(2, argv2);
+}
 
-int main(int argc, char* argv[]) {
-    if (vcfx::handle_common_flags(argc, argv, "VCFX_variant_counter", show_help)) return 0;
+int main(int argc, char *argv[]) {
+    if (vcfx::handle_common_flags(argc, argv, "VCFX_variant_counter", show_help))
+        return 0;
     VCFXVariantCounter app;
     return app.run(argc, argv);
 }

--- a/src/VCFX_variant_counter/VCFX_variant_counter.h
+++ b/src/VCFX_variant_counter/VCFX_variant_counter.h
@@ -5,10 +5,10 @@
 #include <string>
 
 class VCFXVariantCounter {
-public:
-    int run(int argc, char* argv[]);
+  public:
+    int run(int argc, char *argv[]);
 
-private:
+  private:
     // If true, any line with <8 columns is a fatal error
     bool strictMode = false;
 
@@ -19,7 +19,6 @@ private:
     int countVariants(std::istream &in);
     int countVariantsGzip(std::istream &in);
     bool processLine(const std::string &line, int lineNumber, int &count);
-
 };
 
 #endif

--- a/src/vcfx_core.cpp
+++ b/src/vcfx_core.cpp
@@ -1,14 +1,14 @@
 #include "vcfx_core.h"
 #include <algorithm>
 #include <cctype>
-#include <sstream>
-#include <fstream>
-#include <zlib.h>
 #include <cstring>
+#include <fstream>
+#include <sstream>
+#include <zlib.h>
 
 namespace vcfx {
 
-std::string trim(const std::string& str) {
+std::string trim(const std::string &str) {
     auto first = str.find_first_not_of(" \t\n\r");
     if (first == std::string::npos) {
         return "";
@@ -17,7 +17,7 @@ std::string trim(const std::string& str) {
     return str.substr(first, last - first + 1);
 }
 
-std::vector<std::string> split(const std::string& str, char delimiter) {
+std::vector<std::string> split(const std::string &str, char delimiter) {
     std::vector<std::string> result;
     std::istringstream iss(str);
     std::string item;
@@ -27,30 +27,25 @@ std::vector<std::string> split(const std::string& str, char delimiter) {
     return result;
 }
 
-bool flag_present(int argc, char* argv[], const char* long_flag,
-                  const char* short_flag) {
+bool flag_present(int argc, char *argv[], const char *long_flag, const char *short_flag) {
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], long_flag) == 0 ||
-            (short_flag && std::strcmp(argv[i], short_flag) == 0)) {
+        if (std::strcmp(argv[i], long_flag) == 0 || (short_flag && std::strcmp(argv[i], short_flag) == 0)) {
             return true;
         }
     }
     return false;
 }
 
-void print_error(const std::string& msg, std::ostream& os) {
-    os << "Error: " << msg << '\n';
-}
+void print_error(const std::string &msg, std::ostream &os) { os << "Error: " << msg << '\n'; }
 
-void print_version(const std::string& tool, const std::string& version,
-                   std::ostream& os) {
+void print_version(const std::string &tool, const std::string &version, std::ostream &os) {
     os << tool << " version " << version << '\n';
 }
 
 // ------------------------------------------------------------
 // Internal helper: decompress gzip/BGZF data from 'in' into 'out'
 // ------------------------------------------------------------
-static bool decompress_gzip_stream(std::istream& in, std::string& out) {
+static bool decompress_gzip_stream(std::istream &in, std::string &out) {
     constexpr int CHUNK = 16384;
     char inBuf[CHUNK];
     char outBuf[CHUNK];
@@ -68,14 +63,13 @@ static bool decompress_gzip_stream(std::istream& in, std::string& out) {
         if (strm.avail_in == 0 && in.eof()) {
             break;
         }
-        strm.next_in = reinterpret_cast<Bytef*>(inBuf);
+        strm.next_in = reinterpret_cast<Bytef *>(inBuf);
 
         do {
             strm.avail_out = CHUNK;
-            strm.next_out = reinterpret_cast<Bytef*>(outBuf);
+            strm.next_out = reinterpret_cast<Bytef *>(outBuf);
             ret = inflate(&strm, Z_NO_FLUSH);
-            if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT ||
-                ret == Z_DATA_ERROR || ret == Z_MEM_ERROR) {
+            if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR) {
                 inflateEnd(&strm);
                 return false;
             }
@@ -93,7 +87,7 @@ static bool decompress_gzip_stream(std::istream& in, std::string& out) {
 // ------------------------------------------------------------
 // Detect gzip magic numbers on a stream without consuming them
 // ------------------------------------------------------------
-static bool stream_has_gzip_magic(std::istream& in) {
+static bool stream_has_gzip_magic(std::istream &in) {
     int c1 = in.get();
     if (c1 == EOF) {
         return false;
@@ -103,14 +97,13 @@ static bool stream_has_gzip_magic(std::istream& in) {
         in.unget();
         return false;
     }
-    bool isGz = (static_cast<unsigned char>(c1) == 0x1f &&
-                 static_cast<unsigned char>(c2) == 0x8b);
+    bool isGz = (static_cast<unsigned char>(c1) == 0x1f && static_cast<unsigned char>(c2) == 0x8b);
     in.putback(static_cast<char>(c2));
     in.putback(static_cast<char>(c1));
     return isGz;
 }
 
-bool read_maybe_compressed(std::istream& in, std::string& out) {
+bool read_maybe_compressed(std::istream &in, std::string &out) {
     out.clear();
     if (stream_has_gzip_magic(in)) {
         return decompress_gzip_stream(in, out);
@@ -121,20 +114,17 @@ bool read_maybe_compressed(std::istream& in, std::string& out) {
     return true;
 }
 
-bool read_file_maybe_compressed(const std::string& path, std::string& out) {
+bool read_file_maybe_compressed(const std::string &path, std::string &out) {
     std::ifstream file(path, std::ios::binary);
     if (!file.is_open()) {
         return false;
     }
     bool isGz = false;
-    if (path.size() >= 3 &&
-        (path.compare(path.size() - 3, 3, ".gz") == 0)) {
+    if (path.size() >= 3 && (path.compare(path.size() - 3, 3, ".gz") == 0)) {
         isGz = true;
-    } else if (path.size() >= 4 &&
-               (path.compare(path.size() - 4, 4, ".bgz") == 0)) {
+    } else if (path.size() >= 4 && (path.compare(path.size() - 4, 4, ".bgz") == 0)) {
         isGz = true;
-    } else if (path.size() >= 5 &&
-               (path.compare(path.size() - 5, 5, ".bgzf") == 0)) {
+    } else if (path.size() >= 5 && (path.compare(path.size() - 5, 5, ".bgzf") == 0)) {
         isGz = true;
     }
     if (isGz || stream_has_gzip_magic(file)) {
@@ -146,6 +136,4 @@ bool read_file_maybe_compressed(const std::string& path, std::string& out) {
     return true;
 }
 
-
-
-}  // namespace vcfx
+} // namespace vcfx

--- a/src/vcfx_wrapper/vcfx.cpp
+++ b/src/vcfx_wrapper/vcfx.cpp
@@ -1,22 +1,22 @@
-#include <iostream>
-#include <vector>
-#include <string>
-#include <getopt.h>
 #include <cstdlib>
 #include <cstring>
 #include <dirent.h>
-#include <unistd.h>
-#include <sys/stat.h>
+#include <getopt.h>
+#include <iostream>
 #include <limits.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
 #include <fstream>
 #include <set>
 
-static const char* argv0_global = nullptr;
+static const char *argv0_global = nullptr;
 
-static void print_usage(){
+static void print_usage() {
     std::cout << "vcfx - unified interface for VCFX tools\n"
               << "Usage: vcfx [--help] [--list] <subcommand> [args]\n\n"
               << "  <subcommand>  Name of a VCFX tool without the 'VCFX_' prefix\n"
@@ -26,65 +26,68 @@ static void print_usage(){
               << "  --help        Show this help message\n";
 }
 
-static void list_commands(){
-    const char* path_env = std::getenv("PATH");
-    if(!path_env) return;
+static void list_commands() {
+    const char *path_env = std::getenv("PATH");
+    if (!path_env)
+        return;
     std::string paths(path_env);
     std::set<std::string> cmds;
-    size_t start=0;
-    while(true){
+    size_t start = 0;
+    while (true) {
         size_t end = paths.find(':', start);
         std::string dir = paths.substr(start, end - start);
-        DIR* d = opendir(dir.c_str());
-        if(d){
-            struct dirent* e;
-            while((e = readdir(d)) != nullptr){
-                if(std::strncmp(e->d_name, "VCFX_", 5)==0){
+        DIR *d = opendir(dir.c_str());
+        if (d) {
+            struct dirent *e;
+            while ((e = readdir(d)) != nullptr) {
+                if (std::strncmp(e->d_name, "VCFX_", 5) == 0) {
                     std::string name = e->d_name + 5;
                     std::string full = dir + "/" + e->d_name;
-                    if(access(full.c_str(), X_OK)==0){
+                    if (access(full.c_str(), X_OK) == 0) {
                         cmds.insert(name);
                     }
                 }
             }
             closedir(d);
         }
-        if(end == std::string::npos) break;
+        if (end == std::string::npos)
+            break;
         start = end + 1;
     }
-    for(const auto& c : cmds){
+    for (const auto &c : cmds) {
         std::cout << c << '\n';
     }
 }
 
-static std::vector<std::string> get_doc_dirs(){
+static std::vector<std::string> get_doc_dirs() {
     std::vector<std::string> dirs;
-    const char* env = std::getenv("VCFX_DOCS_DIR");
-    if(env) dirs.emplace_back(env);
+    const char *env = std::getenv("VCFX_DOCS_DIR");
+    if (env)
+        dirs.emplace_back(env);
 
     std::string exe;
     char buf[PATH_MAX];
-    ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf)-1);
-    if(len > 0){
+    ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+    if (len > 0) {
         buf[len] = '\0';
         exe = buf;
     }
 #ifdef __APPLE__
-    if(exe.empty()){
+    if (exe.empty()) {
         uint32_t size = sizeof(buf);
-        if(_NSGetExecutablePath(buf, &size) == 0){
+        if (_NSGetExecutablePath(buf, &size) == 0) {
             exe = buf;
         }
     }
 #endif
-    if(exe.empty() && argv0_global){
+    if (exe.empty() && argv0_global) {
         exe = argv0_global;
     }
 
-    if(!exe.empty()){
+    if (!exe.empty()) {
         auto pos = exe.find_last_of('/');
-        if(pos != std::string::npos){
-            std::string base = exe.substr(0,pos);
+        if (pos != std::string::npos) {
+            std::string base = exe.substr(0, pos);
             dirs.push_back(base + "/../share/doc/VCFX");
             dirs.push_back(base + "/../share/vcfx/docs");
             dirs.push_back(base + "/../docs");
@@ -96,12 +99,12 @@ static std::vector<std::string> get_doc_dirs(){
     return dirs;
 }
 
-static int print_tool_doc(const std::string& tool){
+static int print_tool_doc(const std::string &tool) {
     std::string fname = "VCFX_" + tool + ".md";
-    for(const auto& dir : get_doc_dirs()){
+    for (const auto &dir : get_doc_dirs()) {
         std::string path = dir + "/" + fname;
         std::ifstream in(path);
-        if(in){
+        if (in) {
             std::cout << in.rdbuf();
             return 0;
         }
@@ -110,49 +113,47 @@ static int print_tool_doc(const std::string& tool){
     return 1;
 }
 
-int main(int argc, char* argv[]){
+int main(int argc, char *argv[]) {
     argv0_global = argv[0];
     bool show_help = false;
     bool show_list = false;
-    static struct option long_opts[] = {
-        {"help", no_argument, 0, 'h'},
-        {"list", no_argument, 0, 'l'},
-        {0,0,0,0}
-    };
+    static struct option long_opts[] = {{"help", no_argument, 0, 'h'}, {"list", no_argument, 0, 'l'}, {0, 0, 0, 0}};
 
     int opt;
-    while((opt = getopt_long(argc, argv, "hl", long_opts, nullptr)) != -1){
-        if(opt == 'h') show_help = true;
-        else if(opt == 'l') show_list = true;
+    while ((opt = getopt_long(argc, argv, "hl", long_opts, nullptr)) != -1) {
+        if (opt == 'h')
+            show_help = true;
+        else if (opt == 'l')
+            show_list = true;
         else {
             print_usage();
             return 1;
         }
     }
 
-    if(show_help){
+    if (show_help) {
         print_usage();
         return 0;
     }
-    if(show_list){
+    if (show_list) {
         list_commands();
         return 0;
     }
 
-    if(optind >= argc){
+    if (optind >= argc) {
         print_usage();
         return 1;
     }
 
     std::string sub = argv[optind];
 
-    if(sub == "list"){
+    if (sub == "list") {
         list_commands();
         return 0;
     }
 
-    if(sub == "help"){
-        if(optind + 1 >= argc){
+    if (sub == "help") {
+        if (optind + 1 >= argc) {
             print_usage();
             return 0;
         }
@@ -161,9 +162,9 @@ int main(int argc, char* argv[]){
 
     std::string exec_name = "VCFX_" + sub;
 
-    std::vector<char*> exec_args;
-    exec_args.push_back(const_cast<char*>(exec_name.c_str()));
-    for(int i = optind + 1; i < argc; ++i){
+    std::vector<char *> exec_args;
+    exec_args.push_back(const_cast<char *>(exec_name.c_str()));
+    for (int i = optind + 1; i < argc; ++i) {
         exec_args.push_back(argv[i]);
     }
     exec_args.push_back(nullptr);
@@ -172,4 +173,3 @@ int main(int argc, char* argv[]){
     std::perror(exec_name.c_str());
     return 1;
 }
-


### PR DESCRIPTION
## Summary
- run clang-format on all C++ sources

## Testing
- `ruff check .`
- `flake8` *(fails: command not found)*
- `clang-format` no replacements
- `mypy python`
- `pytest -q`