### PR TITLE
Fix relative import for results dataclasses

### DIFF
--- a/python/tools/analysis.py
+++ b/python/tools/analysis.py
@@ -8,7 +8,7 @@ import os
 from typing import Any, Callable, Sequence, Type, TypeVar, get_type_hints
 from dataclasses import fields as dataclass_fields
 
-from .results import (
+from ..results import (
     AlignmentDiscrepancy,
     AlleleCount,
     AlleleFrequency,


### PR DESCRIPTION
## Summary
- fix broken import in `vcfx.tools.analysis`

## Testing
- `bash tests/test_python_bindings.sh`
- `bash tests/test_python_tool_wrappers.sh`
- `bash tests/test_python_tool_wrappers_extra.sh`
- `ctest --output-on-failure -R test_python_bindings`
- `ctest --output-on-failure -R test_python_tool_wrappers`
- `ctest --output-on-failure -R test_python_tool_wrappers_extra`


------
https://chatgpt.com/codex/tasks/task_e_683aea3b15b08327816ee61ea31d7577