### PR TITLE
Add unit tests for Python helpers

### DIFF
--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -2,3 +2,32 @@
 def test_python_bindings(vcfx):
     assert vcfx.trim("  hello  ") == "hello"
     assert vcfx.read_maybe_compressed(b"hello") == b"hello"
+
+
+def test_read_file_maybe_compressed(vcfx, tmp_path):
+    import gzip
+
+    p = tmp_path / "hello.txt.gz"
+    data = b"hello world\n"
+    with gzip.open(p, "wb") as fh:
+        fh.write(data)
+
+    result = vcfx.read_file_maybe_compressed(str(p))
+    assert result == data
+
+
+def test_split_and_get_version(vcfx):
+    from pathlib import Path
+    import subprocess
+    import sys
+
+    assert vcfx.split("a,b,c", ",") == ["a", "b", "c"]
+
+    root = Path(__file__).resolve().parents[2]
+    expected = subprocess.check_output(
+        [sys.executable, str(root / "scripts" / "extract_version.py")],
+        text=True,
+    ).strip()
+    assert vcfx.get_version() == expected
+    assert vcfx.__version__ == expected
+

--- a/tests/python/test_convenience_wrappers.py
+++ b/tests/python/test_convenience_wrappers.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+DATA = Path(__file__).resolve().parents[1] / "data"
+
+
+def test_variant_counter_wrapper(vcfx):
+    count = vcfx.variant_counter(DATA / "variant_counter_normal.vcf")
+    assert count == 5
+
+
+def test_allele_freq_calc_wrapper(vcfx):
+    freqs = vcfx.allele_freq_calc(DATA / "allele_freq_calc" / "simple.vcf")
+    assert abs(freqs[0].Allele_Frequency - 0.5) < 1e-6
+


### PR DESCRIPTION
## Summary
- add coverage for `read_file_maybe_compressed`, `split` and `get_version`
- test a few wrappers from `tools.py`

## Testing
- `pytest -q tests/python/test_bindings.py tests/python/test_convenience_wrappers.py`

------
https://chatgpt.com/codex/tasks/task_e_683a482f54e083278f9a9ec853135d08